### PR TITLE
Test des requêtes ajax

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,3 @@
+coverage_clover: tests/coverage/clover.xml
+service_name: travis-ci
+json_path: coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-    - 7.0
+    - 7.1
 services:
     - mysql
     - docker
@@ -17,14 +17,25 @@ before_install:
     - sudo python3 -m pip install --upgrade pip
     - sudo pip3 install --ignore-installed urllib3[secure] pylint
     - sudo pip install jsmin
-    - ./scripts/gen_global.sh && composer install --dev
+    - ./scripts/gen_global.sh
+    - composer install --dev
+    - composer require --dev satooshi/php-coveralls
     - cd tests
     - sudo ./install_env.sh
 install:
     - mysql -e 'CREATE DATABASE nextdom_test;'
 script:
     - cd ${TRAVIS_BUILD_DIR}/tests
-    - ../vendor/bin/phpunit phpunit_tests
+    - mkdir coverage
+    - python3 launch_php_tests.py
+    - python3 launch_compatibility_tests.py
     - python3 launch_code_consistency.py
     - python3 launch_features_tests.py
     - python3 launch_gui_tests.py
+    - python3 check_jeedom_compatibility_from_src.py
+after_script:
+    - cd ${TRAVIS_BUILD_DIR}/tests
+    - wget https://phar.phpunit.de/phpcov.phar
+    - php phpcov.phar merge coverage --clover coverage/clover.xml
+    - cd ${TRAVIS_BUILD_DIR}
+    - php vendor/bin/php-coveralls -v

