### PR TITLE
Docker dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+PROJECT_PATH = .
+DC = docker-compose
+DC_RUN = $(DC) run --rm
+COMPOSER = $(DC_RUN) composer
+
+vendor: composer.lock
+	@$(COMPOSER) install
+
+clean: ${PROJECT_PATH}
+	@rm -rf ${PROJECT_PATH}/vendor && \
+	$(DC) down -v --remove-orphans
+
+install: clean vendor ## Clean, pull containers, run composer install and npm install
+	notify-send "Make install completed"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  composer:
+    user: 1000:1000
+    image: composer:1.8
+    volumes:
+      - .:/app
+      - $HOME/.composer:/tmp


### PR DESCRIPTION
Un début pour faciliter l'install du projet. 
L'idée est de n'avoir que docker sur un pc pour contribuer.
Evite les conflits entre les différentes versions de composer/php que les gens peuvent avoir en local.