### PR TITLE
Fix du bug d'affichage des commandes

### DIFF
--- a/assets/js/desktop/tools/display.js
+++ b/assets/js/desktop/tools/display.js
@@ -106,6 +106,7 @@ $('.displayListContainer').packery();
         $(this).removeClass('fa-chevron-down').addClass('fa-chevron-right');
         $(this).closest('.eqLogic').find('.cmdSortable').hide();
     }
+     $('.displayListContainer').packery();
 });
 
  $('.showEqLogic').on('click',function(){


### PR DESCRIPTION
Dans la page display, les commandes s'affichaient sous les autres objets.