--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ Procédure : [https://www.nextdom.org/elementor-230/installation-de-nextdom/](ic
 # Téléchargement des releases
 
 Github : [https://github.com/NextDom/nextdom-core/releases](ici).
+
+# Builds
+## Master
+[![Build Status](https://travis-ci.org/NextDom/nextdom-core.svg?branch=master)](https://travis-ci.org/NextDom/nextdom-core) [![Coverage Status](https://coveralls.io/repos/github/NextDom/nextdom-core/badge.svg?branch=master)](https://coveralls.io/github/NextDom/nextdom-core?branch=master)
+
+## Develop
+[![Build Status](https://travis-ci.org/NextDom/nextdom-core.svg?branch=develop)](https://travis-ci.org/NextDom/nextdom-core) [![Coverage Status](https://coveralls.io/repos/github/NextDom/nextdom-core/badge.svg?branch=develop)](https://coveralls.io/github/NextDom/nextdom-core?branch=develop)

--- a/assets/js/desktop/params/profils.js
+++ b/assets/js/desktop/params/profils.js
@@ -177,7 +177,7 @@ $('.bt_deleteSession').on('click',function(){
 
 $('#user_avatar').fileupload({
     dataType: 'json',
-    url: "core/ajax/profils.ajax.php?action=imageUpload",
+    url: "core/ajax/profils.ajax.php?action=imageUpload&ajax_token=" + NEXTDOM_AJAX_TOKEN,
     dropZone: "#bsImagesPanel",
     done: function (e, data) {
         if (data.result.state !== 'ok') {

--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -213,6 +213,9 @@ try {
         if (!isConnect('admin')) {
             throw new Exception(__('401 - Accès non autorisé', __FILE__));
         }
+        if (init('cmd_id') === '') {
+            throw new Exception(__('Historique impossible'));
+        }
         unautorizedInDemo();
         $history = history::byCmdIdDatetime(init('cmd_id'), init('datetime'));
         if (!is_object($history)) {

--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -21,7 +21,7 @@ try {
     include_file('core', 'authentification', 'php');
 
     if (!isConnect()) {
-        throw new Exception(__('401 - Accès non autorisé', __FILE__));
+        throw new \Exception(__('401 - Accès non autorisé', __FILE__));
     }
 
     ajax::init();
@@ -36,17 +36,17 @@ try {
                 }
                 $return[$cmd->getId()] = array(
                     'html' => $cmd->toHtml($value['version']),
-                    'id' => $cmd->getId(),
+                    'id'   => $cmd->getId(),
                 );
             }
             ajax::success($return);
         } else {
             $cmd = cmd::byId(init('id'));
             if (!is_object($cmd)) {
-                throw new Exception(__('Commande inconnue - Vérifiez l\'id', __FILE__));
+                throw new \Exception(__('Commande inconnue - Vérifiez l\'id', __FILE__));
             }
             $info_cmd = array();
-            $info_cmd['id'] = $cmd->getId();
+            $info_cmd['id']   = $cmd->getId();
             $info_cmd['html'] = $cmd->toHtml(init('version'), init('option'), init('cmdColor', null));
             ajax::success($info_cmd);
         }
@@ -55,17 +55,17 @@ try {
     if (init('action') == 'execCmd') {
         $cmd = cmd::byId(init('id'));
         if (!is_object($cmd)) {
-            throw new Exception(__('Commande ID inconnu : ', __FILE__) . init('id'));
+            throw new \Exception(__('Commande ID inconnu : ', __FILE__) . init('id'));
         }
         $eqLogic = $cmd->getEqLogicId();
         if ($cmd->getType() == 'action' && !$eqLogic->hasRight('x')) {
-            throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+            throw new \Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
         }
         if (!$cmd->checkAccessCode(init('codeAccess'))) {
-            throw new Exception(__('Cette action nécessite un code d\'accès', __FILE__), -32005);
+            throw new \Exception(__('Cette action nécessite un code d\'accès', __FILE__), -32005);
         }
         if ($cmd->getType() == 'action' && $cmd->getConfiguration('actionConfirm') == 1 && init('confirmAction') != 1) {
-            throw new Exception(__('Cette action nécessite une confirmation', __FILE__), -32006);
+            throw new \Exception(__('Cette action nécessite une confirmation', __FILE__), -32006);
         }
         $options = json_decode(init('value', '{}'), true);
         if (init('utid') != '') {
@@ -77,7 +77,7 @@ try {
     if (init('action') == 'getByObjectNameEqNameCmdName') {
         $cmd = cmd::byObjectNameEqLogicNameCmdName(init('object_name'), init('eqLogic_name'), init('cmd_name'));
         if (!is_object($cmd)) {
-            throw new Exception(__('Cmd inconnu : ', __FILE__) . init('object_name') . '/' . init('eqLogic_name') . '/' . init('cmd_name'));
+            throw new \Exception(__('Cmd inconnu : ', __FILE__) . init('object_name') . '/' . init('eqLogic_name') . '/' . init('cmd_name'));
         }
         ajax::success($cmd->getId());
     }
@@ -85,7 +85,7 @@ try {
     if (init('action') == 'getByObjectNameCmdName') {
         $cmd = cmd::byObjectNameCmdName(init('object_name'), init('cmd_name'));
         if (!is_object($cmd)) {
-            throw new Exception(__('Cmd inconnu : ', __FILE__) . init('object_name') . '/' . init('cmd_name'), 9999);
+            throw new \Exception(__('Cmd inconnu : ', __FILE__) . init('object_name') . '/' . init('cmd_name'), 9999);
         }
         ajax::success(utils::o2a($cmd));
     }
@@ -93,14 +93,14 @@ try {
     if (init('action') == 'byId') {
         $cmd = cmd::byId(init('id'));
         if (!is_object($cmd)) {
-            throw new Exception(__('Commande inconnue : ', __FILE__) . init('id'), 9999);
+            throw new \Exception(__('Commande inconnue : ', __FILE__) . init('id'), 9999);
         }
         ajax::success(nextdom::toHumanReadable(utils::o2a($cmd)));
     }
 
     if (init('action') == 'copyHistoryToCmd') {
         if (!isConnect('admin')) {
-            throw new Exception(__('401 - Accès non autorisé', __FILE__));
+            throw new \Exception(__('401 - Accès non autorisé', __FILE__));
         }
         unautorizedInDemo();
         ajax::success(history::copyHistoryToCmd(init('source_id'), init('target_id')));
@@ -108,7 +108,7 @@ try {
 
     if (init('action') == 'replaceCmd') {
         if (!isConnect('admin')) {
-            throw new Exception(__('401 - Accès non autorisé', __FILE__));
+            throw new \Exception(__('401 - Accès non autorisé', __FILE__));
         }
         unautorizedInDemo();
         ajax::success(nextdom::replaceTag(array('#' . str_replace('#', '', init('source_id')) . '#' => '#' . str_replace('#', '', init('target_id')) . '#')));
@@ -125,30 +125,30 @@ try {
 
     if (init('action') == 'usedBy') {
         if (!isConnect('admin')) {
-            throw new Exception(__('401 - Accès non autorisé', __FILE__));
+            throw new \Exception(__('401 - Accès non autorisé', __FILE__));
         }
         $cmd = cmd::byId(init('id'));
         if (!is_object($cmd)) {
-            throw new Exception(__('Commande inconnue : ', __FILE__) . init('id'), 9999);
+            throw new \Exception(__('Commande inconnue : ', __FILE__) . init('id'), 9999);
         }
         $result = $cmd->getUsedBy();
         $return = array('cmd' => array(), 'eqLogic' => array(), 'scenario' => array());
         foreach ($result['cmd'] as $cmd) {
             $info = utils::o2a($cmd);
             $info['humanName'] = $cmd->getHumanName();
-            $info['link'] = $cmd->getEqLogic()->getLinkToConfiguration();
+            $info['link']      = $cmd->getEqLogic()->getLinkToConfiguration();
             $return['cmd'][] = $info;
         }
         foreach ($result['eqLogic'] as $eqLogic) {
             $info = utils::o2a($eqLogic);
             $info['humanName'] = $eqLogic->getHumanName();
-            $info['link'] = $eqLogic->getLinkToConfiguration();
+            $info['link']      = $eqLogic->getLinkToConfiguration();
             $return['eqLogic'][] = $info;
         }
         foreach ($result['scenario'] as $scenario) {
             $info = utils::o2a($cmd);
             $info['humanName'] = $scenario->getHumanName();
-            $info['link'] = $scenario->getLinkToConfiguration();
+            $info['link']      = $scenario->getLinkToConfiguration();
             $return['scenario'][] = $info;
         }
         ajax::success($return);
@@ -165,7 +165,7 @@ try {
     if (init('action') == 'getCmd') {
         $cmd = cmd::byId(init('id'));
         if (!is_object($cmd)) {
-            throw new Exception(__('Commande inconnue : ', __FILE__) . init('id'));
+            throw new \Exception(__('Commande inconnue : ', __FILE__) . init('id'));
         }
         $return = nextdom::toHumanReadable(utils::o2a($cmd));
         $eqLogic = $cmd->getEqLogicId();
@@ -179,7 +179,7 @@ try {
 
     if (init('action') == 'save') {
         if (!isConnect('admin')) {
-            throw new Exception(__('401 - Accès non autorisé', __FILE__));
+            throw new \Exception(__('401 - Accès non autorisé', __FILE__));
         }
         unautorizedInDemo();
         $cmd_ajax = nextdom::fromHumanReadable(json_decode(init('cmd'), true));
@@ -194,7 +194,7 @@ try {
 
     if (init('action') == 'multiSave') {
         if (!isConnect('admin')) {
-            throw new Exception(__('401 - Accès non autorisé', __FILE__));
+            throw new \Exception(__('401 - Accès non autorisé', __FILE__));
         }
         unautorizedInDemo();
         $cmds = json_decode(init('cmd'), true);
@@ -211,10 +211,10 @@ try {
 
     if (init('action') == 'changeHistoryPoint') {
         if (!isConnect('admin')) {
-            throw new Exception(__('401 - Accès non autorisé', __FILE__));
+            throw new \Exception(__('401 - Accès non autorisé', __FILE__));
         }
         if (init('cmd_id') === '') {
-            throw new Exception(__('Historique impossible'));
+            throw new \Exception(__('Historique impossible'));
         }
         unautorizedInDemo();
         $history = history::byCmdIdDatetime(init('cmd_id'), init('datetime'));
@@ -231,7 +231,7 @@ try {
             $history = history::byCmdIdDatetime(init('cmd_id'), init('datetime'), date('Y-m-d H:i:s', strtotime(init('datetime') . ' +1 month')), init('oldValue'));
         }
         if (!is_object($history)) {
-            throw new Exception(__('Aucun point ne correspond pour l\'historique : ', __FILE__) . init('cmd_id') . ' - ' . init('datetime'), init('oldValue'));
+            throw new \Exception(__('Aucun point ne correspond pour l\'historique : ', __FILE__) . init('cmd_id') . ' - ' . init('datetime'), init('oldValue'));
         }
         $history->setValue(init('value', null));
         $history->save(null, true);
@@ -286,18 +286,18 @@ try {
         if (is_numeric(init('id'))) {
             $cmd = cmd::byId(init('id'));
             if (!is_object($cmd)) {
-                throw new Exception(__('Commande ID inconnu : ', __FILE__) . init('id'));
+                throw new \Exception(__('Commande ID inconnu : ', __FILE__) . init('id'));
             }
             $eqLogic = $cmd->getEqLogicId();
             if (!$eqLogic->hasRight('r')) {
-                throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+                throw new \Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
             }
             $histories = $cmd->getHistory($dateStart, $dateEnd);
-            $return['cmd_name'] = $cmd->getName();
+            $return['cmd_name']     = $cmd->getName();
             $return['history_name'] = $cmd->getHumanName();
-            $return['unite'] = $cmd->getUnite();
-            $return['cmd'] = utils::o2a($cmd);
-            $return['eqLogic'] = utils::o2a($cmd->getEqLogicId());
+            $return['unite']        = $cmd->getUnite();
+            $return['cmd']          = utils::o2a($cmd);
+            $return['eqLogic']      = utils::o2a($cmd->getEqLogicId());
             $return['timelineOnly'] = $NEXTDOM_INTERNAL_CONFIG['cmd']['type']['info']['subtype'][$cmd->getSubType()]['isHistorized']['timelineOnly'];
             $previsousValue = null;
             $derive = init('derive', $cmd->getDisplay('graphDerive'));
@@ -351,9 +351,9 @@ try {
                     $data[] = $info_history;
                 }
             }
-            $return['cmd_name'] = init('id');
+            $return['cmd_name']     = init('id');
             $return['history_name'] = init('id');
-            $return['unite'] = init('unite');
+            $return['unite']        = init('unite');
         }
         $return['data'] = $data;
         ajax::success($return);
@@ -361,12 +361,12 @@ try {
 
     if (init('action') == 'emptyHistory') {
         if (!isConnect('admin')) {
-            throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+            throw new \Exception(__('401 - Accès non autorisé', __FILE__), -1234);
         }
         unautorizedInDemo();
         $cmd = cmd::byId(init('id'));
         if (!is_object($cmd)) {
-            throw new Exception(__('Commande ID inconnu : ', __FILE__) . init('id'));
+            throw new \Exception(__('Commande ID inconnu : ', __FILE__) . init('id'));
         }
         $cmd->emptyHistory(init('date'));
         ajax::success();
@@ -409,8 +409,8 @@ try {
         ajax::success();
     }
 
-    throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
+    throw new \Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
     /*     * *********Catch exeption*************** */
-} catch (Exception $e) {
+} catch (\Exception $e) {
     ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/eqLogic.ajax.php
+++ b/core/ajax/eqLogic.ajax.php
@@ -382,6 +382,7 @@ try {
             }
             ajax::success(utils::o2a($eqLogic));
         }
+        ajax::success(null);
     }
 
     if (init('action') == 'getAlert') {

--- a/core/ajax/nextdom.ajax.php
+++ b/core/ajax/nextdom.ajax.php
@@ -150,7 +150,12 @@ try {
     
     if (init('action') == 'db') {
         unautorizedInDemo();
-        ajax::success(DB::prepare(init('command'), array(), DB::FETCH_TYPE_ALL));
+        if (init('command', '') !== '') {
+            ajax::success(DB::prepare(init('command'), array(), DB::FETCH_TYPE_ALL));
+        }
+        else {
+            ajax::error(__('Aucune requête à exécuter'));
+        }
     }
     
     if (init('action') == 'health') {
@@ -275,11 +280,16 @@ try {
         $return = array('node' => array(), 'link' => array());
         $object = null;
         $type = init('filter_type');
-        $object = $type::byId(init('filter_id'));
-        if (!is_object($object)) {
-            throw new Exception(__('Type :', __FILE__) . init('filter_type') . __(' avec id : ', __FILE__) . init('filter_id') . __(' inconnu', __FILE__));
+        if ($type !== '') {
+            $object = $type::byId(init('filter_id'));
+            if (!is_object($object)) {
+                throw new Exception(__('Type :', __FILE__) . init('filter_type') . __(' avec id : ', __FILE__) . init('filter_id') . __(' inconnu', __FILE__));
+            }
+            ajax::success($object->getLinkData());
         }
-        ajax::success($object->getLinkData());
+        else {
+            ajax::error(__('Aucun filtre'));
+        }
     }
     
     if (init('action') == 'getTimelineEvents') {

--- a/core/ajax/note.ajax.php
+++ b/core/ajax/note.ajax.php
@@ -25,6 +25,8 @@ try {
         throw new Exception(__('401 - Accès non autorisé', __FILE__));
     }
 
+    ajax::init();
+
     if (init('action') == 'all') {
         if (!isConnect('admin')) {
             throw new Exception(__('401 - Accès non autorisé', __FILE__));
@@ -66,8 +68,6 @@ try {
         $note->remove();
         ajax::success();
     }
-
-    ajax::init();
 
     throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
     /*     * *********Catch exeption*************** */

--- a/core/ajax/plan.ajax.php
+++ b/core/ajax/plan.ajax.php
@@ -66,6 +66,9 @@ try {
         if (!isConnect('admin')) {
             throw new Exception(__('401 - Accès non autorisé', __FILE__));
         }
+        if (init('plan', '') === '') {
+            throw new Exception(__('L\'identifiant du plan doit être fourni', __FILE__));
+        }
         unautorizedInDemo();
         $plan = new plan();
         utils::a2o($plan, json_decode(init('plan'), true));

--- a/core/ajax/plan3d.ajax.php
+++ b/core/ajax/plan3d.ajax.php
@@ -57,6 +57,9 @@ try {
         if (!isConnect('admin')) {
             throw new Exception(__('401 - Accès non autorisé', __FILE__));
         }
+        if (init('plan3d', '') === '') {
+            throw new Exception(__('L\'identifiant du plan doit être fourni', __FILE__));
+        }
         unautorizedInDemo();
         $plan3d = new plan3d();
         utils::a2o($plan3d, json_decode(init('plan3d'), true));

--- a/core/ajax/profils.ajax.php
+++ b/core/ajax/profils.ajax.php
@@ -19,16 +19,15 @@
 try {
     require_once dirname(__FILE__) . '/../../core/php/core.inc.php';
     include_file('core', 'authentification', 'php');
-    if (!isConnect('admin')) {
+    if (!isConnect()) {
         throw new Exception(__('401 - Accès non autorisé', __FILE__));
 
     }
 
-
     if (init('action') == 'removeImage') {
         $uploaddir = dirname(__FILE__) . '/../../public/img/profils/';
-        $name = init('image');
-        ajax::success(unlink($uploaddir . $name));
+        $pathInfo = pathinfo(init('image'));
+        ajax::success(unlink($uploaddir . $pathInfo['basename'] . '.' . $pathInfo['extension']));
     }
 
     if (init('action') == 'imageUpload') {

--- a/core/ajax/repo.ajax.php
+++ b/core/ajax/repo.ajax.php
@@ -34,112 +34,152 @@ try {
 
     if (init('action') == 'restoreCloud') {
         unautorizedInDemo();
-        $class = 'repo_' . init('repo');
-        $class::backup_restore(init('backup'));
-        ajax::success();
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            $class::backup_restore(init('backup'));
+            ajax::success();
+        }
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     if (init('action') == 'sendReportBug') {
         unautorizedInDemo();
-        $class = 'repo_' . init('repo');
-        ajax::success($class::saveTicket(json_decode(init('ticket'), true)));
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            ajax::success($class::saveTicket(json_decode(init('ticket'), true)));
+        }
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     if (init('action') == 'install') {
         unautorizedInDemo();
-        $class = 'repo_' . init('repo');
-        $repo = $class::byId(init('id'));
-        if (!is_object($repo)) {
-            throw new Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            $repo = $class::byId(init('id'));
+            if (!is_object($repo)) {
+                throw new Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
+            }
+            $update = update::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
+            if (!is_object($update)) {
+                $update = new update();
+            }
+            $update->setSource(init('repo'));
+            $update->setLogicalId($repo->getLogicalId());
+            $update->setType($repo->getType());
+            $update->setLocalVersion($repo->getDatetime(init('version', 'stable')));
+            $update->setConfiguration('version', init('version', 'stable'));
+            $update->save();
+            $update->doUpdate();
+            ajax::success();
         }
-        $update = update::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
-        if (!is_object($update)) {
-            $update = new update();
-        }
-        $update->setSource(init('repo'));
-        $update->setLogicalId($repo->getLogicalId());
-        $update->setType($repo->getType());
-        $update->setLocalVersion($repo->getDatetime(init('version', 'stable')));
-        $update->setConfiguration('version', init('version', 'stable'));
-        $update->save();
-        $update->doUpdate();
-        ajax::success();
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     if (init('action') == 'test') {
-        $class = 'repo_' . init('repo');
-        $class::test();
-        ajax::success();
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            $class::test();
+            ajax::success();
+        }
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     if (init('action') == 'remove') {
         unautorizedInDemo();
-        $class = 'repo_' . init('repo');
-        $repo = $class::byId(init('id'));
-        if (!is_object($market)) {
-            throw new Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
-        }
-        $update = update::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
-        try {
-            if (is_object($update)) {
-                $update->remove();
-            } else {
-                $market->remove();
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            $repo = $class::byId(init('id'));
+            if (!is_object($market)) {
+                throw new Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
             }
-        } catch (Exception $e) {
-            if (is_object($update)) {
-                $update->deleteObjet();
+            $update = update::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
+            try {
+                if (is_object($update)) {
+                    $update->remove();
+                } else {
+                    $market->remove();
+                }
+            } catch (Exception $e) {
+                if (is_object($update)) {
+                    $update->deleteObjet();
+                }
             }
+            ajax::success();
         }
-        ajax::success();
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     if (init('action') == 'save') {
         unautorizedInDemo();
-        $class = 'repo_' . init('repo');
-        $repo_ajax = json_decode(init('market'), true);
-        try {
-            $repo = $class::byId($repo_ajax['id']);
-        } catch (Exception $e) {
-            $repo = new $class();
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            $repo_ajax = json_decode(init('market'), true);
+            try {
+                $repo = $class::byId($repo_ajax['id']);
+            } catch (Exception $e) {
+                $repo = new $class();
+            }
+            utils::a2o($repo, $repo_ajax);
+            $repo->save();
+            ajax::success();
         }
-        utils::a2o($repo, $repo_ajax);
-        $repo->save();
-        ajax::success();
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     if (init('action') == 'getInfo') {
-        $class = 'repo_' . init('repo');
-        ajax::success($class::getInfo(init('logicalId')));
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            ajax::success($class::getInfo(init('logicalId')));
+        }
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     if (init('action') == 'byLogicalId') {
-        $class = 'repo_' . init('repo');
-        if (init('noExecption', 0) == 1) {
-            try {
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            if (init('noExecption', 0) == 1) {
+                try {
+                    ajax::success(utils::o2a($class::byLogicalIdAndType(init('logicalId'), init('type'))));
+                } catch (Exception $e) {
+                    ajax::success();
+                }
+            } else {
                 ajax::success(utils::o2a($class::byLogicalIdAndType(init('logicalId'), init('type'))));
-            } catch (Exception $e) {
-                ajax::success();
             }
-        } else {
-            ajax::success(utils::o2a($class::byLogicalIdAndType(init('logicalId'), init('type'))));
         }
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     if (init('action') == 'setRating') {
         unautorizedInDemo();
-        $class = 'repo_' . init('repo');
-        $repo = $class::byId(init('id'));
-        if (!is_object($repo)) {
-            throw new Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            $repo = $class::byId(init('id'));
+            if (!is_object($repo)) {
+                throw new Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
+            }
+            $repo->setRating(init('rating'));
+            ajax::success();
         }
-        $repo->setRating(init('rating'));
-        ajax::success();
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     if (init('action') == 'backupList') {
-        $class = 'repo_' . init('repo');
-        ajax::success($class::backup_list());
+        $repoName = init('repo');
+        if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
+            $class = 'repo_' . $repoName;
+            ajax::success($class::backup_list());
+        }
+        ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
     throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));

--- a/core/ajax/repo.ajax.php
+++ b/core/ajax/repo.ajax.php
@@ -21,7 +21,7 @@ try {
     include_file('core', 'authentification', 'php');
 
     if (!isConnect('admin')) {
-        throw new Exception(__('401 - Accès non autorisé', __FILE__));
+        throw new \Exception(__('401 - Accès non autorisé', __FILE__));
     }
 
     ajax::init();
@@ -66,11 +66,11 @@ try {
             if (!is_object($update)) {
                 $update = new update();
             }
-            $update->setSource(init('repo'));
-            $update->setLogicalId($repo->getLogicalId());
-            $update->setType($repo->getType());
-            $update->setLocalVersion($repo->getDatetime(init('version', 'stable')));
-            $update->setConfiguration('version', init('version', 'stable'));
+            $update->setSource(init('repo'))
+                ->setLogicalId($repo->getLogicalId()
+                ->setType($repo->getType()
+                ->setLocalVersion($repo->getDatetime(init('version', 'stable')))
+                ->setConfiguration('version', init('version', 'stable'));
             $update->save();
             $update->doUpdate();
             ajax::success();
@@ -95,7 +95,7 @@ try {
             $class = 'repo_' . $repoName;
             $repo = $class::byId(init('id'));
             if (!is_object($market)) {
-                throw new Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
+                throw new \Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
             }
             $update = update::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
             try {
@@ -145,7 +145,7 @@ try {
         $repoName = init('repo');
         if (file_exists(NEXTDOM_ROOT . '/core/repo/' . $repoName . '.repo.php')) {
             $class = 'repo_' . $repoName;
-            if (init('noExecption', 0) == 1) {
+            if (init('noException', 0) == 1) {
                 try {
                     ajax::success(utils::o2a($class::byLogicalIdAndType(init('logicalId'), init('type'))));
                 } catch (Exception $e) {
@@ -165,7 +165,7 @@ try {
             $class = 'repo_' . $repoName;
             $repo = $class::byId(init('id'));
             if (!is_object($repo)) {
-                throw new Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
+                throw new \Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
             }
             $repo->setRating(init('rating'));
             ajax::success();
@@ -182,9 +182,9 @@ try {
         ajax::error(__('Le repo n\'existe pas : ' . $repoName));
     }
 
-    throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
+    throw new \Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 
     /*     * *********Catch exeption*************** */
-} catch (Exception $e) {
+} catch (\Exception $e) {
     ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/update.ajax.php
+++ b/core/ajax/update.ajax.php
@@ -19,21 +19,21 @@
 try {
     require_once __DIR__ . '/../../core/php/core.inc.php';
     include_file('core', 'authentification', 'php');
-    
+
     if (!isConnect()) {
         throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
     }
-    
+
     ajax::init();
-    
+
     if (init('action') == 'nbUpdate') {
         ajax::success(update::nbNeedUpdate());
     }
-    
+
     if (!isConnect('admin')) {
         throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
     }
-    
+
     if (init('action') == 'all') {
         $return = array();
         foreach (update::all(init('filter')) as $update) {
@@ -43,20 +43,20 @@ try {
                     $plugin = plugin::byId($update->getLogicalId());
                     $infos['plugin'] = is_object($plugin) ? utils::o2a($plugin) : array();
                 } catch (Exception $e) {
-                    
+
                 }
             }
             $return[] = $infos;
         }
         ajax::success($return);
     }
-    
+
     if (init('action') == 'checkAllUpdate') {
         unautorizedInDemo();
         update::checkAllUpdate();
         ajax::success();
     }
-    
+
     if (init('action') == 'update') {
         unautorizedInDemo();
         log::clear('update');
@@ -77,7 +77,7 @@ try {
                         $cron->start();
                     }
                 } catch (Exception $e) {
-                    
+
                 }
                 log::add('update', 'alert', __("[END UPDATE SUCCESS]", __FILE__));
             }
@@ -89,7 +89,7 @@ try {
         }
         ajax::success();
     }
-    
+
     if (init('action') == 'remove') {
         unautorizedInDemo();
         update::findNewUpdateObject();
@@ -103,7 +103,7 @@ try {
         $update->deleteObjet();
         ajax::success();
     }
-    
+
     if (init('action') == 'checkUpdate') {
         unautorizedInDemo();
         $update = update::byId(init('id'));
@@ -116,13 +116,13 @@ try {
         $update->checkUpdate();
         ajax::success();
     }
-    
+
     if (init('action') == 'updateAll') {
         unautorizedInDemo();
         nextdom::update(json_decode(init('options', '{}'), true));
             ajax::success();
         }
-        
+
         if (init('action') == 'save') {
             unautorizedInDemo();
             $new = false;
@@ -152,14 +152,14 @@ try {
             }
             ajax::success(utils::o2a($update));
         }
-        
+
         if (init('action') == 'saves') {
             unautorizedInDemo();
             utils::processJsonObject('update', init('updates'));
             ajax::success();
         }
-        
-        if (init('action') == 'preUploadFile') {
+
+            if (init('action') == 'preUploadFile') {
             unautorizedInDemo();
             $uploaddir = '/tmp';
             if (!file_exists($uploaddir)) {
@@ -180,7 +180,7 @@ try {
             }
             ajax::success($uploaddir . '/' . $filename);
         }
-        
+
         throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
         /*     * *********Catch exeption*************** */
     } catch (Exception $e) {

--- a/src/Managers/EqLogicManager.php
+++ b/src/Managers/EqLogicManager.php
@@ -366,6 +366,8 @@ class EqLogicManager
         } elseif ($objectId != '') {
             $values['object_id'] = $objectId;
             $sql .= 'object_id = :object_id ';
+        } else {
+            return null;
         }
         if ($subTypeCmd != '') {
             $values['subTypeCmd'] = $subTypeCmd;

--- a/src/Managers/Plan3dManager.php
+++ b/src/Managers/Plan3dManager.php
@@ -38,7 +38,7 @@ use NextDom\Model\Entity\Plan3d;
 class Plan3dManager
 {
     const CLASS_NAME = Plan3d::class;
-    const DB_CLASS_NAME = '`Plan3d`';
+    const DB_CLASS_NAME = '`plan3d`';
 
     public static function byId($_id)
     {

--- a/src/Managers/ScenarioManager.php
+++ b/src/Managers/ScenarioManager.php
@@ -56,7 +56,7 @@ class ScenarioManager
      *
      * @throws \Exception
      */
-    public static function byId(int $id)
+    public static function byId($id)
     {
         $values = array('id' => $id);
         $sql = 'SELECT ' . \DB::buildField(self::CLASS_NAME) . ' FROM ' . self::DB_CLASS_NAME . ' WHERE id = :id';

--- a/src/Model/Entity/JeeObject.php
+++ b/src/Model/Entity/JeeObject.php
@@ -43,7 +43,7 @@ class JeeObject
      *
      * @ORM\Column(name="name", type="string", length=45, nullable=false)
      */
-    protected $name;
+    protected $name = '';
 
     /**
      * @var boolean
@@ -495,7 +495,7 @@ class JeeObject
      *
      * @return string Object name
      */
-    public function getName(): string
+    public function getName()
     {
         return $this->name;
     }

--- a/tests/check_jeedom_compatibility_from_src.py
+++ b/tests/check_jeedom_compatibility_from_src.py
@@ -1,0 +1,185 @@
+"""Check Jeedom compatibility
+"""
+import re
+import sys
+import os
+from tests.libs.tests_funcs import *
+
+AJAX_PATH = 'core/core/ajax/'
+CLASS_PATH = 'core/core/class/'
+NEXTDOM_CLASS_PATH = '../core/class/'
+NEXTDOM_ENTITY_PATH = '../src/Model/Entity/'
+TESTS_PATH = 'compatibility/'
+
+def get_ajax_actions_from_file(ajax_file):
+    """Get ajax actions from a single Jeedom file
+    :param ajax_file: Path of the ajax file
+    :type ajax_file:  str
+    :return:          List of actions
+    :rtype:           list
+    """
+    with open(AJAX_PATH + ajax_file, 'r') as file_content:
+        content = file_content.read()
+        return re.findall(r'action\'\) == \'(.*?)\'', content)
+
+def get_class_methods_from_file(class_file):
+    """Get class methods from a single Jeedom file
+    :param ajax_file: Path of the class file
+    :type ajax_file:  str
+    :return:          List of methods
+    :rtype:           list
+    """
+    with open(CLASS_PATH + class_file, 'r') as file_content:
+        content = file_content.read()
+        return re.findall(r' function (\w+)\(', content)
+
+def get_class_methods():
+    """Get all class methods from Jeedom
+    :return: All class methods actions
+    :rtype:  dict
+    """
+    result = {}
+    for class_file in os.listdir(CLASS_PATH):
+        if class_file not in ('.', '..'):
+            class_methods = get_class_methods_from_file(class_file)
+            if class_methods:
+                result[class_file] = class_methods
+    return result
+
+def get_ajax_actions():
+    """Get all ajax actions from Jeedom
+    :return: All ajax actions
+    :rtype:  dict
+    """
+    result = {}
+    for ajax_file in os.listdir(AJAX_PATH):
+        if ajax_file not in ('.', '..'):
+            ajax_actions = get_ajax_actions_from_file(ajax_file)
+            if ajax_actions:
+                result[ajax_file] = ajax_actions
+    return result
+
+def check_ajax_file(file_to_check, actions_list):
+    """Check actions from file
+    :param file_to_check: Ajax file to check
+    :param actions_list:  List of actions
+    :type:                str
+    :type:                list
+    :return:              True if all actions are tested
+    :rtype:               bool
+    """
+    result = True
+    test_name = file_to_check.replace('.ajax.php', '').capitalize()
+    if test_name == 'Jeedom':
+        test_name = 'NextDom'
+    # Ignore migration functionnality
+    if test_name == 'Migrate':
+        return True
+    test_file = TESTS_PATH + 'Ajax' + test_name + 'Test.php'
+    if os.path.isfile(test_file):
+        with open(test_file, 'r') as test_file_content:
+            test_content = test_file_content.read()
+            test_content = test_content.lower()
+            for action in actions_list:
+                if test_content.find('test' + action.lower()) == -1:
+                    print_warning('In ' + test_name + ', test for action ' + action + ' not found.')
+                    result = False
+    else:
+        print('File ' + test_file + ' not found.')
+        result = False
+    return result
+
+def check_if_ajax_action_is_tested(actions_to_check):
+    """Check if file has tests
+    :param actions_to_check: List of all actions to test
+    :type actions_to_check:  dict
+    """
+    result = True
+    for file_to_check in actions_to_check.keys():
+        if not check_ajax_file(file_to_check, actions_to_check[file_to_check]):
+            result = False
+    return result
+
+def get_entity_content_if_exists(base_class_file_content):
+    """Get content of the entity file
+    :param base_class_file_content: Name of the entity file
+    :type base_class_file_content:  str
+    :return:                        Content of the entity file if exists
+    :rtype:                         str
+    """
+    result = ''
+    entity_regex = r'extends \\?NextDom\\Model\\Entity\\(\w+)'
+    entity_file_re = re.findall(entity_regex, base_class_file_content)
+    if entity_file_re:
+        with open(NEXTDOM_ENTITY_PATH + entity_file_re[0] + '.php') as entity_content:
+            result = entity_content.read()
+    return result
+
+def check_class_methods_file(file_to_check, methods_list):
+    """Check class methods from file
+    :param file_to_check: Ajax file to check
+    :param actions_list:  List of actions
+    :type:                str
+    :type:                list
+    :return:              True if all actions are tested
+    :rtype:               bool
+    """
+    result = True
+    if file_to_check == 'jeedom.class.php':
+        file_to_check = 'nextdom.class.php'
+    # Ignore migration functionnality
+    if file_to_check == 'migrate.class.php':
+        return True
+    if os.path.isfile(NEXTDOM_CLASS_PATH + file_to_check):
+        with open(NEXTDOM_CLASS_PATH + file_to_check, 'r') as class_file_content:
+            test_content = class_file_content.read()
+            test_content = test_content + get_entity_content_if_exists(test_content)
+            test_content = test_content.lower()
+            for method in methods_list:
+                if test_content.find('function ' + method.lower()) == -1:
+                    print_warning('In ' + file_to_check + ', method ' + method + ' not found.')
+                    result = False
+    else:
+        print('Class ' + file_to_check + ' not found.')
+        result = False
+    return result
+
+def check_if_class_methods_exists(class_methods_to_check):
+    """Check if methods exists
+    :param class_methods_to_check: Methods to check
+    :type class_methods_to_check:  dict
+    """
+    result = True
+    for file_to_check in class_methods_to_check.keys():
+        if not check_class_methods_file(file_to_check, class_methods_to_check[file_to_check]):
+            result = False
+    return result
+
+def start_tests():
+    """Test compatibility with jeedom
+    :return: False if error found
+    :rtype:  bool
+    """
+    print_subtitle('Ajax')
+    error = False
+    jeedom_ajax_actions = get_ajax_actions()
+    if not check_if_ajax_action_is_tested(jeedom_ajax_actions):
+        error = True
+    else:
+        print_info('OK')
+
+    print_subtitle('Classes')
+    jeedom_class_methods = get_class_methods()
+    if not check_if_class_methods_exists(jeedom_class_methods):
+        error = True
+    else:
+        print_info('OK')
+
+    return error
+
+if __name__ == "__main__":
+    print_title('Compatibility with Jeedom')
+    os.system('git clone https://github.com/jeedom/core')
+    os.system('cd core && git checkout stable -f > /dev/null')
+    if start_tests():
+        sys.exit(1)

--- a/tests/compatibility/AjaxCacheTest.php
+++ b/tests/compatibility/AjaxCacheTest.php
@@ -1,0 +1,88 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxCacheTest extends AjaxBase
+{
+    private $ajaxFile = 'cache';
+    
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'flush']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testFlushAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'flush']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testFlushAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'flush']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        // TODO : Change
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCleanAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'clean']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCleanAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'clean']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        // TODO : Change
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testStatsAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'stats']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testStatsAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'stats']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        // TODO : Change
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxCmdTest.php
+++ b/tests/compatibility/AjaxCmdTest.php
@@ -1,0 +1,218 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxCmdTest extends AjaxBase
+{
+    private $ajaxFile = 'cmd';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'toHtml']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testToHtmlAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'toHtml']);
+        $this->assertContains('Commande inconnue', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testExecCmdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'execCmd']);
+        $this->assertContains('Commande ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetByObjectNameEqNameCmdNameAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getByObjectNameEqNameCmdName']);
+        $this->assertContains('Cmd inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetByObjectNameCmdNameAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getByObjectNameCmdName']);
+        $this->assertContains('Cmd inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByIdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byId']);
+        $this->assertContains('Commande inconnue', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCopyHistoryToCmdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copyHistoryToCmd']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCopyHistoryToCmdAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copyHistoryToCmd']);
+        $this->assertContains('La commande source', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testReplaceCmdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'replaceCmd']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testReplaceCmdAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'replaceCmd']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByHumanNameAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byHumanName']);
+        $this->assertContains('Commande inconnue', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUsedByAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'usedBy']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUsedByAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'usedBy']);
+        $this->assertContains('Commande inconnue', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetHumanCmdNameAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getHumanCmdName']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByEqLogicAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byEqLogic']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetCmdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getCmd']);
+        $this->assertContains('Commande inconnue', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('Le nom de la commande ne', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testMultiSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'multiSave']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testMultiSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'multiSave']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testChangeHistoryPointAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changeHistoryPoint']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testChangeHistoryPointAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changeHistoryPoint']);
+        $this->assertContains('Historique impossible', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetHistoryAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getHistory']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testEmptyHistoryAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'emptyHistory']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testEmptyHistoryAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'emptyHistory']);
+        $this->assertContains('Commande ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetOrderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setOrder']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxConfigTest.php
+++ b/tests/compatibility/AjaxConfigTest.php
@@ -1,0 +1,88 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxConfigTest extends AjaxBase
+{
+    private $ajaxFile = 'config';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'genApiKey']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGenApiKeyAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'genApiKey']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGenApiKeyAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'genApiKey']);
+        $this->assertEquals(32, strlen(json_decode((string) $result->getBody(), true)['result']));
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetKeyAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getKey']);
+        $this->assertContains('Aucune clef demand', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAddKeyAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'addKey']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAddKeyAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'addKey']);
+        $this->assertContains('"state":"ok"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveKeyAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeKey']);
+        $this->assertContains('Aucune clef demand', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+        // TODO : Pas normal ça
+    }
+
+
+}

--- a/tests/compatibility/AjaxCronTest.php
+++ b/tests/compatibility/AjaxCronTest.php
@@ -1,0 +1,114 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxCronTest extends AjaxBase
+{
+    private $ajaxFile = 'cron';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('Invalid json', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Cron id inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertEquals(17, count(json_decode((string) $result->getBody(), true)['result']));
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testStartAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'start']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testStartAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'start']);
+        $this->assertContains('Cron id inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testStopAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'stop']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testStopAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'stop']);
+        $this->assertContains('Cron id inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxDataStoreTest.php
+++ b/tests/compatibility/AjaxDataStoreTest.php
@@ -1,0 +1,65 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxDataStoreTest extends AjaxBase
+{
+    private $ajaxFile = 'dataStore';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Dépôt de données inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('Le type doit être un des suivants', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxEqLogicTest.php
+++ b/tests/compatibility/AjaxEqLogicTest.php
@@ -1,0 +1,220 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxEqLogicTest extends AjaxBase
+{
+    private $ajaxFile = 'eqLogic';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetEqLogicObjectAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getEqLogicObject']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByIdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byId']);
+        $this->assertContains('EqLogic inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testToHtmlAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'toHtml']);
+        $this->assertContains('Eqlogic inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testHtmlAlertAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'htmlAlert']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testHtmlBatteryAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'htmlBattery']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListByTypeAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'listByType']);
+        $this->assertContains('"result":null', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListByObjectAndCmdTypeAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'listByObjectAndCmdType']);
+        $this->assertContains('"result":null', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListByObjectAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'listByObject']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListByTypeAndCmdTypeAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'listByTypeAndCmdType']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetIsEnableAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setIsEnable']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetIsEnableAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setIsEnable']);
+        $this->assertContains('EqLogic inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetOrderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setOrder']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemovesAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removes']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+        // Todo : Bizarre
+    }
+
+    public function testSetIsVisiblesAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setIsVisibles']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetIsEnablesAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setIsEnables']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSimpleSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'simpleSave']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSimpleSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'simpleSave']);
+        $this->assertContains('EqLogic inconnu.', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCopyAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copy']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCopyAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copy']);
+        $this->assertContains('EqLogic inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveCmdAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('EqLogic inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('Type incorrect (classe équipement inexistante)', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('"result":null', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAlertAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getAlert']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+        // Todo : Bizarre
+    }
+}

--- a/tests/compatibility/AjaxEventTest.php
+++ b/tests/compatibility/AjaxEventTest.php
@@ -1,0 +1,50 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxEventTest extends AjaxBase
+{
+    private $ajaxFile = 'event';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changes']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testChangesAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changes']);
+        $this->assertTrue(count(json_decode((string) $result->getBody(), true)['result']) > 0);
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxInteractTest.php
+++ b/tests/compatibility/AjaxInteractTest.php
@@ -1,0 +1,156 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxInteractTest extends AjaxBase
+{
+    private $ajaxFile = 'interact';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByIdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byId']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByIdAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byId']);
+        $this->assertContains('"result":{"nbInteractQuery":0,"nbEnableInteractQuery":0}', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('La commande (demande) ne peut pas être vide', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRegenerateInteractAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'regenerateInteract']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRegenerateInteractAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'regenerateInteract']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Interaction inconnue.', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testChangeStateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changeState']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testChangeStateAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changeState']);
+        $this->assertContains('InteractQuery ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testChangeAllStateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changeAllState']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testChangeAllStateAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changeAllState']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testExecuteAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'execute']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testExecuteAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'execute']);
+        $this->assertContains('"result":{"reply":""}', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+}

--- a/tests/compatibility/AjaxListenerTest.php
+++ b/tests/compatibility/AjaxListenerTest.php
@@ -1,0 +1,85 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxListenerTest extends AjaxBase
+{
+    private $ajaxFile = 'listener';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('Invalid json', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Listerner id inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxLogTest.php
+++ b/tests/compatibility/AjaxLogTest.php
@@ -1,0 +1,113 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxLogTest extends AjaxBase
+{
+    private $ajaxFile = 'log';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'clear']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testClearAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'clear']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testClearAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'clear']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'list']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'list']);
+        $this->assertEquals(7, count(json_decode((string) $result->getBody(), true)['result']));
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeAll']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAllAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeAll']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('Cannot use SplFileObject with directories', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxMessageTest.php
+++ b/tests/compatibility/AjaxMessageTest.php
@@ -1,0 +1,71 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxMessageTest extends AjaxBase
+{
+    private $ajaxFile = 'message';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'nbMessage']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testClearMessageAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'clearMessage']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testNbMessageAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'nbMessage']);
+        $this->assertContains('"result":"0"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveMessageAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeMessage']);
+        $this->assertContains('Message inconnu.', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxNetworkTest.php
+++ b/tests/compatibility/AjaxNetworkTest.php
@@ -1,0 +1,71 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxNetworkTest extends AjaxBase
+{
+    private $ajaxFile = 'network';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'restartDns']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRestartDNSAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'restartDns']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRestartDNSAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'restartDns']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testStopDNSAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'stopDns']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testStopDNSAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'stopDns']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxNextDomTest.php
+++ b/tests/compatibility/AjaxNextDomTest.php
@@ -1,0 +1,414 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxNextDomTest extends AjaxBase
+{
+    private $ajaxFile = 'nextdom';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'addWarnme']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetInfoApplicationWithoutAjax() {
+        $this->connectAsUser();
+        $this->resetAjaxToken();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getInfoApplication']);
+        $this->assertContains('"product_name":"NextDom"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetDocumentationUrlAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getDocumentationUrl']);
+        $this->assertContains('nextdom.github.io', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAddWarnMeAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'addWarnme']);
+        $this->assertContains('Commande non trouvée', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSshAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'ssh']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSshAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'ssh']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDbAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'db']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDbAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'db']);
+        $this->assertContains('Aucune requête à exécuter', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testHealthAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'health']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testHealthAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'health']);
+        $this->assertContains('{"state":"ok","result":[{"icon":"fa-cogs"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUpdateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'update']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUpdateAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'update']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testClearDateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'clearDate']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testClearDateAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'clearDate']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testBackupAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'backup']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testBackupAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'backup']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRestoreAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'restore']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRestoreAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'restore']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveBackupAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeBackup']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveBackupAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeBackup']);
+        $this->assertContains('Impossible de trouver le fichier', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListBackupAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'listBackup']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListBackupAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'listBackup']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetConfigurationAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getConfiguration']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetConfigurationAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getConfiguration']);
+        $this->assertContains('{"state":"ok","result":{"eqLogic":{"category"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testResetHwKeyAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'resetHwKey']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testResetHwKeyAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'resetHwKey']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testResetHourAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'resetHour']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testResetHourAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'resetHour']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testBackupUploadAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'backupupload']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testBackupUploadAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'backupupload']);
+        $this->assertContains('Aucun fichier trouvé', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+    public function testHaltSystemAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'haltSystem']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRebootSystemAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'rebootSystem']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testForceSyncHourAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'forceSyncHour']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testForceSyncHourAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'forceSyncHour']);
+        $this->assertContains('"result":null', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveCustomAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'saveCustom']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveCustomAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'saveCustom']);
+        $this->assertContains('La version ne peut être que desktop ou mobile', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetGraphDataAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getGraphData']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetGraphDataAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getGraphData']);
+        $this->assertContains('Aucun filtre', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetTimelineEventsAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getTimelineEvents']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetTimelineEventsAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getTimelineEvents']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveTimelineEventsAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeTimelineEvents']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveTimelineEventsAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeTimelineEvents']);
+        $this->assertContains('"result":null', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetFileFolderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getFileFolder']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetFileFolderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getFileFolder']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetFileContentAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getFileContent']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetFileContentAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getFileContent']);
+        $this->assertContains('Vous ne pouvez éditer ce type d\'extension', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetFileContentAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setFileContent']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetFileContentAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setFileContent']);
+        $this->assertContains('Vous ne pouvez éditer ce type d\'extension', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDeleteFileAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deleteFile']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDeleteFileAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deleteFile']);
+        $this->assertContains('Vous ne pouvez éditer ce type d\'extension', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCreateFileAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'createFile']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCreateFileAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'createFile']);
+        $this->assertContains('Vous ne pouvez éditer ce type d\'extension', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testEmptyRemoveHistoryAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'emptyRemoveHistory']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testEmptyRemoveHistoryAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'emptyRemoveHistory']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxNoteTest.php
+++ b/tests/compatibility/AjaxNoteTest.php
@@ -1,0 +1,99 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxNoteTest extends AjaxBase
+{
+    private $ajaxFile = 'note';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByIdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byId']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByIdAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byId']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('Le nom de la note ne peut être vide', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Note inconnue.', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxObjectTest.php
+++ b/tests/compatibility/AjaxObjectTest.php
@@ -1,0 +1,157 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxObjectTest extends AjaxBase
+{
+    private $ajaxFile = 'object';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByIdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byId']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCreateSummaryVirtualAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'createSummaryVirtual']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('"state":"ok","result":{', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove', 'id' => 1]);
+    }
+
+    public function testGetChildAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getChild']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testToHtmlAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'toHtml']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetOrderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setOrder']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetOrderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setOrder']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetSummaryHtmlAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getSummaryHtml']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveImageAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeImage']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveImageAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeImage']);
+        $this->assertContains('Vue inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadImageAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadImage']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadImageAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadImage']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+}

