### PR TITLE
Hide Plan3D menu (voté)

### DIFF
--- a/assets/css/adminlte/_AdminLTE-nextdom.scss
+++ b/assets/css/adminlte/_AdminLTE-nextdom.scss
@@ -333,7 +333,7 @@ padding-left: 7px;
   box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.2), 0 1px 5px 0 rgba(0,0,0,.12);
   margin: {
     bottom: 60px;
-    top: 15px;
+    top: 30px;
   }
   color: #333;
   width: 100%;

--- a/views/commons/AdminLTE_sidebar.html.twig
+++ b/views/commons/AdminLTE_sidebar.html.twig
@@ -73,6 +73,7 @@
                     {% endfor %}
                 </ul>
             </li>
+            {#
             <li class="treeview">
                 <a href="#"><i class="fas fa-building"></i><span>&nbsp;&nbsp;{{ 'Plan(s) 3D' }}</span><span class="pull-right-container"><i class="fas fa-angle-left pull-right"></i></span></a>
                 <ul class="treeview-menu">
@@ -83,6 +84,7 @@
                     {% endfor %}
                 </ul>
             </li>
+            #}
 
             <li class="header">{{ 'MENU GESTION' }}</li>
             <li class="treeview">


### PR DESCRIPTION
- Hide menu Plan3D comme voté
- Fix Marge haute cards sur dashboard

Tester :
- le menu plan3D est bien désactivé dans menu de gauche (on le reactivera quand jeedom aura finalisé la fonction)
- les bjets (pieces) sur dash ne sont pas collées au header
