### PR TITLE
Fix des falses dans les formulaires

### DIFF
--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -289,6 +289,9 @@ function displayException($e)
 
 function is_json($_string, $_default = null)
 {
+    if ($_string === null && $_default === null) {
+        return null;
+    }
     if ($_default !== null) {
         if (!is_string($_string)) {
             return $_default;


### PR DESCRIPTION
Depuis quelques temps la valeur "false" apparait dans certains formulaire.
Ce fix essaie de régler ce problème mais peut avoir des effets de bord. Donc à tester en prod.