### PR TITLE
Pages rename & Admin page button tests

### DIFF
--- a/assets/js/desktop/admin/services.js
+++ b/assets/js/desktop/admin/services.js
@@ -43,12 +43,12 @@ initEvents();
  */
 function loadInformations() {
     nextdom.config.load({
-        configuration: $('#update_admin').getValues('.configKey:not(.noSet)')[0],
+        configuration: $('#services').getValues('.configKey:not(.noSet)')[0],
         error: function (error) {
             notify("Erreur", error.message, 'error');
         },
         success: function (data) {
-            $('#update_admin').setValues(data, '.configKey');
+            $('#services').setValues(data, '.configKey');
             modifyWithoutSave = false;
             $(".bt_cancelModifs").hide();
         }
@@ -60,7 +60,7 @@ function loadInformations() {
  */
 function initEvents() {
     // Param changed : page leaving lock by msgbox
-    $('#update_admin').delegate('.configKey', 'change', function () {
+    $('#services').delegate('.configKey', 'change', function () {
         if (!lockModify) {
             modifyWithoutSave = true;
             $(".bt_cancelModifs").show();
@@ -73,8 +73,8 @@ function initEvents() {
     });
 
     // Save button
-    $("#bt_saveupdate_admin").on('click', function (event) {
-        var config = $('#update_admin').getValues('.configKey')[0];
+    $("#bt_saveservices").on('click', function (event) {
+        var config = $('#services').getValues('.configKey')[0];
         config.actionOnMessage = json_encode($('#div_actionOnMessage .actionOnMessage').getValues('.expressionAttr'));
         nextdom.config.save({
             configuration: config,
@@ -83,12 +83,12 @@ function initEvents() {
             },
             success: function () {
                 nextdom.config.load({
-                    configuration: $('#update_admin').getValues('.configKey:not(.noSet)')[0],
+                    configuration: $('#services').getValues('.configKey:not(.noSet)')[0],
                     error: function (error) {
                         notify("Erreur", error.message, 'error');
                     },
                     success: function (data) {
-                        $('#update_admin').setValues(data, '.configKey');
+                        $('#services').setValues(data, '.configKey');
                         modifyWithoutSave = false;
                         $(".bt_cancelModifs").hide();
                         notify("Info", '{{Sauvegarde réussie}}', 'success');
@@ -102,18 +102,18 @@ function initEvents() {
     $('.testRepoConnection').on('click',function(){
         var repo = $(this).attr('data-repo');
         nextdom.config.save({
-            configuration: $('#update_admin').getValues('.configKey')[0],
+            configuration: $('#services').getValues('.configKey')[0],
             error: function (error) {
                 notify("Erreur", error.message, 'error');
             },
             success: function () {
                 nextdom.config.load({
-                    configuration: $('#update_admin').getValues('.configKey:not(.noSet)')[0],
+                    configuration: $('#services').getValues('.configKey:not(.noSet)')[0],
                     error: function (error) {
                         notify("Erreur", error.message, 'error');
                     },
                     success: function (data) {
-                        $('#update_admin').setValues(data, '.configKey');
+                        $('#services').setValues(data, '.configKey');
                         modifyWithoutSave = false;
                         nextdom.repo.test({
                             repo: repo,
@@ -131,7 +131,7 @@ function initEvents() {
     });
 
     // Repo activation/desactivation
-    $('#update_admin').delegate('.enableRepository', 'change', function () {
+    $('#services').delegate('.enableRepository', 'change', function () {
         if($(this).value() == 1){
             $('.repositoryConfiguration'+$(this).attr('data-repo')).show();
         }else{

--- a/assets/js/desktop/params/interact_config.js
+++ b/assets/js/desktop/params/interact_config.js
@@ -45,12 +45,12 @@ initEvents();
  */
 function loadInformations() {
     nextdom.config.load({
-        configuration: $('#interact_admin').getValues('.configKey:not(.noSet)')[0],
+        configuration: $('#interact_config').getValues('.configKey:not(.noSet)')[0],
         error: function (error) {
             notify("Erreur", error.message, 'error');
         },
         success: function (data) {
-            $('#interact_admin').setValues(data, '.configKey');
+            $('#interact_config').setValues(data, '.configKey');
             modifyWithoutSave = false;
             $(".bt_cancelModifs").hide();
         }
@@ -62,7 +62,7 @@ function loadInformations() {
  */
 function initEvents() {
     // Param changed : page leaving lock by msgbox
-    $('#interact_admin').delegate('.configKey', 'change', function () {
+    $('#interact_config').delegate('.configKey', 'change', function () {
         if (!lockModify) {
             modifyWithoutSave = true;
             $(".bt_cancelModifs").show();
@@ -75,22 +75,22 @@ function initEvents() {
     });
 
     // Save button
-    $('#bt_saveinteract_admin').on('click', function (event) {
+    $('#bt_saveinteract_config').on('click', function (event) {
         saveConvertColor();
         nextdom.config.save({
-            configuration: $('#interact_admin').getValues('.configKey')[0],
+            configuration: $('#interact_config').getValues('.configKey')[0],
             error: function (error) {
                 notify("Erreur", error.message, 'error');
             },
             success: function () {
                 nextdom.config.load({
-                    configuration: $('#interact_admin').getValues('.configKey')[0],
+                    configuration: $('#interact_config').getValues('.configKey')[0],
                     plugin: 'core',
                     error: function (error) {
                         notify("Erreur", error.message, 'error');
                     },
                     success: function (data) {
-                        $('#interact_admin').setValues(data, '.configKey');
+                        $('#interact_config').setValues(data, '.configKey');
                         modifyWithoutSave = false;
                         $(".bt_cancelModifs").hide();
                         notify("Info", '{{Sauvegarde réussie}}', 'success');

--- a/assets/js/desktop/params/log_config.js
+++ b/assets/js/desktop/params/log_config.js
@@ -43,12 +43,12 @@ initEvents();
  */
 function loadInformations() {
     nextdom.config.load({
-        configuration: $('#log_admin').getValues('.configKey:not(.noSet)')[0],
+        configuration: $('#log_config').getValues('.configKey:not(.noSet)')[0],
         error: function (error) {
             notify("Erreur", error.message, 'error');
         },
         success: function (data) {
-            $('#log_admin').setValues(data, '.configKey');
+            $('#log_config').setValues(data, '.configKey');
             loadActionOnMessage();
             modifyWithoutSave = false;
             $(".bt_cancelModifs").hide();
@@ -61,7 +61,7 @@ function loadInformations() {
  */
 function initEvents() {
     // Param changed : page leaving lock by msgbox
-    $('#log_admin').delegate('.configKey', 'change', function () {
+    $('#log_config').delegate('.configKey', 'change', function () {
         if (!lockModify) {
             modifyWithoutSave = true;
             $(".bt_cancelModifs").show();
@@ -74,8 +74,8 @@ function initEvents() {
     });
 
     // Save button
-    $("#bt_savelog_admin").on('click', function (event) {
-        var config = $('#log_admin').getValues('.configKey')[0];
+    $("#bt_savelog_config").on('click', function (event) {
+        var config = $('#log_config').getValues('.configKey')[0];
         config.actionOnMessage = json_encode($('#div_actionOnMessage .actionOnMessage').getValues('.expressionAttr'));
         nextdom.config.save({
             configuration: config,
@@ -84,13 +84,13 @@ function initEvents() {
             },
             success: function () {
                 nextdom.config.load({
-                    configuration: $('#log_admin').getValues('.configKey')[0],
+                    configuration: $('#log_config').getValues('.configKey')[0],
                     plugin: 'core',
                     error: function (error) {
                         notify("Erreur", error.message, 'error');
                     },
                     success: function (data) {
-                        $('#log_admin').setValues(data, '.configKey');
+                        $('#log_config').setValues(data, '.configKey');
                         modifyWithoutSave = false;
                         $(".bt_cancelModifs").hide();
                         notify("Info", '{{Sauvegarde réussie}}', 'success');
@@ -101,7 +101,7 @@ function initEvents() {
     });
 
     // Log engine change
-    $('#log_admin').delegate('.configKey[data-l1key="log::engine"]', 'change', function () {
+    $('#log_config').delegate('.configKey[data-l1key="log::engine"]', 'change', function () {
         $('.logEngine').hide();
         $('.logEngine.'+$(this).value()).show();
         modifyWithoutSave = true;

--- a/assets/js/desktop/params/report_config.js
+++ b/assets/js/desktop/params/report_config.js
@@ -43,12 +43,12 @@ initEvents();
  */
 function loadInformations() {
     nextdom.config.load({
-        configuration: $('#reports_admin').getValues('.configKey:not(.noSet)')[0],
+        configuration: $('#report_config').getValues('.configKey:not(.noSet)')[0],
         error: function (error) {
             notify("Erreur", error.message, 'error');
         },
         success: function (data) {
-            $('#reports_admin').setValues(data, '.configKey');
+            $('#report_config').setValues(data, '.configKey');
             modifyWithoutSave = false;
             $(".bt_cancelModifs").hide();
         }
@@ -60,7 +60,7 @@ function loadInformations() {
  */
 function initEvents() {
     // Param changed : page leaving lock by msgbox
-    $('#reports_admin').delegate('.configKey', 'change', function () {
+    $('#report_config').delegate('.configKey', 'change', function () {
         if (!lockModify) {
             modifyWithoutSave = true;
             $(".bt_cancelModifs").show();
@@ -73,21 +73,21 @@ function initEvents() {
     });
 
     // Save button
-    $("#bt_savereports_admin").on('click', function (event) {
+    $("#bt_savereport_config").on('click', function (event) {
       nextdom.config.save({
-          configuration: $('#reports_admin').getValues('.configKey')[0],
+          configuration: $('#report_config').getValues('.configKey')[0],
           error: function (error) {
               notify("Erreur", error.message, 'error');
           },
           success: function () {
               nextdom.config.load({
-                  configuration: $('#reports_admin').getValues('.configKey')[0],
+                  configuration: $('#report_config').getValues('.configKey')[0],
                   plugin: 'core',
                   error: function (error) {
                       notify("Erreur", error.message, 'error');
                   },
                   success: function (data) {
-                      $('#reports_admin').setValues(data, '.configKey');
+                      $('#report_config').setValues(data, '.configKey');
                       modifyWithoutSave = false;
                       notify("Info", '{{Sauvegarde réussie}}', 'success');
                   }

--- a/src/Controller/Admin/ServicesController.php
+++ b/src/Controller/Admin/ServicesController.php
@@ -20,46 +20,42 @@
  * @Authors/Contributors: Sylvaner, Byackee, cyrilphoenix71, ColonelMoutarde, edgd1er, slobberbone, Astral0, DanoneKiD
  */
 
-namespace NextDom\Controller\Params;
+namespace NextDom\Controller\Admin;
 
 use NextDom\Controller\BaseController;
 use NextDom\Helpers\AuthentificationHelper;
+use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Render;
+use NextDom\Managers\CacheManager;
 use NextDom\Managers\ConfigManager;
 use NextDom\Managers\PluginManager;
+use NextDom\Managers\UpdateManager;
+use NextDom\Managers\UserManager;
 
 /**
- * Class LogAdminController
- * @package NextDom\Controller\Params
+ * Class ServicesController
+ * @package NextDom\Controller\Admin
  */
-class LogAdminController extends BaseController
+class ServicesController extends BaseController
 {
-    /**
-     * Render logAdmin page
+    /** Render Services page
      *
      * @param array $pageData Page data
      *
-     * @return string Content of log_admin page
+     * @return string Content of update_admin page
      *
      * @throws \Exception
      */
     public static function get(&$pageData): string
     {
-
-        global $NEXTDOM_INTERNAL_CONFIG;
-        $pageData['adminAlerts'] = $NEXTDOM_INTERNAL_CONFIG['alerts'];
-        $pageData['adminOthersLogs'] = array('scenario', 'plugin', 'market', 'api', 'connection', 'interact', 'tts', 'report', 'event');
-        $pageData['adminPluginsList'] = [];
-        $pluginsList = PluginManager::listPlugin(true);
-        foreach ($pluginsList as $plugin) {
-            $pluginApi = ConfigManager::byKey('api', $plugin->getId());
-            $pluginData = [];
-            $pluginData['api'] = $pluginApi;
-            $pluginData['plugin'] = $plugin;
-            $pageData['adminPluginsList'][] = $pluginData;
+        $pageData['adminReposList'] = UpdateManager::listRepo();
+        $keys = array('market::allowDNS', 'ldap::enable');
+        foreach ($pageData['adminReposList'] as $key => $value) {
+            $keys[] = $key . '::enable';
         }
-        $pageData['JS_END_POOL'][] = '/public/js/desktop/params/log_admin.js';
+        $pageData['adminConfigs'] = ConfigManager::byKeys($keys);
+        $pageData['JS_END_POOL'][] = '/public/js/desktop/admin/services.js';
 
-        return Render::getInstance()->get('/desktop/params/log_admin.html.twig', $pageData);
+        return Render::getInstance()->get('/desktop/admin/services.html.twig', $pageData);
     }
 }

--- a/src/Controller/Admin/ServicesController.php
+++ b/src/Controller/Admin/ServicesController.php
@@ -42,7 +42,7 @@ class ServicesController extends BaseController
      *
      * @param array $pageData Page data
      *
-     * @return string Content of update_admin page
+     * @return string Content of services page
      *
      * @throws \Exception
      */

--- a/src/Controller/Diagnostic/LogController.php
+++ b/src/Controller/Diagnostic/LogController.php
@@ -81,7 +81,7 @@ class LogController extends BaseController
 
         $pageData['JS_END_POOL'][] = '/public/js/desktop/diagnostic/log.js';
 
-        return Render::getInstance()->get('/desktop/diagnostic/logs-view.html.twig', $pageData);
+        return Render::getInstance()->get('/desktop/diagnostic/log.html.twig', $pageData);
     }
 
 

--- a/src/Controller/Diagnostic/RealtimeController.php
+++ b/src/Controller/Diagnostic/RealtimeController.php
@@ -37,7 +37,7 @@ class RealtimeController extends BaseController
      *
      * @param array $pageData Page data
      *
-     * @return string Content of log_admin page
+     * @return string Content of realtime page
      *
      */
     public static function get(&$pageData): string

--- a/src/Controller/Diagnostic/ReportController.php
+++ b/src/Controller/Diagnostic/ReportController.php
@@ -81,6 +81,6 @@ class ReportController extends BaseController
             }
         }
 
-        return Render::getInstance()->get('/desktop/diagnostic/reports-view.html.twig', $pageData);
+        return Render::getInstance()->get('/desktop/diagnostic/report.html.twig', $pageData);
     }
 }

--- a/src/Controller/Params/InteractConfigController.php
+++ b/src/Controller/Params/InteractConfigController.php
@@ -36,7 +36,7 @@ class InteractConfigController extends BaseController
      *
      * @param array $pageData Page data
      *
-     * @return string Content of interact_admin page
+     * @return string Content of interaction config page
      *
      */
     public static function get(&$pageData): string

--- a/src/Controller/Params/InteractConfigController.php
+++ b/src/Controller/Params/InteractConfigController.php
@@ -20,42 +20,31 @@
  * @Authors/Contributors: Sylvaner, Byackee, cyrilphoenix71, ColonelMoutarde, edgd1er, slobberbone, Astral0, DanoneKiD
  */
 
-namespace NextDom\Controller\Admin;
+namespace NextDom\Controller\Params;
 
 use NextDom\Controller\BaseController;
-use NextDom\Helpers\AuthentificationHelper;
-use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Render;
-use NextDom\Managers\CacheManager;
-use NextDom\Managers\ConfigManager;
-use NextDom\Managers\PluginManager;
-use NextDom\Managers\UpdateManager;
-use NextDom\Managers\UserManager;
 
 /**
- * Class UpdateAdminController
- * @package NextDom\Controller\Admin
+ * Class InteractConfigController
+ * @package NextDom\Controller\Params
  */
-class UpdateAdminController extends BaseController
+class InteractConfigController extends BaseController
 {
-    /** Render updateAdmin page
+    /**
+     * Render InteractConfig page
      *
      * @param array $pageData Page data
      *
-     * @return string Content of update_admin page
+     * @return string Content of interact_admin page
      *
-     * @throws \Exception
      */
     public static function get(&$pageData): string
     {
-        $pageData['adminReposList'] = UpdateManager::listRepo();
-        $keys = array('market::allowDNS', 'ldap::enable');
-        foreach ($pageData['adminReposList'] as $key => $value) {
-            $keys[] = $key . '::enable';
-        }
-        $pageData['adminConfigs'] = ConfigManager::byKeys($keys);
-        $pageData['JS_END_POOL'][] = '/public/js/desktop/admin/update_admin.js';
 
-        return Render::getInstance()->get('/desktop/admin/update_admin.html.twig', $pageData);
+        $pageData['JS_END_POOL'][] = '/public/js/desktop/params/interact_config.js';
+
+        return Render::getInstance()->get('/desktop/params/interact_config.html.twig', $pageData);
     }
+
 }

--- a/src/Controller/Params/LogConfigController.php
+++ b/src/Controller/Params/LogConfigController.php
@@ -23,28 +23,43 @@
 namespace NextDom\Controller\Params;
 
 use NextDom\Controller\BaseController;
+use NextDom\Helpers\AuthentificationHelper;
 use NextDom\Helpers\Render;
+use NextDom\Managers\ConfigManager;
+use NextDom\Managers\PluginManager;
 
 /**
- * Class InteractAdminController
+ * Class LogConfigController
  * @package NextDom\Controller\Params
  */
-class InteractAdminController extends BaseController
+class LogConfigController extends BaseController
 {
     /**
-     * Render interactAdmin page
+     * Render logConfig page
      *
      * @param array $pageData Page data
      *
-     * @return string Content of interact_admin page
+     * @return string Content of log_admin page
      *
+     * @throws \Exception
      */
     public static function get(&$pageData): string
     {
 
-        $pageData['JS_END_POOL'][] = '/public/js/desktop/params/interact_admin.js';
+        global $NEXTDOM_INTERNAL_CONFIG;
+        $pageData['adminAlerts'] = $NEXTDOM_INTERNAL_CONFIG['alerts'];
+        $pageData['adminOthersLogs'] = array('scenario', 'plugin', 'market', 'api', 'connection', 'interact', 'tts', 'report', 'event');
+        $pageData['adminPluginsList'] = [];
+        $pluginsList = PluginManager::listPlugin(true);
+        foreach ($pluginsList as $plugin) {
+            $pluginApi = ConfigManager::byKey('api', $plugin->getId());
+            $pluginData = [];
+            $pluginData['api'] = $pluginApi;
+            $pluginData['plugin'] = $plugin;
+            $pageData['adminPluginsList'][] = $pluginData;
+        }
+        $pageData['JS_END_POOL'][] = '/public/js/desktop/params/log_config.js';
 
-        return Render::getInstance()->get('/desktop/params/interact_admin.html.twig', $pageData);
+        return Render::getInstance()->get('/desktop/params/log_config.html.twig', $pageData);
     }
-
 }

--- a/src/Controller/Params/LogConfigController.php
+++ b/src/Controller/Params/LogConfigController.php
@@ -39,7 +39,7 @@ class LogConfigController extends BaseController
      *
      * @param array $pageData Page data
      *
-     * @return string Content of log_admin page
+     * @return string Content of log config page
      *
      * @throws \Exception
      */

--- a/src/Controller/Params/ReportConfigController.php
+++ b/src/Controller/Params/ReportConfigController.php
@@ -36,7 +36,7 @@ class ReportConfigController extends BaseController
      *
      * @param array $pageData Page data
      *
-     * @return string Content of report_admin page
+     * @return string Content of report config page
      *
      */
     public static function get(&$pageData): string

--- a/src/Controller/Params/ReportConfigController.php
+++ b/src/Controller/Params/ReportConfigController.php
@@ -26,13 +26,13 @@ use NextDom\Controller\BaseController;
 use NextDom\Helpers\Render;
 
 /**
- * Class ReportAdminController
+ * Class ReportConfigController
  * @package NextDom\Controller\Params
  */
-class ReportAdminController extends BaseController
+class ReportConfigController extends BaseController
 {
     /**
-     * Render reportsAdmin page
+     * Render ReportConfig page
      *
      * @param array $pageData Page data
      *
@@ -41,8 +41,8 @@ class ReportAdminController extends BaseController
      */
     public static function get(&$pageData): string
     {
-        $pageData['JS_END_POOL'][] = '/public/js/desktop/params/reports_admin.js';
+        $pageData['JS_END_POOL'][] = '/public/js/desktop/params/report_config.js';
 
-        return Render::getInstance()->get('/desktop/params/reports_admin.html.twig', $pageData);
+        return Render::getInstance()->get('/desktop/params/report_config.html.twig', $pageData);
     }
 }

--- a/src/pages_routes.yml
+++ b/src/pages_routes.yml
@@ -70,9 +70,9 @@ interact:
   path: 'interact'
   controller: NextDom\Controller\Tools\InteractController::get
   condition: 'admin'
-interact_admin:
-  path: 'interact_admin'
-  controller: NextDom\Controller\Params\InteractAdminController::get
+interact_config:
+  path: 'interact_config'
+  controller: NextDom\Controller\Params\InteractConfigController::get
   condition: 'admin'
 links:
   path: 'links'
@@ -82,9 +82,9 @@ log:
   path: 'log'
   controller: NextDom\Controller\Diagnostic\LogController::get
   condition: 'admin'
-log_admin:
-  path: 'log_admin'
-  controller: NextDom\Controller\Params\LogAdminController::get
+log_config:
+  path: 'log_config'
+  controller: NextDom\Controller\Params\LogConfigController::get
   condition: 'admin'
 market:
   path: 'market'
@@ -141,9 +141,9 @@ report:
   path: 'report'
   controller: NextDom\Controller\Diagnostic\ReportController::get
   condition: 'admin'
-reports_admin:
-  path: 'reports_admin'
-  controller: NextDom\Controller\Params\ReportAdminController::get
+report_config:
+  path: 'report_config'
+  controller: NextDom\Controller\Params\ReportConfigController::get
   condition: 'admin'
 scenario:
   path: 'scenario'
@@ -152,6 +152,10 @@ scenario:
 security:
   path: 'security'
   controller: NextDom\Controller\Admin\SecurityController::get
+  condition: 'admin'
+services:
+  path: 'services'
+  controller: NextDom\Controller\Admin\ServicesController::get
   condition: 'admin'
 shutdown:
   path: 'shutdown'
@@ -172,10 +176,6 @@ timeline:
 update:
   path: 'update'
   controller: NextDom\Controller\Tools\UpdateController::get
-  condition: 'admin'
-update_admin:
-  path: 'update_admin'
-  controller: NextDom\Controller\Admin\UpdateAdminController::get
   condition: 'admin'
 users:
   path: 'users'

--- a/tests/phpunit_tests/Controllers/InteractConfigControllerTest.php
+++ b/tests/phpunit_tests/Controllers/InteractConfigControllerTest.php
@@ -18,7 +18,7 @@
 require_once(__DIR__ . '/../../../src/core.php');
 require_once(__DIR__ . '/BaseControllerTest.php');
 
-class ReportAdminControllerTest extends BaseControllerTest
+class InteractConfigControllerTest extends BaseControllerTest
 {
     public function setUp()
     {
@@ -32,14 +32,14 @@ class ReportAdminControllerTest extends BaseControllerTest
     public function testSimple()
     {
         $pageData = [];
-        $result = \NextDom\Controller\Params\ReportAdminController::get($pageData);
-        $this->assertContains('id="reports_admin"', $result);
+        $result = \NextDom\Controller\Params\InteractConfigController::get($pageData);
+        $this->assertContains('id="interact_config"', $result);
     }
 
     public function testPageDataVars()
     {
         $pageData = [];
-        \NextDom\Controller\Params\ReportAdminController::get($pageData);
-        $this->pageDataVars('desktop/params/reports_admin.html.twig', $pageData);
+        \NextDom\Controller\Params\InteractConfigController::get($pageData);
+        $this->pageDataVars('desktop/params/interact_config.html.twig', $pageData);
     }
 }

--- a/tests/phpunit_tests/Controllers/LogConfigControllerTest.php
+++ b/tests/phpunit_tests/Controllers/LogConfigControllerTest.php
@@ -18,7 +18,7 @@
 require_once(__DIR__ . '/../../../src/core.php');
 require_once(__DIR__ . '/BaseControllerTest.php');
 
-class InteractAdminControllerTest extends BaseControllerTest
+class LogConfigControllerTest extends BaseControllerTest
 {
     public function setUp()
     {
@@ -32,14 +32,15 @@ class InteractAdminControllerTest extends BaseControllerTest
     public function testSimple()
     {
         $pageData = [];
-        $result = \NextDom\Controller\Params\InteractAdminController::get($pageData);
-        $this->assertContains('id="interact_admin"', $result);
+        $result = \NextDom\Controller\Params\LogConfigController::get($pageData);
+        $this->assertArrayHasKey('adminPluginsList', $pageData);
+        $this->assertContains('id="log_config"', $result);
     }
 
     public function testPageDataVars()
     {
         $pageData = [];
-        \NextDom\Controller\Params\InteractAdminController::get($pageData);
-        $this->pageDataVars('desktop/params/interact_admin.html.twig', $pageData);
+        \NextDom\Controller\Params\LogConfigController::get($pageData);
+        $this->pageDataVars('desktop/params/log_config.html.twig', $pageData);
     }
 }

--- a/tests/phpunit_tests/Controllers/LogControllerTest.php
+++ b/tests/phpunit_tests/Controllers/LogControllerTest.php
@@ -42,7 +42,7 @@ class LogControllerTest extends BaseControllerTest
     {
         $pageData = [];
         \NextDom\Controller\Diagnostic\LogController::get($pageData);
-        $this->pageDataVars('desktop/diagnostic/logs-view.html.twig', $pageData);
+        $this->pageDataVars('desktop/diagnostic/log.html.twig', $pageData);
     }
 
 }

--- a/tests/phpunit_tests/Controllers/ReportConfigControllerTest.php
+++ b/tests/phpunit_tests/Controllers/ReportConfigControllerTest.php
@@ -18,7 +18,7 @@
 require_once(__DIR__ . '/../../../src/core.php');
 require_once(__DIR__ . '/BaseControllerTest.php');
 
-class UpdateAdminControllerTest extends BaseControllerTest
+class ReportConfigControllerTest extends BaseControllerTest
 {
     public function setUp()
     {
@@ -32,15 +32,14 @@ class UpdateAdminControllerTest extends BaseControllerTest
     public function testSimple()
     {
         $pageData = [];
-        $result = \NextDom\Controller\Admin\UpdateAdminController::get($pageData);
-        $this->assertArrayHasKey('adminReposList', $pageData);
-        $this->assertContains('href="#tabgithub"', $result);
+        $result = \NextDom\Controller\Params\ReportConfigController::get($pageData);
+        $this->assertContains('id="report_config"', $result);
     }
 
     public function testPageDataVars()
     {
         $pageData = [];
-        \NextDom\Controller\Admin\UpdateAdminController::get($pageData);
-        $this->pageDataVars('desktop/admin/update_admin.html.twig', $pageData);
+        \NextDom\Controller\Params\ReportConfigController::get($pageData);
+        $this->pageDataVars('desktop/params/report_config.html.twig', $pageData);
     }
 }

--- a/tests/phpunit_tests/Controllers/ReportControllerTest.php
+++ b/tests/phpunit_tests/Controllers/ReportControllerTest.php
@@ -41,6 +41,6 @@ class ReportControllerTest extends BaseControllerTest
     {
         $pageData = [];
         \NextDom\Controller\Diagnostic\ReportController::get($pageData);
-        $this->pageDataVars('desktop/diagnostic/reports-view.html.twig', $pageData);
+        $this->pageDataVars('desktop/diagnostic/report.html.twig', $pageData);
     }
 }

--- a/tests/phpunit_tests/Controllers/ServicesControllerTest.php
+++ b/tests/phpunit_tests/Controllers/ServicesControllerTest.php
@@ -18,7 +18,7 @@
 require_once(__DIR__ . '/../../../src/core.php');
 require_once(__DIR__ . '/BaseControllerTest.php');
 
-class LogAdminControllerTest extends BaseControllerTest
+class ServicesControllerTest extends BaseControllerTest
 {
     public function setUp()
     {
@@ -32,15 +32,15 @@ class LogAdminControllerTest extends BaseControllerTest
     public function testSimple()
     {
         $pageData = [];
-        $result = \NextDom\Controller\Params\LogAdminController::get($pageData);
-        $this->assertArrayHasKey('adminPluginsList', $pageData);
-        $this->assertContains('id="log_admin"', $result);
+        $result = \NextDom\Controller\Admin\ServicesController::get($pageData);
+        $this->assertArrayHasKey('adminReposList', $pageData);
+        $this->assertContains('href="#tabgithub"', $result);
     }
 
     public function testPageDataVars()
     {
         $pageData = [];
-        \NextDom\Controller\Params\LogAdminController::get($pageData);
-        $this->pageDataVars('desktop/params/log_admin.html.twig', $pageData);
+        \NextDom\Controller\Admin\ServicesController::get($pageData);
+        $this->pageDataVars('desktop/admin/services.html.twig', $pageData);
     }
 }

--- a/tests/tests/administrations_page.py
+++ b/tests/tests/administrations_page.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# line 100 caracters max or #pylint: disable=line-too-long
+####################################################################################################
 """Run all tests of administration pages
 """
 import unittest
@@ -38,12 +40,16 @@ class AdministrationPages(BaseGuiTest):
         """Test global administration page
         """
         self.goto('index.php?v=d&p=administration')
-        users_button = self.get_element_by_css('a[href="index.php?v=d&p=users"]')
-        interact_admin_button = self.get_element_by_css('a[href="index.php?v=d&p=interact_admin"]')
-        cache_button = self.get_element_by_css('a[href="index.php?v=d&p=cache"]')
-        self.assertIsNotNone(users_button)
-        self.assertIsNotNone(interact_admin_button)
-        self.assertIsNotNone(cache_button)
+        link_buttons = ['users', 'api', 'network', 'security', 'cache', 'services',
+                        'general', 'custom', 'profils', 'commandes', 'links', 'interact_config',
+                        'eqlogic', 'summary', 'report_config', 'log_config',
+                        'health', 'cron', 'eqAnalyse', 'realtime', 'history', 'timeline',
+                        'report', 'log',
+                        'display', 'backup', 'update', 'osdb', 'interact', 'scenario',
+                        'object', 'plugin']
+        for link_button in link_buttons:
+            admin_button = self.get_element_by_css('a[href="index.php?v=d&p='+link_button+'"]')
+            self.assertIsNotNone(admin_button)
         self.assertEqual(0, len(self.get_js_logs()))
 
     def test_users_page(self):
@@ -102,9 +108,9 @@ class AdministrationPages(BaseGuiTest):
         back_button.click()
 
     def test_service_page(self):
-        """Test service administration page
+        """Test services administration page
         """
-        self.goto('index.php?v=d&p=update_admin')
+        self.goto('index.php?v=d&p=services')
         test_repo_buttons = self.driver.find_element_by_class_name('testRepoConnection')
         back_button = self.get_link_by_title('Retour')
         self.assertIsNotNone(test_repo_buttons)
@@ -168,10 +174,10 @@ class AdministrationPages(BaseGuiTest):
         self.assertEqual(0, len(self.get_js_logs()))
         back_button.click()
 
-    def test_interact_admin_page(self):
-        """Test interact administration page
+    def test_interact_config_page(self):
+        """Test interact config administration page
         """
-        self.goto('index.php?v=d&p=interact_admin')
+        self.goto('index.php?v=d&p=interact_config')
         add_color_button = self.get_element_by_id('bt_addColorConvert')
         back_button = self.get_link_by_title('Retour')
         self.assertIsNotNone(add_color_button)
@@ -190,10 +196,10 @@ class AdministrationPages(BaseGuiTest):
         self.assertEqual(0, len(self.get_js_logs()))
         back_button.click()
 
-    def test_reports_admin_page(self):
-        """Test reports administration page
+    def test_report_config_page(self):
+        """Test report config administration page
         """
-        self.goto('index.php?v=d&p=reports_admin')
+        self.goto('index.php?v=d&p=report_config')
         report_delay_input = self.get_element_by_css('input[data-l1key="report::delay"]')
         back_button = self.get_link_by_title('Retour')
         self.assertIsNotNone(report_delay_input)
@@ -201,10 +207,10 @@ class AdministrationPages(BaseGuiTest):
         self.assertEqual(0, len(self.get_js_logs()))
         back_button.click()
 
-    def test_log_admin_page(self):
-        """Test log view administration page
+    def test_log_config_page(self):
+        """Test log config administration page
         """
-        self.goto('index.php?v=d&p=log_admin')
+        self.goto('index.php?v=d&p=log_config')
         max_event_input = self.get_element_by_css('input[data-l1key="timeline::maxevent"]')
         back_button = self.get_link_by_title('Retour')
         self.assertIsNotNone(max_event_input)

--- a/views/desktop/admin/services.html.twig
+++ b/views/desktop/admin/services.html.twig
@@ -39,14 +39,14 @@
             <a class="btn btn-danger btn-action-bar" href="index.php?v=d&p=administration"><i class="fas fa-chevron-left"></i>{{ 'common.return' | trans}}</a>
         </div>
         <div class="action-group">
-            <a class="btn btn-success btn-action-bar pull-right" id="bt_saveupdate_admin"><i class="fas fa-save"></i>{{ 'common.save' | trans }}</a>
+            <a class="btn btn-success btn-action-bar pull-right" id="bt_saveservices"><i class="fas fa-save"></i>{{ 'common.save' | trans }}</a>
             <a class="btn btn-danger btn-action-bar pull-right bt_cancelModifs"><i class="fas fa-times"></i>{{ 'common.cancel'|trans }}</a>
         </div>
     </div>
 </section>
 
 <section class="content">
-    <div id="update_admin">
+    <div id="services">
         <div class="nav-tabs-custom">
             <ul class="nav nav-tabs pull-right" role="tablist">
                 {% for repo, data in adminReposList %}

--- a/views/desktop/diagnostic/log.html.twig
+++ b/views/desktop/diagnostic/log.html.twig
@@ -37,7 +37,7 @@
     <div class="action-bar">
         <div class="action-group">
             <a class="btn btn-danger btn-action-bar" href="index.php?v=d&p=administration"><i class="fas fa-chevron-left"></i>{{ 'common.return' | trans }}</a>
-            <a class="btn btn-default btn-action-bar" href="index.php?v=d&p=log_admin"><i class="fas fa-cog"></i>{{ 'common.settings' | trans }}</a>
+            <a class="btn btn-default btn-action-bar" href="index.php?v=d&p=log_config"><i class="fas fa-cog"></i>{{ 'common.settings' | trans }}</a>
             <a class="btn btn-warning btn-action-bar" data-state="1" id="bt_globalLogStopStart"><i class="fas fa-pause"></i>{{ 'common.pause' | trans }}</a>
         </div>
         <div class="action-group">
@@ -50,7 +50,7 @@
 </section>
 
 <section class="content">
-    <div class="box" id="div_Logs-view">
+    <div class="box" id="div_Log">
         <!-- Header bar -->
         <div class="box-header with-border">
             <h3 class="box-title"><i class="fas fa-file-alt"></i>{{ 'Logs' }}</h3>

--- a/views/desktop/diagnostic/report.html.twig
+++ b/views/desktop/diagnostic/report.html.twig
@@ -37,7 +37,7 @@
     <div class="action-bar">
         <div class="action-group">
             <a class="btn btn-danger btn-action-bar" href="index.php?v=d&p=administration"><i class="fas fa-chevron-left"></i>{{ 'common.return' | trans }}</a>
-            <a class="btn btn-default btn-action-bar" href="index.php?v=d&p=reports_admin"><i class="fas fa-cog"></i>{{ 'common.settings' | trans }}</a>
+            <a class="btn btn-default btn-action-bar" href="index.php?v=d&p=report_config"><i class="fas fa-cog"></i>{{ 'common.settings' | trans }}</a>
         </div>
         <div class="action-group" id="div_reportBtn" style="display:none;">
             <a class="btn btn-danger btn-action-bar pull-right" id="bt_removeAll"><i class="fas fa-trash"></i>{{ 'Tout supprimer' }}</a>
@@ -48,7 +48,7 @@
 </section>
 
 <section class="content">
-    <div class="box" id="div_Reports-view">
+    <div class="box" id="report">
         <div class="box-header with-border">
             <h3 class="box-title"><i class="fas fa-newspaper-o"></i>{{ 'Rapports' }}</h3>
         </div>

--- a/views/desktop/pages/administration.html.twig
+++ b/views/desktop/pages/administration.html.twig
@@ -105,7 +105,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-sm-6 col-xs-12">
+        <div class="col-md-6 col-xs-12">
             <div class="box box-danger">
                 <div class="box-header with-border">
                     <h3 class="box-title"><i class="fas fa-cog"></i>{{ 'page-title.administration'|trans }}</h3>
@@ -116,11 +116,11 @@
                     <a class="btn btn-app" href="index.php?v=d&p=network"><i class="fas fa-rss"></i>{{ 'page-title.networks'|trans }}</a>
                     <a class="btn btn-app" href="index.php?v=d&p=security"><i class="fas fa-shield-alt"></i>{{ 'page-title.security'|trans }}</a>
                     <a class="btn btn-app" href="index.php?v=d&p=cache"><i class="fas fa-hdd-o"></i>{{ 'page-title.cache'|trans }}</a>
-                    <a class="btn btn-app" href="index.php?v=d&p=update_admin"><i class="fas fa-credit-card"></i>{{ 'page-title.services'|trans }}</a>
+                    <a class="btn btn-app" href="index.php?v=d&p=services"><i class="fas fa-credit-card"></i>{{ 'page-title.services'|trans }}</a>
                 </div>
             </div>
         </div>
-        <div class="col-sm-6 col-xs-12">
+        <div class="col-md-6 col-xs-12">
             <div class="box box-warning">
                 <div class="box-header with-border">
                     <h3 class="box-title"><i class="fas fa-sliders-h"></i>{{ 'page-title.settings'|trans }}</h3>
@@ -131,17 +131,17 @@
                     <a class="btn btn-app" href="index.php?v=d&p=profils"><i class="fas fa-briefcase"></i>{{ 'page-title.profil'|trans }}</a>
                     <a class="btn btn-app" href="index.php?v=d&p=commandes"><i class="fas fa-hand-o-right"></i>{{ 'page-title.commands'|trans }}</a>
                     <a class="btn btn-app" href="index.php?v=d&p=links"><i class="fas fa-sitemap"></i>{{ 'page-title.links'|trans }}</a>
-                    <a class="btn btn-app" href="index.php?v=d&p=interact_admin"><i class="fas fa-comments"></i>{{ 'page-title.interacts'|trans }}</a>
+                    <a class="btn btn-app" href="index.php?v=d&p=interact_config"><i class="fas fa-comments"></i>{{ 'page-title.interacts'|trans }}</a>
                     <a class="btn btn-app" href="index.php?v=d&p=eqlogic"><i class="fas fa-plug"></i>{{ 'page-title.equipments'|trans }}</a>
                     <a class="btn btn-app" href="index.php?v=d&p=summary"><i class="fas fa-table"></i>{{ 'page-title.summaries'|trans }}</a>
-                    <a class="btn btn-app" href="index.php?v=d&p=reports_admin"><i class="fas fa-newspaper-o"></i>{{ 'page-title.reports'|trans }}</a>
-                    <a class="btn btn-app" href="index.php?v=d&p=log_admin"><i class="fas fa-file-alt"></i>{{ 'page-title.logs'|trans }}</a>
+                    <a class="btn btn-app" href="index.php?v=d&p=report_config"><i class="fas fa-newspaper-o"></i>{{ 'page-title.reports'|trans }}</a>
+                    <a class="btn btn-app" href="index.php?v=d&p=log_config"><i class="fas fa-file-alt"></i>{{ 'page-title.logs'|trans }}</a>
                 </div>
             </div>
         </div>
     </div>
     <div class="row">
-        <div class="col-sm-6 col-xs-12">
+        <div class="col-md-6 col-xs-12">
             <div class="box box-success">
                 <div class="box-header with-border">
                     <h3 class="box-title"><i class="fas fa-stethoscope"></i>{{ 'page-title.diagnostics'|trans }}</h3>
@@ -158,7 +158,7 @@
                 </div>
             </div>
         </div>
-        <div class="col-sm-6 col-xs-12">
+        <div class="col-md-6 col-xs-12">
             <div class="box box-primary">
                 <div class="box-header with-border">
                     <h3 class="box-title"><i class="fas fa-tools"></i>{{ 'page-title.tools'|trans }}</h3>
@@ -178,7 +178,7 @@
         </div>
     </div>
     <div id="informations-div" class="row form-group">
-        <div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
+        <div class="col-lg-4 col-md-6 col-xs-12">
             <div class="info-box info-box-small">
               <span class="info-box-icon info-box-small-icon">
                   <i class="fas fa-globe"></i>
@@ -189,7 +189,7 @@
               </div>
             </div>
         </div>
-        <div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
+        <div class="col-lg-4 col-md-6 col-xs-12">
             <div class="info-box info-box-small">
               <span class="info-box-icon info-box-small-icon">
                   <i class="fas fa-chalkboard-teacher"></i>
@@ -200,7 +200,7 @@
               </div>
             </div>
         </div>
-        <div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
+        <div class="col-lg-4 col-md-6 col-xs-12">
             <div class="info-box info-box-small">
               <span class="info-box-icon info-box-small-icon">
                   <i class="fas fa-clock"></i>

--- a/views/desktop/params/interact_config.html.twig
+++ b/views/desktop/params/interact_config.html.twig
@@ -42,14 +42,14 @@
             <a class="btn btn-success btn-action-bar" id="bt_addColorConvert"><i class="fas fa-plus-circle"></i>{{ 'Ajouter une couleur' }}</a>
         </div>
         <div class="action-group">
-            <a class="btn btn-success btn-action-bar pull-right" id="bt_saveinteract_admin"><i class="fas fa-save"></i>{{ 'common.save' | trans }}</a>
+            <a class="btn btn-success btn-action-bar pull-right" id="bt_saveinteract_config"><i class="fas fa-save"></i>{{ 'common.save' | trans }}</a>
             <a class="btn btn-danger btn-action-bar pull-right bt_cancelModifs"><i class="fas fa-times"></i>{{ 'common.cancel'|trans }}</a>
         </div>
     </div>
 </section>
 
 <section class="content">
-    <div class="box" id="interact_admin">
+    <div class="box" id="interact_config">
         <!-- Header bar -->
         <div class="box-header with-border">
             <h3 class="box-title"><i class="fas fa-comments"></i>{{ 'Interactions' }}</h3>

--- a/views/desktop/params/log_config.html.twig
+++ b/views/desktop/params/log_config.html.twig
@@ -40,14 +40,14 @@
             <a class="btn btn-default btn-action-bar" href="index.php?v=d&p=log"><i class="fas fa-eye"></i>{{ 'common.display' | trans }}</a>
         </div>
         <div class="action-group">
-            <a class="btn btn-success btn-action-bar pull-right" id="bt_savelog_admin"><i class="fas fa-save"></i>{{ 'common.save' | trans }}</a>
+            <a class="btn btn-success btn-action-bar pull-right" id="bt_savelog_config"><i class="fas fa-save"></i>{{ 'common.save' | trans }}</a>
             <a class="btn btn-danger btn-action-bar pull-right bt_cancelModifs"><i class="fas fa-times"></i>{{ 'common.cancel'|trans }}</a>
         </div>
     </div>
 </section>
 
 <section class="content">
-    <div class="box" id="log_admin">
+    <div class="box" id="log_config">
         <!-- Header bar -->
         <div class="box-header with-border">
             <h3 class="box-title"><i class="fas fa-file-alt"></i>{{ 'Logs' }}</h3>

--- a/views/desktop/params/report_config.html.twig
+++ b/views/desktop/params/report_config.html.twig
@@ -41,14 +41,14 @@
             <a class="btn btn-default btn-action-bar" href="index.php?v=d&p=report"><i class="fas fa-eye"></i>{{ 'common.display' | trans }}</a>
         </div>
         <div class="action-group">
-            <a class="btn btn-success btn-action-bar pull-right" id="bt_savereports_admin"><i class="fas fa-save"></i>{{ 'common.save' | trans }}</a>
+            <a class="btn btn-success btn-action-bar pull-right" id="bt_savereport_config"><i class="fas fa-save"></i>{{ 'common.save' | trans }}</a>
             <a class="btn btn-danger btn-action-bar pull-right bt_cancelModifs"><i class="fas fa-times"></i>{{ 'common.cancel'|trans }}</a>
         </div>
     </div>
 </section>
 
 <section class="content">
-    <div class="box" id="reports_admin">
+    <div class="box" id="report_config">
         <!-- Header bar -->
         <div class="box-header with-border">
             <h3 class="box-title"><i class="fas fa-newspaper-o"></i>{{ 'Rapports' | trans }}</h3>

--- a/views/desktop/tools/backup.html.twig
+++ b/views/desktop/tools/backup.html.twig
@@ -168,7 +168,7 @@
                                     </div>
                                 {% else %}
                                     <div class="form-group col-xs-12 col-padding">
-                                        <p class="alert alert-warning">{{ 'backup.the_service_is_disabled_you_can__activate' | trans }}<a href="/index.php?v=d&p=update_admin">{{'common.here'|trans }}</a></p>
+                                        <p class="alert alert-warning">{{ 'backup.the_service_is_disabled_you_can__activate' | trans }}<a href="/index.php?v=d&p=services">{{'common.here'|trans }}</a></p>
                                     </div>
                                 {% endif %}
                             </div>

--- a/views/desktop/tools/interact.html.twig
+++ b/views/desktop/tools/interact.html.twig
@@ -39,7 +39,7 @@
         <div class="action-bar">
             <div class="action-group">
                 <a class="btn btn-danger btn-action-bar" href="index.php?v=d&p=administration"><i class="fas fa-chevron-left"></i>{{ 'common.return' | trans }}</a>
-                <a class="btn btn-default btn-action-bar" href="index.php?v=d&p=interact_admin"><i class="fas fa-cog"></i>{{ 'common.settings' | trans }}</a>
+                <a class="btn btn-default btn-action-bar" href="index.php?v=d&p=interact_config"><i class="fas fa-cog"></i>{{ 'common.settings' | trans }}</a>
                 <a class="btn btn-success btn-action-bar" id="bt_addInteract"><i class="fas fa-plus-circle"></i>{{ 'common.add' | trans }}</a>
             </div>
             <div class="action-group">

--- a/views/desktop/tools/plugin.html.twig
+++ b/views/desktop/tools/plugin.html.twig
@@ -43,7 +43,7 @@
             <div class="action-group">
                 <a class="btn btn-action btn-action-bar pull-right" id="bt_pluginCollapse"><i class="fas fa-plus-square"></i>{{ 'Déplier' }}</a>
                 <a class="btn btn-action btn-action-bar pull-right" style="display:none;" id="bt_pluginUncollapse"><i class="fas fa-minus-square"></i>{{ 'Replier' }}</a>
-                <a class="btn btn-default btn-action-bar pull-right" href="index.php?v=d&p=update_admin"><i class="fas fa-cog"></i>{{ 'Configurer Markets' }}</a>
+                <a class="btn btn-default btn-action-bar pull-right" href="index.php?v=d&p=services"><i class="fas fa-cog"></i>{{ 'Configurer Markets' }}</a>
                 {% for repoCode, repoData in pluginReposList %}
                     {% if repoData['name'] == 'Market' %}
                         <a class="btn btn-default btn-action-bar pull-right displayStore btn-jeedom" data-repo="{{ repoCode }}"><i class="fas fa-shopping-cart"></i>{{ 'Jeedom '}} {{ repoData['name'] }}</a>


### PR DESCRIPTION
Modif :
- Rename html, js and all calls
--- logs-view to log
--- reports-view to report
--- log_admin to log_config
--- reports_admin to report_config
--- update_admin to services
--- interact_admin to interact_config
- Add tests to all button of administration menu page

To test : 
- Test all modified pages
- Travis will be check if tests are correct



