### PR TITLE
correction affichage par apt

### DIFF
--- a/install/postinst
+++ b/install/postinst
@@ -39,7 +39,9 @@ print_log_in() {
 
 
 print_log_ok() {
-    echo " OK"
+    if [ 1 -eq "0${isdev}"  ] ; then
+        echo " OK"
+    fi
     echo " OK" >> $LOG_DIRECTORY/postinst.log
 }
 


### PR DESCRIPTION
Protège l'affiche des "OK" après chaque fonctions, dans le cas du paquet Debian (sinon ca va être moche dans l'output de apt...)
