### PR TITLE
Fix de la gestion des évènements des plugins

### DIFF
--- a/src/Controller/Pages/FirstUseController.php
+++ b/src/Controller/Pages/FirstUseController.php
@@ -70,7 +70,8 @@ class FirstUseController extends BaseController
             'notify_status' => $configs['notify::status'],
             'notify_position' => $configs['notify::position'],
             'notify_timeout' => $configs['notify::timeout'],
-            'serverTZoffsetMin' => Utils::getTZoffsetMin()
+            'serverTZoffsetMin' => Utils::getTZoffsetMin(),
+            'serverDatetime' => Utils::getMicrotime()
         ];
         $pageData['CSS_POOL'][] = '/public/css/nextdom.css';
         $pageData['CSS_POOL'][] = '/public/css/pages/firstUse.css';

--- a/src/Helpers/PrepareView.php
+++ b/src/Helpers/PrepareView.php
@@ -39,6 +39,8 @@ class PrepareView
 {
     private static $NB_THEME_COLORS = 1+23;
 
+    private $currentConfig = [];
+
     /**
      * Read configuration
      * @throws \Exception
@@ -90,6 +92,7 @@ class PrepareView
     {
         $pageData = [];
         $this->initHeaderData($pageData);
+        $pageData['JS_VARS_RAW']['serverDatetime'] = Utils::getMicrotime();
         echo $this->getContentFromRoute('pages_routes.yml', $pageCode, $pageData);
     }
 
@@ -476,10 +479,11 @@ class PrepareView
             'widget_size' => $this->currentConfig['widget::size'],
             'widget_margin' => $this->currentConfig['widget::margin'],
             'widget_padding' => $this->currentConfig['widget::padding'],
-            'widget_radius' => $this->currentConfig['widget::radius'],
+            'widget_radius' => $this->currentConfig['widget::radius']
         ];
         $pageData['JS_VARS_RAW'] = [
             'userProfils' => Utils::getArrayToJQueryJson(UserManager::getStoredUser()->getOptions()),
+            'serverDatetime' => Utils::getMicrotime()
         ];
 
         $this->initMenu($pageData, $currentPlugin);
@@ -570,6 +574,7 @@ class PrepareView
 
                 $pageData['MENU_PLUGIN_CATEGORY'][$categoryCode]['name'] = Render::getInstance()->getTranslation($name);
                 $pageData['MENU_PLUGIN_CATEGORY'][$categoryCode]['icon'] = $icon;
+
                 /** @var Plugin $plugin */
                 foreach ($pluginsList as $plugin) {
                     $pageData['MENU_PLUGIN'][$categoryCode][] = $plugin;
@@ -581,7 +586,7 @@ class PrepareView
                         $pageData['PANEL_MENU'][] = $plugin;
                     }
                     if ($plugin->getEventjs() == 1) {
-                        $eventJsPlugin[] = $plugin->getId();
+                        $eventsJsPlugin[] = $plugin->getId();
                     }
                 }
             }
@@ -599,11 +604,11 @@ class PrepareView
     private function initPluginsEvents($eventsJsPlugin, &$pageData)
     {
         if (count($eventsJsPlugin) > 0) {
-            foreach ($eventsJsPlugin as $value) {
-                try {
-                    $pageData['JS_POOL'][] = '/plugins/' . $value . '/public/js/desktop/events.js';
-                } catch (\Exception $e) {
-                    LogHelper::add($value, 'error', 'Event JS file not found');
+            $pageData['PLUGINS_JS_POOL'] = [];
+            foreach ($eventsJsPlugin as $pluginId) {
+                $eventJsFile = '/plugins/' . $pluginId . '/desktop/js/event.js';
+                if (file_exists(NEXTDOM_ROOT . $eventJsFile)) {
+                    $pageData['PLUGINS_JS_POOL'][] = $eventJsFile;
                 }
             }
         }
@@ -698,15 +703,16 @@ class PrepareView
         $this->initHeaderData($pageData);
         $render = Render::getInstance();
         $pageData['CSS'] = $render->getCssHtmlTag('/public/css/nextdom.css');
-        $pageData['varToJs'] = Utils::getVarsToJS([
+        $pageData['JS_VARS'] = [
             'userProfils' => UserManager::getStoredUser()->getOptions(),
             'user_id' => UserManager::getStoredUser()->getId(),
             'user_isAdmin' => AuthentificationHelper::isConnectedAsAdmin(),
             'user_login' => UserManager::getStoredUser()->getLogin(),
-            'serverTZoffsetMin' => Utils::getTZoffsetMin(),
-        ]);
+            'serverTZoffsetMin' => Utils::getTZoffsetMin()];
+        $pageData['JS_VARS_RAW'] = [
+            'serverDatetime' => Utils::getMicrotime()
+        ];
         $pageData['JS'] = '';
-
         $pageData['MENU'] = $render->get('commons/menu_rescue.html.twig');
 
         if (!NextDomHelper::isStarted()) {

--- a/tests/tests/administrations_page.py
+++ b/tests/tests/administrations_page.py
@@ -98,7 +98,6 @@ class AdministrationPages(BaseGuiTest):
         back_button = self.get_link_by_title('Retour')
         self.assertIsNotNone(clean_cache_button)
         self.assertIsNotNone(back_button)
-        print(str(self.get_js_logs()))
         self.assertEqual(0, len(self.get_js_logs()))
         back_button.click()
 

--- a/views/commons/footer.html.twig
+++ b/views/commons/footer.html.twig
@@ -38,7 +38,6 @@
     var clientDatetime = new Date();
     var clientServerDiff = {{ date().timestamp }} * 1000;
     var clientServerDiffDatetime = clientServerDiff - clientDatetime.getTime();
-    var serverDatetime = {{ date().timestamp }};
     var io = null;
     NEXTDOM_PRODUCT_NAME='{{ PRODUCT_NAME }}';
     NEXTDOM_AJAX_TOKEN = '{{ AJAX_TOKEN }}';

--- a/views/layouts/base_dashboard.html.twig
+++ b/views/layouts/base_dashboard.html.twig
@@ -13,6 +13,11 @@
         <div class="fabs fab-left">
             <a class="fab-action-button cursor animationShakeDelay" style="display: none;" id="bt_goOnTop"><i class="fab-action-button__icon fas fa-angle-double-up"></i></a>
         </div>
+        {% if PLUGINS_JS_POOL is defined %}
+            {% for jsFile in PLUGINS_JS_POOL %}
+                <script src="{{ jsFile }}"></script>
+            {% endfor %}
+        {% endif %}
         {% if JS_END_POOL is defined %}
             {% for jsFile in JS_END_POOL %}
                 <script src="{{ jsFile }}"></script>


### PR DESCRIPTION
Pour tester cette PR, il faut vérifier que lorsqu'un évènement se déclenche sur le dashboard (une lumière a été allumé, une chose a changée d'état), le changement visuel s'effectue bien.
Ceci peut avoir d'autres influences que les plugins.

https://github.com/NextDom/nextdom-core/issues/1155
