### PR TITLE
Correction syntaxe des liens README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Website (English): [https://www.nextdom.org/en/](https://www.nextdom.org/en/)
 
 Website (French):  [https://www.nextdom.org/](https://www.nextdom.org/)
 
-Forum : [https://www.nextdom.org/forum/](ici).
+Forum : [https://www.nextdom.org/forum/](https://www.nextdom.org/forum/).
 
 # Installation #
 
-Procédure : [https://www.nextdom.org/elementor-230/installation-de-nextdom/](ici).
+Procédure : [https://www.nextdom.org/elementor-230/installation-de-nextdom/](https://www.nextdom.org/elementor-230/installation-de-nextdom/).
 
 <img src="https://www.nextdom.org/wp-content/uploads/2018/12/Install3.png">
 
 # Téléchargement des releases
 
-Github : [https://github.com/NextDom/nextdom-core/releases](ici).
+Github : [https://github.com/NextDom/nextdom-core/releases](https://github.com/NextDom/nextdom-core/releases).


### PR DESCRIPTION
Le markup GItHub est [texte affiché](URL). Du coup, tous les liens du type
 Forum : [https://www.nextdom.org/forum/](ici) faisaient une erreur 404.