--- a/tests/compatibility/AjaxPlan3dTest.php
+++ b/tests/compatibility/AjaxPlan3dTest.php
@@ -1,0 +1,164 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxPlan3dTest extends AjaxBase
+{
+    private $ajaxFile = 'plan3d';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'create']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove', 'id' => 1]);
+    }
+
+    public function testPlan3dHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'plan3dHeader']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCreateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'create']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCreateAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'create']);
+        $this->assertContains('L\'identifiant du plan doit être fourni', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove', 'id' => 1]);
+    }
+
+    public function testGetAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('Aucun plan3d correspondant', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByNameAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byName']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Aucun plan3d correspondant', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemovePlan3dHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeplan3dHeader']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemovePlan3dHeaderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeplan3dHeader']);
+        $this->assertContains('Objet inconnu verifiez l\'id', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'allHeader']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetPlan3dHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getplan3dHeader']);
+        $this->assertContains('plan3d header inconnu verifiez', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSavePlan3dHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'saveplan3dHeader']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSavePlan3dHeaderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'saveplan3dHeader']);
+        $this->assertContains('Le nom du l\'objet ne peut pas être vide', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadModelAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadModel']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadModelAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadModel']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxPlanTest.php
+++ b/tests/compatibility/AjaxPlanTest.php
@@ -1,0 +1,221 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxPlanTest extends AjaxBase
+{
+    private $ajaxFile = 'plan';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove', 'id' => 1]);
+    }
+
+    public function testExecuteAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'execute']);
+        $this->assertContains('Aucun plan correspondant', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testPlanHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'planHeader']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCreateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'create']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCreateAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'create']);
+        $this->assertContains('L\'identifiant du plan doit être fourni', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove', 'id' => 1]);
+    }
+
+    public function testCopyAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copy']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCopyAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copy']);
+        $this->assertContains('Aucun plan correspondant', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove', 'id' => 1]);
+    }
+
+    public function testGetAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('Aucun plan correspondant', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Aucun plan correspondant', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemovePlanHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removePlanHeader']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemovePlanHeaderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removePlanHeader']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'allHeader']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetPlanHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getPlanHeader']);
+        $this->assertContains('lan header inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSavePlanHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'savePlanHeader']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSavePlanHeaderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'savePlanHeader']);
+        $this->assertContains('Le nom du plan ne peut pas être vide', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCopyPlanHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copyPlanHeader']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCopyPlanHeaderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copyPlanHeader']);
+        $this->assertContains('Plan header inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveImageHeaderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeImageHeader']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveImageHeaderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeImageHeader']);
+        $this->assertContains('Plan header inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadImageAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadImage']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadImageAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadImage']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadImagePlanAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadImagePlan']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadImagePlanAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadImagePlan']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxPluginTest.php
+++ b/tests/compatibility/AjaxPluginTest.php
@@ -1,0 +1,162 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxPluginTest extends AjaxBase
+{
+    private $ajaxFile = 'plugin';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getConf']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetConfAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getConf']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetConfAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getConf']);
+        $this->assertContains('Plugin introuvable', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testToggleAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'toggle']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testToggleAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'toggle']);
+        $this->assertContains('Plugin introuvable', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetDependancyInfoAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getDependancyInfo']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetDependancyInfoAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getDependancyInfo']);
+        $this->assertContains('Plugin introuvable', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDependancyInstallAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'dependancyInstall']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDependancyInstallAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'dependancyInstall']);
+        $this->assertContains('Plugin introuvable', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetDeamonInfoAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getDeamonInfo']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetDeamonInfoAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getDeamonInfo']);
+        $this->assertContains('Plugin introuvable', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDeamonStartAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deamonStart']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDeamonStartAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deamonStart']);
+        $this->assertContains('Plugin introuvable', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDeamonStopAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deamonStop']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDeamonStopAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deamonStop']);
+        $this->assertContains('Plugin introuvable', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDeamonChangeAutoModeAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deamonChangeAutoMode']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDeamonChangeAutoModeAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deamonChangeAutoMode']);
+        $this->assertContains('Plugin introuvable', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxProfilsTest.php
+++ b/tests/compatibility/AjaxProfilsTest.php
@@ -1,0 +1,57 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxProfilsTest extends AjaxBase
+{
+    private $ajaxFile = 'profils';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeImage']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveImageAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeImage']);
+        $this->assertContains('"result":false', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImageUploadAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'imageUpload']);
+        $this->assertContains('Aucun fichier trouvé. Vérifié parametre PHP', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxRepoTest.php
+++ b/tests/compatibility/AjaxRepoTest.php
@@ -1,0 +1,197 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxRepoTest extends AjaxBase
+{
+    private $ajaxFile = 'repo';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadCloud']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadCloudAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadCloud']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadCloudAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadCloud']);
+        $this->assertContains('Aucun serveur de backup defini', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRestoreCloudAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'restoreCloud']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRestoreCloudAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'restoreCloud']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSendReportBugAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'sendReportBug']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSendReportBugAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'sendReportBug']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testInstallAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'install']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testInstallAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'install']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testTestAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'test']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testTestAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'test']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetInfoAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getInfo']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetInfoAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getInfo']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByLogicalIdAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byLogicalId']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testByLogicalIdAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'byLogicalId']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetRaingAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setRating']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetRatingAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setRating']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testBackupListAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'backupList']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testBackupListAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'backupList']);
+        $this->assertContains('Le repo n\'existe pas', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxReportTest.php
+++ b/tests/compatibility/AjaxReportTest.php
@@ -1,0 +1,99 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxReportTest extends AjaxBase
+{
+    private $ajaxFile = 'report';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'list']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'list']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'list']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('"result":{"dirname":"\/var\/lib\/nextdom\/data"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeAll']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAllAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeAll']);
+        $this->assertContains('"result":null', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxScenarioTest.php
+++ b/tests/compatibility/AjaxScenarioTest.php
@@ -1,0 +1,218 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxScenarioTest extends AjaxBase
+{
+    private $ajaxFile = 'scenario';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changeState']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testChangeStateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'changeState']);
+        $this->assertContains('Scénario ID inconnu :', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testListScenarioHtmlAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'listScenarioHtml']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetOrderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setOrder']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testTestExpressionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'testExpression']);
+        $this->assertContains('"result":{"evaluate":"","result":"","correct":"nok"}}', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetTemplateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getTemplate']);
+        $this->assertContains('"result":[]}', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testConvertToTemplateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'convertToTemplate']);
+        $this->assertContains('Scénario ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveTemplateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeTemplate']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testLoadTemplateDiffAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'loadTemplateDiff']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testApplyTemplateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'applyTemplate']);
+        $this->assertContains('Scénario ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'saveAll']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAutoCompleteGroupAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'autoCompleteGroup']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAutoCompleteGroupAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'autoCompleteGroup']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testToHtmlAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'toHtml']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Scénario ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testEmptyLogAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'emptyLog']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testEmptyLogAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'emptyLog']);
+        $this->assertContains('Scénario ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCopyAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copy']);
+        $this->assertContains('401 -', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCopyAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'copy']);
+        $this->assertContains('Scénario ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('Scénario ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 -', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('Champs json invalide', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testActionToHtmlAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'actionToHtml']);
+        $this->assertContains('"result":{"html":"","template":""}}', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testTemplateUploadAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'templateupload']);
+        $this->assertContains('Aucun fichier trouvé. Vérifiez le paramètre PHP', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxUpdateTest.php
+++ b/tests/compatibility/AjaxUpdateTest.php
@@ -1,0 +1,176 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxUpdateTest extends AjaxBase
+{
+    private $ajaxFile = 'update';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'nbUpdate']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testNbUpdateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'nbUpdate']);
+        $this->assertContains('"result":"0"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('{"state":"ok","result":[{"type":"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCheckAllUpdateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'checkAllUpdate']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCheckAllUpdateAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'checkAllUpdate']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUpdateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'update']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUpdateAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'update']);
+        $this->assertContains('Aucune correspondance pour l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Aucune correspondance pour l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCheckUpdateAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'checkUpdate']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testCheckUpdateAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'checkUpdate']);
+        $this->assertContains('Aucune correspondance pour l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUpdateAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'updateAll']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUpdateAllAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'updateAll']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('Le logical ID ne peut pas être vide', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSavesAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'saves']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSavesAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'saves']);
+        $this->assertContains('Invalid json', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testPreUploadFilesAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'preUploadFile']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testPreUploadFileAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'preUploadFile']);
+        $this->assertContains('Aucun fichier trouvé', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/AjaxUserTest.php
+++ b/tests/compatibility/AjaxUserTest.php
@@ -1,0 +1,230 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once(__DIR__ . '/libs/AjaxBase.php');
+
+class AjaxUserTest extends AjaxBase
+{
+    private $ajaxFile = 'user';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deleteSession']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUseTwoFactorAuthentificationWithoutAjax() {
+        $this->resetAjaxToken();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'useTwoFactorAuthentification']);
+        $this->assertContains('"result":0', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testLoginAsWithoutAjax() {
+        $this->resetAjaxToken();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'login']);
+        $this->assertContains('Mot de passe ou nom d\'utilisateur incorrect', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetApikeyWithoutAjax() {
+        $this->resetAjaxToken();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getApikey']);
+        $this->assertContains('Mot de passe ou nom d\'utilisateur incorrect', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testValidateTwoFactorCodeAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'validateTwoFactorCode']);
+        $this->assertContains('Invalid characters in the base32 string.', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveTwoFactorCodeAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeTwoFactorCode']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveTwoFactorCodeAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeTwoFactorCode']);
+        $this->assertContains('User ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testIsConnectAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'isConnect']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRefreshAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'refresh']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testLogoutAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'logout']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('{"state":"ok","result":[{"login":"admin"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('User ID inconnu', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('{"state":"ok","result":{"login":"user"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveProfilsAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'saveProfils']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveRegisterDeviceAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeRegisterDevice']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveRegisterDeviceAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeRegisterDevice']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testDeleteSessionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'deleteSession']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testTestLdapConnectionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'testLdapConnection']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testTestLdapConnectionAsAdmin() {
+        // ldap not installed
+        $this->connectAsAdmin();
+        try {
+            $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'testLdapConnection']);
+        }
+        catch (Exception $e) {
+            $this->assertContains('500 Internal Server Error', $e->getMessage());
+        }
+    }
+
+    public function testRemoveBanIpAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeBanIp']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveBanIpAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeBanIp']);
+        $this->assertContains('"result":null', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSupportAccessAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'supportAccess']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSupportAccessAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'supportAccess']);
+        $this->assertContains('"result":null', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+}

--- a/tests/compatibility/AjaxViewTest.php
+++ b/tests/compatibility/AjaxViewTest.php
@@ -1,0 +1,162 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('libs/AjaxBase.php');
+
+class AjaxViewTest extends AjaxBase
+{
+    private $ajaxFile = 'view';
+
+    public function testWithout() {
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'nbUpdate']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testImpossibleActionAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'with-is-not-possible']);
+        $this->assertContains('"state":"error"', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'remove']);
+        $this->assertContains('Vue non trouvée. Vérifiez l\'iD', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testAllAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'all']);
+        $this->assertContains('"result":[]', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('Vue non trouvée. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'get']);
+        $this->assertContains('Vue non trouvée. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSaveAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'save']);
+        $this->assertContains('Le nom de la vue ne peut pas être vide', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetEqLogicviewZoneAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getEqLogicviewZone']);
+        $this->assertContains('Vue non trouvée. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testGetEqLogicviewZoneAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'getEqLogicviewZone']);
+        $this->assertContains('Vue non trouvée. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetEqLogicOrderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setEqLogicOrder']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetEqLogicOrderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setEqLogicOrder']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetOrderAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setOrder']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testSetOrderAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'setOrder']);
+        $this->assertContains('"result":""', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveImageAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeImage']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testRemoveImageAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'removeImage']);
+        $this->assertContains('Vue inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadImageAsUser() {
+        $this->connectAsUser();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadImage']);
+        $this->assertContains('401 - ', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testUploadImageAsAdmin() {
+        $this->connectAsAdmin();
+        $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'uploadImage']);
+        $this->assertContains('Objet inconnu. Vérifiez l\'ID', (string) $result->getBody());
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+}

--- a/tests/compatibility/libs/AjaxBase.php
+++ b/tests/compatibility/libs/AjaxBase.php
@@ -1,0 +1,96 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require('vendor/autoload.php');
+
+define('TEST_URL', 'http://127.0.0.1:8765/core/ajax/');
+define('ADMIN_ACCOUNT', 'admin');
+define('USER_ACCOUNT', 'user');
+define('PASSWORD', 'nextdom-test');
+
+class AjaxBase extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var GuzzleHttp\Client
+     */
+    private $client;
+
+    private $ajaxToken;
+
+    public function setUp()
+    {
+        $this->client = new GuzzleHttp\Client(['cookies' => true]);
+        $this->getAjaxTokenFromBody();
+    }
+
+    protected function connectAsAdmin()
+    {
+        $this->login(ADMIN_ACCOUNT, PASSWORD);
+    }
+
+    protected function connectAsUser()
+    {
+        $this->login(USER_ACCOUNT, PASSWORD);
+    }
+
+    private function login($username, $password)
+    {
+        $result = $this->getAjaxQueryResult('user', ['action' => 'login', 'username' => $username, 'password' => $password]);
+        if ($result->getBody() === '{"state":"ok","result":""}') {
+            return true;
+        }
+        return false;
+    }
+
+    protected function getAjaxQueryResult($ajaxFile, $params)
+    {
+        return $this->getUrlResult(TEST_URL . $ajaxFile . '.ajax.php?' . http_build_query($params));
+
+    }
+
+    protected function getAjaxQueryWithTokenResult($ajaxFile, $params)
+    {
+        $params = array_merge($params, ['nextdom_token' => $this->ajaxToken]);
+        return $this->getUrlResult(TEST_URL . $ajaxFile . '.ajax.php?' . http_build_query($params));
+    }
+
+    private function getUrlResult($url)
+    {
+        $res = '';
+        try {
+
+            $res = $this->client->request('GET', $url);
+        } catch (GuzzleHttp\Exception\ClientException $e) {
+            $res = $e->getResponse();
+        }
+        return $res;
+    }
+
+    private function getAjaxTokenFromBody()
+    {
+        $res = $this->client->request('GET', 'http://127.0.0.1:8765/');
+        preg_match('/NEXTDOM_AJAX_TOKEN = \'(.*?)\'/', $res->getBody(), $matchResult);
+        if (count($matchResult) > 1) {
+            $this->ajaxToken = $matchResult[1];
+        }
+    }
+
+    protected function resetAjaxToken()
+    {
+        $this->ajaxToken = '';
+    }
+}

--- a/tests/compatibility/phpunit.xml
+++ b/tests/compatibility/phpunit.xml
@@ -1,0 +1,48 @@
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
+        backupGlobals="true"
+        backupStaticAttributes="false"
+        bootstrap="../../vendor/autoload.php"
+        cacheTokens="false"
+        colors="false"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        forceCoversAnnotation="false"
+        printerClass="PHPUnit_TextUI_ResultPrinter"
+        processIsolation="true"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        stopOnRisky="false"
+        stderr="true"
+        testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
+        timeoutForSmallTests="1"
+        timeoutForMediumTests="10"
+        timeoutForLargeTests="60"
+        verbose="false">
+    <testsuites>
+        <testsuite name="AllTests">
+            <directory>../compatibility</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../../</directory>
+            <exclude>
+                <directory>../../vendor</directory>
+                <directory>../../assets</directory>
+                <directory>../../install</directory>
+                <directory>../../scripts</directory>
+                <directory>../../var</directory>
+                <directory>../../tests/archives</directory>
+                <directory>../../tests/data</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-php" target="../coverage/clover-compatibility.cov"/>
+    </logging>
+</phpunit>

--- a/tests/launch_code_consistency.py
+++ b/tests/launch_code_consistency.py
@@ -1,5 +1,6 @@
 """Launch NextDom code consistency tests
 """
+import sys
 from tests.libs.tests_funcs import *
 
 def check_php():
@@ -7,11 +8,14 @@ def check_php():
     """
     print_subtitle('PHP syntax')
     output, status = get_command_output('find . -type f -name "*.php" -not -path "./vendor/*" | xargs -n1 php -l') #pylint: disable=line-too-long
+    error = False
     if status == 0:
         print_info('OK')
     else:
         print_error('Fail')
         print(output)
+        error = True
+    return error
 
 def check_python():
     """Check python code quality
@@ -27,8 +31,13 @@ def check_python():
             error = True
     if not error:
         print_info('OK')
+    return error
 
 if __name__ == "__main__":
     print_title('Code consistency')
-    check_php()
-    check_python()
+    TESTS_LIST = {
+        'php': check_php,
+        'python': check_python
+    }
+    if not start_all_tests('Code consistency', TESTS_LIST):
+        sys.exit(1)

--- a/tests/launch_compatibility_tests.py
+++ b/tests/launch_compatibility_tests.py
@@ -1,0 +1,33 @@
+"""Launch NextDom GUI tests
+"""
+import sys
+from tests.libs.tests_funcs import *
+
+NEXTDOM_URL = 'http://127.0.0.1:8765'
+NEXTDOM_LOGIN = 'admin'
+NEXTDOM_PASSWORD = 'nextdom-test'
+
+def ajax_tests():
+    """Starts gui tests related to the Custom JS and CSS page
+    """
+    container_name = 'compatibility'
+    print_subtitle('Ajax')
+    start_test_container(container_name, NEXTDOM_PASSWORD)
+    # Create standard user
+    exec_command_in_container(container_name, '/usr/bin/mysql -u root nextdomdev -e "INSERT INTO \\`user\\` VALUES (NULL, \'user\', \'user\', SHA2(\'nextdom-test\', 512), \'{\\\"localOnly\\\":\\\"0\\\",\\\"lastConnection\\\":\\\"\\\"}\', \'VD5OOmHSVT3VFYjng4XEaZF5wAI9jEi8\', \'[]\', 1)"') #pylint: disable=line-too-long
+    ret_code = os.system('cd .. && ./vendor/bin/phpunit --configuration tests/compatibility/phpunit.xml --testsuite AllTests') #pylint: disable=line-too-long
+    remove_test_container(container_name)
+    if ret_code != 0:
+        return True
+    return False
+
+if __name__ == "__main__":
+    TESTS_LIST = {
+        'ajax': ajax_tests
+    }
+    init_docker()
+    if len(sys.argv) == 1:
+        if not start_all_tests('Compatibility Tests', TESTS_LIST):
+            sys.exit(1)
+    else:
+        start_specific_test(sys.argv[1], TESTS_LIST)

--- a/tests/launch_php_tests.py
+++ b/tests/launch_php_tests.py
@@ -1,0 +1,18 @@
+"""Launch NextDom GUI tests
+"""
+import sys
+from tests.libs.tests_funcs import *
+
+def php_tests():
+    """Starts gui tests related to the Custom JS and CSS page
+    """
+    os.system('cd .. && ./vendor/bin/phpunit --configuration tests/phpunit_tests/phpunit.xml --testsuite AllTests') #pylint: disable=line-too-long
+
+if __name__ == "__main__":
+    TESTS_LIST = {
+        'php': php_tests
+    }
+    if len(sys.argv) == 1:
+        start_all_tests('PHPUnit Tests', TESTS_LIST, False)
+    else:
+        start_specific_test(sys.argv[1], TESTS_LIST)

--- a/tests/phpunit_tests/NextDomHelperTest.php
+++ b/tests/phpunit_tests/NextDomHelperTest.php
@@ -26,12 +26,8 @@ class NextDomHelperTest extends PHPUnit_Framework_TestCase
 {
     public static function setUpBeforeClass()
     {
-        mkdir(NEXTDOM_DATA . '/data', 0777, true);
-    }
-
-    public static function tearDownAfterClass()
-    {
         system('rm -fr ' . NEXTDOM_DATA . '/data');
+        mkdir(NEXTDOM_DATA . '/data', 0777, true);
     }
 
     public function setUp()

--- a/tests/phpunit_tests/bootstrap.php
+++ b/tests/phpunit_tests/bootstrap.php
@@ -1,3 +1,0 @@
-a<?php
-echo "Test de NextDom\n";
-?>

--- a/tests/phpunit_tests/phpunit.xml
+++ b/tests/phpunit_tests/phpunit.xml
@@ -1,0 +1,48 @@
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
+        backupGlobals="true"
+        backupStaticAttributes="false"
+        bootstrap="../../vendor/autoload.php"
+        cacheTokens="false"
+        colors="false"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        forceCoversAnnotation="false"
+        printerClass="PHPUnit_TextUI_ResultPrinter"
+        processIsolation="true"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        stopOnRisky="false"
+        stderr="true"
+        testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
+        timeoutForSmallTests="1"
+        timeoutForMediumTests="10"
+        timeoutForLargeTests="60"
+        verbose="false">
+    <testsuites>
+        <testsuite name="AllTests">
+            <directory>../phpunit_tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../../</directory>
+            <exclude>
+                <directory>../../vendor</directory>
+                <directory>../../assets</directory>
+                <directory>../../install</directory>
+                <directory>../../scripts</directory>
+                <directory>../../var</directory>
+                <directory>../../tests/archives</directory>
+                <directory>../../tests/data</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-php" target="../coverage/clover-php.cov"/>
+    </logging>
+</phpunit>

--- a/tests/tests/libs/tests_funcs.py
+++ b/tests/tests/libs/tests_funcs.py
@@ -112,7 +112,7 @@ def init_docker():
             create_docker()
         else:
             reset_answer = ask_y_n('Reset base test container', 'n')
-            if reset_answer == '-y':
+            if reset_answer == 'y':
                 create_docker()
         clear_docker()
 
@@ -157,17 +157,25 @@ def copy_file_in_container(container_name, src, dest):
     """
     os.system('docker cp ' + src + ' nextdom-test-' + container_name + ':' + dest)
 
-def start_all_tests(title, tests_list):
+def start_all_tests(title, tests_list, use_docker=True):
     """Start all tests
     :param title:      Title of the type of tests
     :param tests_list: List of all tests
+    :param use_docker: True if docker is used during tests
     :type title:       str
     :type tests_list:  dict
+    :type use_docker:  bool
+    :return:           True if all tests pass
+    :rtype:            bool
     """
-    clear_docker()
+    if use_docker:
+        clear_docker()
     print_title(title)
+    all_tests_pass = True
     for test in tests_list:
-        tests_list[test]()
+        if tests_list[test]():
+            all_tests_pass = False
+    return all_tests_pass
 
 def start_specific_test(test_name, tests_list):
     """Start specific test choosed by the user


### PR DESCRIPTION
- Ajout des tests Ajax. Ces tests portent une attention sur les droits d'accès principalement et non sur le fonctionnement
- Ajout d'un test de compatibilité avec la version stable de Jeedom. 
- Corrections d'erreurs 500
- Intégration de coverall
- Séparation des tests unitaires
- Ajout de quelques méthodes manquantes

Travis est en erreur à cause du test de compatibilité (prochain chantier)