### PR TITLE
fix issue 583 : icone raccourcis mobile

### DIFF
--- a/core/config/default.config.ini
+++ b/core/config/default.config.ini
@@ -10,7 +10,7 @@ nextdom::firstUse = 1
 nextdom::Welcome = 1
 folder::tmp = /tmp/nextdom
 product_name=NextDom
-product_icon=/public/img/NextDom/NextDom_Square_BlueAlphaBlack.png
+product_icon=/public/img/NextDom/NextDom_Square_BlueWhiteBlack.png
 product_image=/public/img/NextDom/NextDom_Wide_AlphaBlueBlack.png
 language = fr_FR
 


### PR DESCRIPTION
issue #583
Pour tester sur mobile connectez vous a votre nextdom et faites ajouter à l'ecran d'accueil, l'icone doit etre 
- carré bleu
- maison blanche
- lettre noire