### PR TITLE
Clean code

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -14,5 +14,8 @@ sonar.sourceEncoding=UTF-8
 sonar.php.tests.reportPath=tests/coverage/junitlog.xml
 sonar.php.coverage.reportPaths=tests/coverage/clover.xml
 
+sonar.coverageReportPaths=tests/coverage/clover.xml
+sonar.testExecutionReportPaths=tests/coverage/junitlog.xml
+
 # Exclusions for copy-paste detection
 #sonar.cpd.exclusions=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
+dist: trusty
 language: php
 php:
     - 7.3
 services:
     - docker
+#addons:
+#    sonarcloud:
+#        organization: "nextdom"
+#        token:
+#            secure: GtxUlb7OHChNapdoSpicL5YFLzNLXF7qEjRLk+mjYb7UF8drSSj67L6pxohbCl01kbG8OtEazzplzsnNpbrHhyAwfyuKtP8NYOOcC6nMptDUF9Fx1i45vM7Vom+pPnzPRxztLqZfZ2e1Ua9XrEFybZ7aiAN+KufYSrXwjoI6Ngt7xY76lbbwj4O+2mdR4OCR5YoC6NbdeOBclWTF2fER9bda1rAOTeNkht/+ZRvrPWVv43ELzXUAHFz4A9nqIx+v4ho+9Gy1qpv7B7OUQPlNqkHZL1UWgZ48XZ8Cz8boBrce9mPsHcxjXyB+hfMfbljNbweEMERTilz0q2pT30Cn2WBRaf+/BMau2LHaUxMS26pp4V5dvVIlmAW4nJbYOT2FFTG0HXAxMuRvzCC+3PdUHK08/BUET6NNitnCwf2+E+Zwva53wautdpgfC9sk+G+DbevkXAcQoOfhHXR8jMFBurZEsXEkpiQLpgplT7YS5iOtpq50eaBH6CYH0mutFB7z4tEV4/3V7WN02aJ/5HJY5lrXx4eMoI+AHp69iVmGdT27fWG7GvbOh+Mb2yYSJAQANSH3DnAV0rA/sFLTW1wmht8P9/Ms+lprIytzj1dBdcKwyUBUtGgtx3HZBJqL+P9YfQaFWNZJrvr0W2TeN4PPtnc7MwXPsoK3vGk5GygJMTE=
 before_install:
     - docker pull nextdom/nextdom-test:latest
     - mkdir -p tests/coverage
@@ -37,3 +43,7 @@ after_script:
     - ls tests/coverage/
     - sed -i "s/\/usr\/share\/nextdom\///g" tests/coverage/clover.xml
     - php vendor/bin/php-coveralls -v
+#    - sonar-scanner -X
+#env:
+#    global:
+#        secure: GtxUlb7OHChNapdoSpicL5YFLzNLXF7qEjRLk+mjYb7UF8drSSj67L6pxohbCl01kbG8OtEazzplzsnNpbrHhyAwfyuKtP8NYOOcC6nMptDUF9Fx1i45vM7Vom+pPnzPRxztLqZfZ2e1Ua9XrEFybZ7aiAN+KufYSrXwjoI6Ngt7xY76lbbwj4O+2mdR4OCR5YoC6NbdeOBclWTF2fER9bda1rAOTeNkht/+ZRvrPWVv43ELzXUAHFz4A9nqIx+v4ho+9Gy1qpv7B7OUQPlNqkHZL1UWgZ48XZ8Cz8boBrce9mPsHcxjXyB+hfMfbljNbweEMERTilz0q2pT30Cn2WBRaf+/BMau2LHaUxMS26pp4V5dvVIlmAW4nJbYOT2FFTG0HXAxMuRvzCC+3PdUHK08/BUET6NNitnCwf2+E+Zwva53wautdpgfC9sk+G+DbevkXAcQoOfhHXR8jMFBurZEsXEkpiQLpgplT7YS5iOtpq50eaBH6CYH0mutFB7z4tEV4/3V7WN02aJ/5HJY5lrXx4eMoI+AHp69iVmGdT27fWG7GvbOh+Mb2yYSJAQANSH3DnAV0rA/sFLTW1wmht8P9/Ms+lprIytzj1dBdcKwyUBUtGgtx3HZBJqL+P9YfQaFWNZJrvr0W2TeN4PPtnc7MwXPsoK3vGk5GygJMTE=

--- a/core/repo/market.api.repo.php
+++ b/core/repo/market.api.repo.php
@@ -1,3 +1,3 @@
 <?php
 
-require_once __DIR__ . '/../../src/Repo/RepoMarketApi.php';
+require_once __DIR__ . '/../../src/Market/RepoMarketApi.php';

--- a/core/repo/market.display.repo.php
+++ b/core/repo/market.display.repo.php
@@ -1,3 +1,3 @@
 <?php
 
-require_once __DIR__ . '/../../src/Repo/RepoMarketDisplay.php';
+require_once __DIR__ . '/../../src/Market/RepoMarketDisplay.php';

--- a/core/repo/market.list.repo.php
+++ b/core/repo/market.list.repo.php
@@ -1,3 +1,3 @@
 <?php
 
-require_once __DIR__ . '/../../src/Repo/RepoMarketList.php';
+require_once __DIR__ . '/../../src/Market/RepoMarketList.php';

--- a/src/Ajax/BaseAjax.php
+++ b/src/Ajax/BaseAjax.php
@@ -22,6 +22,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\AjaxHelper;
@@ -59,7 +60,8 @@ abstract class BaseAjax
      * Initialize Ajax helper
      * @throws \Exception
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->ajax = new AjaxHelper();
     }
 
@@ -76,7 +78,7 @@ abstract class BaseAjax
             }
 
             // Check and call the method for the action in query
-            $actionCode = Utils::init('action', '');
+            $actionCode = Utils::init(AjaxParams::ACTION, '');
             if ($this->checkIfActionExists($actionCode)) {
                 $this->$actionCode();
             } else {

--- a/src/Ajax/ConfigAjax.php
+++ b/src/Ajax/ConfigAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\AuthentificationHelper;
@@ -37,14 +38,14 @@ class ConfigAjax extends BaseAjax
     public function genApiKey()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        if (Utils::init('plugin') == 'core') {
+        if (Utils::init(AjaxParams::PLUGIN) == 'core') {
             ConfigManager::save('api', ConfigManager::genKey());
             $this->ajax->success(ConfigManager::byKey('api'));
-        } else if (Utils::init('plugin') == 'pro') {
+        } else if (Utils::init(AjaxParams::PLUGIN) == 'pro') {
             ConfigManager::save('apipro', ConfigManager::genKey());
             $this->ajax->success(ConfigManager::byKey('apipro'));
         } else {
-            $plugin = Utils::init('plugin');
+            $plugin = Utils::init(AjaxParams::PLUGIN);
             ConfigManager::save('api', ConfigManager::genKey(), $plugin);
             $this->ajax->success(ConfigManager::byKey('api', $plugin));
         }
@@ -52,19 +53,19 @@ class ConfigAjax extends BaseAjax
 
     public function getKey()
     {
-        $keys = Utils::init('key');
+        $keys = Utils::init(AjaxParams::KEY);
         if ($keys == '') {
             throw new CoreException(__('Aucune clé demandée'));
         }
         if (is_json($keys)) {
             $keys = json_decode($keys, true);
-            $return = ConfigManager::byKeys(array_keys($keys), Utils::init('plugin', 'core'));
+            $return = ConfigManager::byKeys(array_keys($keys), Utils::init(AjaxParams::PLUGIN, 'core'));
             if (Utils::init('convertToHumanReadable', 0)) {
                 $return = NextDomHelper::toHumanReadable($return);
             }
             $this->ajax->success($return);
         } else {
-            $return = ConfigManager::byKey($keys, Utils::init('plugin', 'core'));
+            $return = ConfigManager::byKey($keys, Utils::init(AjaxParams::PLUGIN, 'core'));
             if (Utils::init('convertToHumanReadable', 0)) {
                 $return = NextDomHelper::toHumanReadable($return);
             }
@@ -84,17 +85,17 @@ class ConfigAjax extends BaseAjax
 
     public function removeKey()
     {
-        $keys = Utils::init('key');
+        $keys = Utils::init(AjaxParams::KEY);
         if ($keys == '') {
             throw new CoreException(__('Aucune clé demandée'));
         }
         if (is_json($keys)) {
             $keys = json_decode($keys, true);
             foreach ($keys as $key => $value) {
-                ConfigManager::remove($key, Utils::init('plugin', 'core'));
+                ConfigManager::remove($key, Utils::init(AjaxParams::PLUGIN, 'core'));
             }
         } else {
-            ConfigManager::remove(Utils::init('key'), Utils::init('plugin', 'core'));
+            ConfigManager::remove(Utils::init(AjaxParams::KEY), Utils::init(AjaxParams::PLUGIN, 'core'));
         }
         $this->ajax->success();
     }

--- a/src/Ajax/CronAjax.php
+++ b/src/Ajax/CronAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Utils;
@@ -40,7 +41,7 @@ class CronAjax extends BaseAjax
 
     public function remove()
     {
-        $cron = CronManager::byId(Utils::init('id'));
+        $cron = CronManager::byId(Utils::initInt(AjaxParams::ID));
         if (!is_object($cron)) {
             throw new CoreException(__('Cron id inconnu'));
         }
@@ -59,7 +60,7 @@ class CronAjax extends BaseAjax
 
     public function start()
     {
-        $cron = CronManager::byId(Utils::init('id'));
+        $cron = CronManager::byId(Utils::initInt(AjaxParams::ID));
         if (!is_object($cron)) {
             throw new CoreException(__('Cron id inconnu'));
         }
@@ -70,7 +71,7 @@ class CronAjax extends BaseAjax
 
     public function stop()
     {
-        $cron = CronManager::byId(Utils::init('id'));
+        $cron = CronManager::byId(Utils::initInt(AjaxParams::ID));
         if (!is_object($cron)) {
             throw new CoreException(__('Cron id inconnu'));
         }

--- a/src/Ajax/EqLogicAjax.php
+++ b/src/Ajax/EqLogicAjax.php
@@ -17,6 +17,10 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\ActionRight;
+use NextDom\Enums\AjaxParams;
+use NextDom\Enums\Common;
+use NextDom\Enums\NextDomObj;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\AuthentificationHelper;
@@ -37,29 +41,29 @@ class EqLogicAjax extends BaseAjax
 
     public function getEqLogicObject()
     {
-        $linkedObject = JeeObjectManager::byId(Utils::init('object_id'));
+        $linkedObject = JeeObjectManager::byId(Utils::init(AjaxParams::OBJECT_ID));
 
         if (!is_object($linkedObject)) {
             throw new CoreException(__('Objet inconnu. Vérifiez l\'ID'));
         }
-        $return = Utils::o2a($linkedObject);
-        $return['eqLogic'] = array();
+        $result = Utils::o2a($linkedObject);
+        $result[NextDomObj::EQLOGIC] = [];
         foreach ($linkedObject->getEqLogic() as $eqLogic) {
-            if ($eqLogic->getIsVisible() == '1') {
-                $info_eqLogic = array();
-                $info_eqLogic['id'] = $eqLogic->getId();
-                $info_eqLogic['type'] = $eqLogic->getEqType_name();
-                $info_eqLogic['object_id'] = $eqLogic->getObject_id();
-                $info_eqLogic['html'] = $eqLogic->toHtml(Utils::init('version'));
-                $return['eqLogic'][] = $info_eqLogic;
+            if ($eqLogic->isVisible()) {
+                $info_eqLogic = [];
+                $info_eqLogic[Common::ID] = $eqLogic->getId();
+                $info_eqLogic[Common::TYPE] = $eqLogic->getEqType_name();
+                $info_eqLogic[Common::OBJECT_ID] = $eqLogic->getObject_id();
+                $info_eqLogic[Common::HTML] = $eqLogic->toHtml(Utils::init(AjaxParams::VERSION));
+                $result[NextDomObj::EQLOGIC][] = $info_eqLogic;
             }
         }
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     public function byId()
     {
-        $eqLogic = EqLogicManager::byId(Utils::init('id'));
+        $eqLogic = EqLogicManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($eqLogic)) {
             throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID'));
         }
@@ -68,56 +72,56 @@ class EqLogicAjax extends BaseAjax
 
     public function toHtml()
     {
-        if (Utils::init('ids') != '') {
-            $return = array();
-            foreach (json_decode(Utils::init('ids'), true) as $id => $value) {
+        if (Utils::init(AjaxParams::IDS) != '') {
+            $result = [];
+            foreach (json_decode(Utils::init(AjaxParams::IDS), true) as $id => $value) {
                 $eqLogic = EqLogicManager::byId($id);
                 if (!is_object($eqLogic)) {
                     continue;
                 }
-                $return[$eqLogic->getId()] = array(
-                    'html' => $eqLogic->toHtml($value['version']),
-                    'id' => $eqLogic->getId(),
-                    'type' => $eqLogic->getEqType_name(),
-                    'object_id' => $eqLogic->getObject_id(),
-                );
+                $result[$eqLogic->getId()] = [
+                    Common::HTML => $eqLogic->toHtml($value['version']),
+                    Common::ID => $eqLogic->getId(),
+                    Common::TYPE => $eqLogic->getEqType_name(),
+                    Common::OBJECT_ID => $eqLogic->getObject_id(),
+                ];
             }
-            $this->ajax->success($return);
+            $this->ajax->success($result);
         } else {
-            $eqLogic = EqLogicManager::byId(Utils::init('id'));
+            $eqLogic = EqLogicManager::byId(Utils::init(AjaxParams::ID));
             if (!is_object($eqLogic)) {
                 throw new CoreException(__('Eqlogic inconnu. Vérifiez l\'ID'));
             }
-            $info_eqLogic = array();
-            $info_eqLogic['id'] = $eqLogic->getId();
-            $info_eqLogic['type'] = $eqLogic->getEqType_name();
-            $info_eqLogic['object_id'] = $eqLogic->getObject_id();
-            $info_eqLogic['html'] = $eqLogic->toHtml(Utils::init('version'));
-            $this->ajax->success($info_eqLogic);
+            $eqLogicInfo = [];
+            $eqLogicInfo[Common::ID] = $eqLogic->getId();
+            $eqLogicInfo[Common::TYPE] = $eqLogic->getEqType_name();
+            $eqLogicInfo[Common::OBJECT_ID] = $eqLogic->getObject_id();
+            $eqLogicInfo[Common::HTML] = $eqLogic->toHtml(Utils::init(AjaxParams::VERSION));
+            $this->ajax->success($eqLogicInfo);
         }
     }
 
     public function htmlAlert()
     {
-        $return = array();
+        $result = [];
         foreach (EqLogicManager::all() as $eqLogic) {
             if ($eqLogic->getAlert() == '') {
                 continue;
             }
-            $return[$eqLogic->getId()] = array(
-                'html' => $eqLogic->toHtml(Utils::init('version')),
-                'id' => $eqLogic->getId(),
-                'type' => $eqLogic->getEqType_name(),
-                'object_id' => $eqLogic->getObject_id(),
-            );
+            $result[$eqLogic->getId()] = [
+                Common::HTML => $eqLogic->toHtml(Utils::init(AjaxParams::VERSION)),
+                Common::ID => $eqLogic->getId(),
+                Common::TYPE => $eqLogic->getEqType_name(),
+                Common::OBJECT_ID => $eqLogic->getObject_id(),
+            ];
         }
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     public function htmlBattery()
     {
-        $return = array();
-        $list = array();
+        $result = [];
+        $list = [];
         foreach (EqLogicManager::all() as $eqLogic) {
             if ($eqLogic->getStatus('battery', -2) != -2) {
                 $list[] = $eqLogic;
@@ -127,60 +131,65 @@ class EqLogicAjax extends BaseAjax
             return ($a->getStatus('battery') < $b->getStatus('battery')) ? -1 : (($a->getStatus('battery') > $b->getStatus('battery')) ? 1 : 0);
         });
         foreach ($list as $eqLogic) {
-            $return[] = array(
-                'html' => $eqLogic->batteryWidget(Utils::init('version')),
-                'id' => $eqLogic->getId(),
-                'type' => $eqLogic->getEqType_name(),
-                'object_id' => $eqLogic->getObject_id(),
-            );
+            $result[] = [
+                Common::HTML => $eqLogic->batteryWidget(Utils::init(AjaxParams::VERSION)),
+                Common::ID => $eqLogic->getId(),
+                Common::TYPE => $eqLogic->getEqType_name(),
+                Common::OBJECT_ID => $eqLogic->getObject_id(),
+            ];
         }
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     public function listByType()
     {
-        $this->ajax->success(Utils::a2o(EqLogicManager::byType(Utils::init('type'))));
+        $result = [];
+        foreach (EqLogicManager::byType(Utils::init(AjaxParams::TYPE)) as $eqLogic) {
+            $result[$eqLogic->getId()] = utils::o2a($eqLogic);
+            $result[$eqLogic->getId()][Common::HUMAN_NAME] = $eqLogic->getHumanName();
+        }
+        $this->ajax->success(array_values($result));
     }
 
     public function listByObjectAndCmdType()
     {
-        $object_id = (Utils::init('object_id') != -1) ? Utils::init('object_id') : null;
+        $object_id = (Utils::init(AjaxParams::OBJECT_ID) != -1) ? Utils::init(AjaxParams::OBJECT_ID) : null;
         $this->ajax->success(EqLogicManager::listByObjectAndCmdType($object_id, Utils::init('typeCmd'), Utils::init('subTypeCmd')));
     }
 
     public function listByObject()
     {
-        $object_id = (Utils::init('object_id') != -1) ? Utils::init('object_id') : null;
-        $this->ajax->success(Utils::o2a(EqLogicManager::byObjectId($object_id, Utils::init('onlyEnable', true), Utils::init('onlyVisible', false), Utils::init('eqType_name', null), Utils::init('logicalId', null), Utils::init('orderByName', false))));
+        $object_id = (Utils::init(AjaxParams::OBJECT_ID) != -1) ? Utils::init(AjaxParams::OBJECT_ID) : null;
+        $this->ajax->success(Utils::o2a(EqLogicManager::byObjectId($object_id, Utils::init('onlyEnable', true), Utils::init('onlyVisible', false), Utils::init('eqType_name', null), Utils::init(AjaxParams::LOGICAL_ID, null), Utils::init('orderByName', false))));
     }
 
     public function listByTypeAndCmdType()
     {
-        $results = EqLogicManager::listByTypeAndCmdType(Utils::init('type'), Utils::init('typeCmd'), Utils::init('subTypeCmd'));
-        $return = array();
-        foreach ($results as $result) {
-            $eqLogic = EqLogicManager::byId($result['id']);
-            $info['eqLogic'] = Utils::o2a($eqLogic);
-            $info['object'] = array('name' => 'Aucun');
+        $eqLogicList = EqLogicManager::listByTypeAndCmdType(Utils::init(AjaxParams::TYPE), Utils::init('typeCmd'), Utils::init('subTypeCmd'));
+        $result = [];
+        foreach ($eqLogicList as $eqLogic) {
+            $eqLogic = EqLogicManager::byId($eqLogic[Common::ID]);
+            $info[NextDomObj::EQLOGIC] = Utils::o2a($eqLogic);
+            $info[NextDomObj::OBJECT] = ['name' => 'Aucun'];
             if (is_object($eqLogic)) {
                 $linkedObject = $eqLogic->getObject();
                 if (is_object($linkedObject)) {
                     $info['object'] = Utils::o2a($eqLogic->getObject());
                 }
             }
-            $return[] = $info;
+            $result[] = $info;
         }
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     public function setIsEnable()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $eqLogic = EqLogicManager::byId(Utils::init('id'));
+        $eqLogic = EqLogicManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($eqLogic)) {
             throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID'));
         }
-        if (!$eqLogic->hasRight('w')) {
+        if (!$eqLogic->hasRight(ActionRight::WRITE)) {
             throw new CoreException(__('Vous n\'êtes pas autorisé à faire cette action'));
         }
         $eqLogic->setIsEnable(Utils::init('isEnable'));
@@ -192,10 +201,10 @@ class EqLogicAjax extends BaseAjax
     {
         $eqLogics = json_decode(Utils::init('eqLogics'), true);
         foreach ($eqLogics as $eqLogic_json) {
-            if (!isset($eqLogic_json['id']) || trim($eqLogic_json['id']) == '') {
+            if (!isset($eqLogic_json[Common::ID]) || trim($eqLogic_json[Common::ID]) == '') {
                 continue;
             }
-            $eqLogic = EqLogicManager::byId($eqLogic_json['id']);
+            $eqLogic = EqLogicManager::byId($eqLogic_json[Common::ID]);
             if (!is_object($eqLogic)) {
                 continue;
             }
@@ -213,7 +222,7 @@ class EqLogicAjax extends BaseAjax
             if (!is_object($eqLogic)) {
                 throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID') . ' ' . $id);
             }
-            if (!$eqLogic->hasRight('w')) {
+            if (!$eqLogic->hasRight(ActionRight::WRITE)) {
                 continue;
             }
             $eqLogic->remove();
@@ -229,7 +238,7 @@ class EqLogicAjax extends BaseAjax
             if (!is_object($eqLogic)) {
                 throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID') . ' ' . $id);
             }
-            if (!$eqLogic->hasRight('w')) {
+            if (!$eqLogic->hasRight(ActionRight::WRITE)) {
                 continue;
             }
             $eqLogic->setIsVisible(Utils::init('isVisible'));
@@ -246,7 +255,7 @@ class EqLogicAjax extends BaseAjax
             if (!is_object($eqLogic)) {
                 throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID') . ' ' . $id);
             }
-            if (!$eqLogic->hasRight('w')) {
+            if (!$eqLogic->hasRight(ActionRight::WRITE)) {
                 continue;
             }
             $eqLogic->setIsEnable(Utils::init('isEnable'));
@@ -258,13 +267,13 @@ class EqLogicAjax extends BaseAjax
     public function simpleSave()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $eqLogicSave = json_decode(Utils::init('eqLogic'), true);
-        $eqLogic = EqLogicManager::byId($eqLogicSave['id']);
+        $eqLogicSave = json_decode(Utils::init(NextDomObj::EQLOGIC), true);
+        $eqLogic = EqLogicManager::byId($eqLogicSave[Common::ID]);
         if (!is_object($eqLogic)) {
-            throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID ') . $eqLogicSave['id']);
+            throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID ') . $eqLogicSave[Common::ID]);
         }
 
-        if (!$eqLogic->hasRight('w')) {
+        if (!$eqLogic->hasRight(ActionRight::WRITE)) {
             throw new CoreException(__('Vous n\'êtes pas autorisé à faire cette action'));
         }
         Utils::a2o($eqLogic, $eqLogicSave);
@@ -275,7 +284,7 @@ class EqLogicAjax extends BaseAjax
     public function copy()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $eqLogic = EqLogicManager::byId(Utils::init('id'));
+        $eqLogic = EqLogicManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($eqLogic)) {
             throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID'));
         }
@@ -288,11 +297,11 @@ class EqLogicAjax extends BaseAjax
     public function remove()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $eqLogic = EqLogicManager::byId(Utils::init('id'));
+        $eqLogic = EqLogicManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($eqLogic)) {
-            throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID ') . Utils::init('id'));
+            throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID ') . Utils::init(AjaxParams::ID));
         }
-        if (!$eqLogic->hasRight('w')) {
+        if (!$eqLogic->hasRight(ActionRight::WRITE)) {
             throw new CoreException(__('Vous n\'êtes pas autorisé à faire cette action'));
         }
         $eqLogic->remove();
@@ -301,44 +310,44 @@ class EqLogicAjax extends BaseAjax
 
     public function get()
     {
-        $typeEqLogic = Utils::init('type');
+        $typeEqLogic = Utils::init(AjaxParams::TYPE);
         if ($typeEqLogic == '' || !class_exists($typeEqLogic)) {
             throw new CoreException(__('Type incorrect (classe équipement inexistante) : ') . $typeEqLogic);
         }
-        $eqLogic = $typeEqLogic::byId(Utils::init('id'));
+        $eqLogic = $typeEqLogic::byId(Utils::init(AjaxParams::ID));
         if (!is_object($eqLogic)) {
-            throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID ') . Utils::init('id'));
+            throw new CoreException(__('EqLogic inconnu. Vérifiez l\'ID ') . Utils::init(AjaxParams::ID));
         }
-        $return = Utils::o2a($eqLogic);
-        $return['cmd'] = Utils::o2a($eqLogic->getCmd());
-        $this->ajax->success(NextDomHelper::toHumanReadable($return));
+        $result = Utils::o2a($eqLogic);
+        $result[NextDomObj::CMD] = Utils::o2a($eqLogic->getCmd());
+        $this->ajax->success(NextDomHelper::toHumanReadable($result));
     }
 
     public function save()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
 
-        $eqLogicsSave = json_decode(Utils::init('eqLogic'), true);
+        $eqLogicsSave = json_decode(Utils::init(NextDomObj::EQLOGIC), true);
 
         foreach ($eqLogicsSave as $eqLogicSave) {
             try {
                 if (!is_array($eqLogicSave)) {
                     throw new CoreException(__('Informations reçues incorrectes'));
                 }
-                $typeEqLogic = Utils::init('type');
-                $typeCmd = $typeEqLogic . 'Cmd';
+                $typeEqLogic = Utils::init(AjaxParams::TYPE);
+                $typeCmd = $typeEqLogic . NextDomObj::CMD;
                 if ($typeEqLogic == '' || !class_exists($typeEqLogic) || !class_exists($typeCmd)) {
                     throw new CoreException(__('Type incorrect, (classe commande inexistante)') . $typeCmd);
                 }
                 $eqLogic = null;
-                if (isset($eqLogicSave['id'])) {
-                    $eqLogic = $typeEqLogic::byId($eqLogicSave['id']);
+                if (isset($eqLogicSave[Common::ID])) {
+                    $eqLogic = $typeEqLogic::byId($eqLogicSave[Common::ID]);
                 }
                 if (!is_object($eqLogic)) {
                     $eqLogic = new $typeEqLogic();
-                    $eqLogic->setEqType_name(Utils::init('type'));
+                    $eqLogic->setEqType_name(Utils::init(AjaxParams::TYPE));
                 } else {
-                    if (!$eqLogic->hasRight('w')) {
+                    if (!$eqLogic->hasRight(ActionRight::WRITE)) {
                         throw new CoreException(__('Vous n\'êtes pas autorisé à faire cette action'));
                     }
                 }
@@ -349,14 +358,14 @@ class EqLogicAjax extends BaseAjax
                 Utils::a2o($eqLogic, $eqLogicSave);
                 $dbList = $typeCmd::byEqLogicId($eqLogic->getId());
                 $eqLogic->save();
-                $enableList = array();
+                $enableList = [];
 
-                if (isset($eqLogicSave['cmd'])) {
+                if (isset($eqLogicSave[NextDomObj::CMD])) {
                     $cmd_order = 0;
-                    foreach ($eqLogicSave['cmd'] as $cmd_info) {
+                    foreach ($eqLogicSave[NextDomObj::CMD] as $cmd_info) {
                         $cmd = null;
-                        if (isset($cmd_info['id'])) {
-                            $cmd = $typeCmd::byId($cmd_info['id']);
+                        if (isset($cmd_info[Common::ID])) {
+                            $cmd = $typeCmd::byId($cmd_info[Common::ID]);
                         }
                         if (!is_object($cmd)) {
                             $cmd = new $typeCmd();
@@ -379,9 +388,9 @@ class EqLogicAjax extends BaseAjax
                 }
             } catch (\Exception $e) {
                 if (strpos($e->getMessage(), '[MySQL] Error code : 23000') !== false) {
-                    if ($e->getTrace()[2]['class'] == 'eqLogic') {
+                    if ($e->getTrace()[2]['class'] == NextDomObj::EQLOGIC) {
                         throw new CoreException(__('Un équipement portant ce nom (') . $e->getTrace()[0]['args'][1]['name'] . __(') existe déjà pour cet objet'));
-                    } elseif ($e->getTrace()[2]['class'] == 'cmd') {
+                    } elseif ($e->getTrace()[2]['class'] == NextDomObj::CMD) {
                         throw new CoreException(__('Une commande portant ce nom (') . $e->getTrace()[0]['args'][1]['name'] . __(') existe déjà pour cet équipement'));
                     }
                 } else {
@@ -395,12 +404,12 @@ class EqLogicAjax extends BaseAjax
 
     public function getAlert()
     {
-        $alerts = array();
+        $alerts = [];
         foreach (EqLogicManager::all() as $eqLogic) {
             if ($eqLogic->getAlert() == '') {
                 continue;
             }
-            $alerts[] = $eqLogic->toHtml(Utils::init('version'));
+            $alerts[] = $eqLogic->toHtml(Utils::init(AjaxParams::VERSION));
         }
         $this->ajax->success($alerts);
     }

--- a/src/Ajax/InteractAjax.php
+++ b/src/Ajax/InteractAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\NextDomHelper;
@@ -60,7 +61,7 @@ class InteractAjax extends BaseAjax
 
     public function byId()
     {
-        $result = Utils::o2a(InteractDefManager::byId(Utils::init('id')));
+        $result = Utils::o2a(InteractDefManager::byId(Utils::init(AjaxParams::ID)));
         $result['nbInteractQuery'] = count(InteractQueryManager::byInteractDefId($result['id']));
         $result['nbEnableInteractQuery'] = count(InteractQueryManager::byInteractDefId($result['id']));
         $this->ajax->success(NextDomHelper::toHumanReadable($result));
@@ -88,7 +89,7 @@ class InteractAjax extends BaseAjax
 
     public function remove()
     {
-        $interact = InteractDefManager::byId(Utils::init('id'));
+        $interact = InteractDefManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($interact)) {
             throw new CoreException(__('Interaction inconnue. Vérifiez l\'ID'));
         }
@@ -98,21 +99,21 @@ class InteractAjax extends BaseAjax
 
     public function changeState()
     {
-        $interactQuery = InteractQueryManager::byId(Utils::init('id'));
+        $interactQuery = InteractQueryManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($interactQuery)) {
             throw new CoreException(__('InteractQuery ID inconnu'));
         }
-        $interactQuery->setEnable(Utils::init('enable'));
+        $interactQuery->setEnable(Utils::init(AjaxParams::ENABLE));
         $interactQuery->save();
         $this->ajax->success();
     }
 
     public function changeAllState()
     {
-        $interactQueries = InteractQueryManager::byInteractDefId(Utils::init('id'));
+        $interactQueries = InteractQueryManager::byInteractDefId(Utils::init(AjaxParams::ID));
         if (is_array($interactQueries)) {
             foreach ($interactQueries as $interactQuery) {
-                $interactQuery->setEnable(Utils::init('enable'));
+                $interactQuery->setEnable(Utils::init(AjaxParams::ENABLE));
                 $interactQuery->save();
             }
         }

--- a/src/Ajax/ListenerAjax.php
+++ b/src/Ajax/ListenerAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\NextDomHelper;
@@ -41,7 +42,7 @@ class ListenerAjax extends BaseAjax
 
     public function remove()
     {
-        $listener = ListenerManager::byId(Utils::init('id'));
+        $listener = ListenerManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($listener)) {
             throw new CoreException(__('Listerner id inconnu'));
         }

--- a/src/Ajax/LogAjax.php
+++ b/src/Ajax/LogAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Helpers\LogHelper;
 use NextDom\Helpers\Utils;
@@ -33,19 +34,19 @@ class LogAjax extends BaseAjax
 
     public function clear()
     {
-        LogHelper::clear(Utils::init('log'));
+        LogHelper::clear(Utils::init(AjaxParams::LOG));
         $this->ajax->success();
     }
 
     public function remove()
     {
-        LogHelper::remove(Utils::init('log'));
+        LogHelper::remove(Utils::init(AjaxParams::LOG));
         $this->ajax->success();
     }
 
     public function list()
     {
-        $this->ajax->success(LogHelper::liste());
+        $this->ajax->success(LogHelper::getLogFileList());
     }
 
     public function removeAll()
@@ -56,6 +57,6 @@ class LogAjax extends BaseAjax
 
     public function get()
     {
-        $this->ajax->success(LogHelper::get(Utils::init('log'), Utils::init('start', 0), Utils::init('nbLine', 99999)));
+        $this->ajax->success(LogHelper::get(Utils::init(AjaxParams::LOG), Utils::init(AjaxParams::START, 0), Utils::init('nbLine', 99999)));
     }
 }

--- a/src/Ajax/MessageAjax.php
+++ b/src/Ajax/MessageAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Utils;
@@ -34,7 +35,7 @@ class MessageAjax extends BaseAjax
 
     public function clearMessage()
     {
-        MessageManager::removeAll(Utils::init('plugin'));
+        MessageManager::removeAll(Utils::init(AjaxParams::PLUGIN));
         $this->ajax->success();
     }
 
@@ -45,10 +46,10 @@ class MessageAjax extends BaseAjax
 
     public function all()
     {
-        if (Utils::init('plugin') == '') {
+        if (Utils::init(AjaxParams::PLUGIN) == '') {
             $messages = Utils::o2a(MessageManager::all());
         } else {
-            $messages = Utils::o2a(MessageManager::byPlugin(Utils::init('plugin')));
+            $messages = Utils::o2a(MessageManager::byPlugin(Utils::init(AjaxParams::PLUGIN)));
         }
         foreach ($messages as &$message) {
             $message['message'] = htmlentities($message['message']);
@@ -58,7 +59,7 @@ class MessageAjax extends BaseAjax
 
     public function removeMessage()
     {
-        $message = MessageManager::byId(Utils::init('id'));
+        $message = MessageManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($message)) {
             throw new CoreException(__('Message inconnu. Vérifiez l\'ID'));
         }

--- a/src/Ajax/NextDomMarketAjax.php
+++ b/src/Ajax/NextDomMarketAjax.php
@@ -18,6 +18,7 @@
 namespace NextDom\Ajax;
 
 use NextDom\Enums\UserRight;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Utils;
 use NextDom\Market\DownloadManager;
 use NextDom\Market\MarketItem;
@@ -78,7 +79,7 @@ class NextDomMarketAjax extends BaseAjax
                 $market->refresh($force);
             }
         } else {
-            throw new \Exception('Aucune source configurée');
+            throw new CoreException('Aucune source configurée');
         }
         return $result;
     }

--- a/src/Ajax/NoteAjax.php
+++ b/src/Ajax/NoteAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Utils;
@@ -40,7 +41,7 @@ class NoteAjax extends BaseAjax
 
     public function byId()
     {
-        $this->ajax->success(Utils::o2a(NoteManager::byId(Utils::init('id'))));
+        $this->ajax->success(Utils::o2a(NoteManager::byId(Utils::init(AjaxParams::ID))));
     }
 
     public function save()
@@ -62,7 +63,7 @@ class NoteAjax extends BaseAjax
 
     public function remove()
     {
-        $note = NoteManager::byId(Utils::init('id'));
+        $note = NoteManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($note)) {
             throw new CoreException(__('Note inconnue. Vérifiez l\'ID'));
         }

--- a/src/Ajax/Plan3dAjax.php
+++ b/src/Ajax/Plan3dAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\AuthentificationHelper;
@@ -57,7 +58,7 @@ class Plan3dAjax extends BaseAjax
 
     public function plan3dHeader()
     {
-        $return = array();
+        $return = [];
         /**
          * @var Plan3d $plan3d
          */
@@ -73,17 +74,17 @@ class Plan3dAjax extends BaseAjax
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
         if (Utils::init('plan3d', '') === '') {
-            throw new CoreException(__('L\'identifiant du plan doit être fourni', __FILE__));
+            throw new CoreException(__('L\'identifiant du plan doit être fourni'));
         }
         $plan3d = new Plan3d();
         Utils::a2o($plan3d, json_decode(Utils::init('plan3d'), true));
         $plan3d->save();
-        $this->ajax->success($plan3d->getHtml(Utils::init('version')));
+        $this->ajax->success($plan3d->getHtml(Utils::init(AjaxParams::VERSION)));
     }
 
     public function get()
     {
-        $plan3d = Plan3dManager::byId(Utils::init('id'));
+        $plan3d = Plan3dManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($plan3d)) {
             throw new CoreException(__('Aucun plan3d correspondant'));
         }
@@ -94,7 +95,7 @@ class Plan3dAjax extends BaseAjax
 
     public function byName()
     {
-        $plan3d = Plan3dManager::byName3dHeaderId(Utils::init('name'), Utils::init('plan3dHeader_id'));
+        $plan3d = Plan3dManager::byName3dHeaderId(Utils::init(AjaxParams::NAME), Utils::init('plan3dHeader_id'));
         if (!is_object($plan3d)) {
             $this->ajax->success();
         }
@@ -104,7 +105,7 @@ class Plan3dAjax extends BaseAjax
     public function remove()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $plan3d = Plan3dManager::byId(Utils::init('id'));
+        $plan3d = Plan3dManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($plan3d)) {
             throw new CoreException(__('Aucun plan3d correspondant'));
         }
@@ -114,7 +115,7 @@ class Plan3dAjax extends BaseAjax
     public function removeplan3dHeader()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $plan3dHeader = Plan3dHeaderManager::byId(Utils::init('id'));
+        $plan3dHeader = Plan3dHeaderManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($plan3dHeader)) {
             throw new CoreException(__('Objet inconnu verifiez l\'id'));
         }
@@ -125,7 +126,7 @@ class Plan3dAjax extends BaseAjax
     public function allHeader()
     {
         $plan3dHeaders = Plan3dHeaderManager::all();
-        $return = array();
+        $return = [];
         foreach ($plan3dHeaders as $plan3dHeader) {
             $info_plan3dHeader = Utils::o2a($plan3dHeader);
             unset($info_plan3dHeader['image']);
@@ -136,9 +137,9 @@ class Plan3dAjax extends BaseAjax
 
     public function getplan3dHeader()
     {
-        $plan3dHeader = Plan3dHeaderManager::byId(Utils::init('id'));
+        $plan3dHeader = Plan3dHeaderManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($plan3dHeader)) {
-            throw new CoreException(__('plan3d header inconnu verifiez l\'id : ') . Utils::init('id'));
+            throw new CoreException(__('plan3d header inconnu verifiez l\'id : ') . Utils::init(AjaxParams::ID));
         }
         if (trim($plan3dHeader->getConfiguration('accessCode', '')) != '' && $plan3dHeader->getConfiguration('accessCode', '') != sha512(Utils::init('code'))) {
             throw new CoreException(__('Code d\'acces invalide'), -32005);
@@ -167,12 +168,12 @@ class Plan3dAjax extends BaseAjax
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
         $uploadDir = '/tmp';
-        $plan3dHeader = Plan3dHeaderManager::byId(Utils::init('id'));
+        $plan3dHeader = Plan3dHeaderManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($plan3dHeader)) {
             throw new CoreException(__('Objet inconnu. Vérifiez l\'ID'));
         }
 
-        $filename = Utils::readUploadedFile($_FILES, "file", $uploadDir, 150, array(".zip"));
+        $filename = Utils::readUploadedFile($_FILES, "file", $uploadDir, 150, [".zip"]);
 
         if ($plan3dHeader->getConfiguration('path') == '') {
             $path = sprintf("%s/data/3d/%s/", NEXTDOM_DATA, ConfigManager::genKey());
@@ -193,12 +194,12 @@ class Plan3dAjax extends BaseAjax
         } else {
             throw new CoreException(__('Impossible de décompresser l\'archive zip : ') . $filename . ' => ' . ZipErrorMessage($res));
         }
-        $objfile = FileSystemHelper::ls($cibDir, '*.obj', false, array('files'));
+        $objfile = FileSystemHelper::ls($cibDir, '*.obj', false, ['files']);
         if (count($objfile) != 1) {
             throw new CoreException(__('Il faut 1 seul et unique fichier .obj'));
         }
         $plan3dHeader->setConfiguration('objfile', $objfile[0]);
-        $mtlfile = FileSystemHelper::ls($cibDir, '*.mtl', false, array('files'));
+        $mtlfile = FileSystemHelper::ls($cibDir, '*.mtl', false, ['files']);
         if (count($mtlfile) == 1) {
             $plan3dHeader->setConfiguration('mtlfile', $mtlfile[0]);
         }

--- a/src/Ajax/PlanAjax.php
+++ b/src/Ajax/PlanAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\AuthentificationHelper;
@@ -55,7 +56,7 @@ class PlanAjax extends BaseAjax
 
     public function execute()
     {
-        $plan = PlanManager::byId(Utils::init('id'));
+        $plan = PlanManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($plan)) {
             throw new CoreException(__('Aucun plan correspondant'));
         }
@@ -64,12 +65,12 @@ class PlanAjax extends BaseAjax
 
     public function planHeader()
     {
-        $return = array();
+        $return = [];
         /**
          * @var Plan $plan
          */
         foreach (PlanManager::byPlanHeaderId(Utils::init('planHeader_id')) as $plan) {
-            $result = $plan->getHtml(Utils::init('version'));
+            $result = $plan->getHtml(Utils::init(AjaxParams::VERSION));
             if (is_array($result)) {
                 $return[] = $result;
             }
@@ -81,27 +82,27 @@ class PlanAjax extends BaseAjax
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
         if (Utils::init('plan', '') === '') {
-            throw new CoreException(__('L\'identifiant du plan doit être fourni', __FILE__));
+            throw new CoreException(__('L\'identifiant du plan doit être fourni'));
         }
         $plan = new Plan();
         Utils::a2o($plan, json_decode(Utils::init('plan'), true));
         $plan->save();
-        $this->ajax->success($plan->getHtml(Utils::init('version')));
+        $this->ajax->success($plan->getHtml(Utils::init(AjaxParams::VERSION)));
     }
 
     public function copy()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $plan = PlanManager::byId(Utils::init('id'));
+        $plan = PlanManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($plan)) {
             throw new CoreException(__('Aucun plan correspondant'));
         }
-        $this->ajax->success($plan->copy()->getHtml(Utils::init('version', 'dplan')));
+        $this->ajax->success($plan->copy()->getHtml(Utils::init(AjaxParams::VERSION, 'dplan')));
     }
 
     public function get()
     {
-        $plan = PlanManager::byId(Utils::init('id'));
+        $plan = PlanManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($plan)) {
             throw new CoreException(__('Aucun plan correspondant'));
         }
@@ -111,7 +112,7 @@ class PlanAjax extends BaseAjax
     public function remove()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $plan = PlanManager::byId(Utils::init('id'));
+        $plan = PlanManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($plan)) {
             throw new CoreException(__('Aucun plan correspondant'));
         }
@@ -121,7 +122,7 @@ class PlanAjax extends BaseAjax
     public function removePlanHeader()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $planHeader = PlanHeaderManager::byId(Utils::init('id'));
+        $planHeader = PlanHeaderManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($planHeader)) {
             throw new CoreException(__('Objet inconnu. Vérifiez l\'ID'));
         }
@@ -132,27 +133,27 @@ class PlanAjax extends BaseAjax
     public function allHeader()
     {
         $planHeaders = PlanHeaderManager::all();
-        $return = array();
+        $result = [];
         foreach ($planHeaders as $planHeader) {
             $info_planHeader = Utils::o2a($planHeader);
             unset($info_planHeader['image']);
-            $return[] = $info_planHeader;
+            $result[] = $info_planHeader;
         }
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     public function getPlanHeader()
     {
-        $planHeader = PlanHeaderManager::byId(Utils::init('id'));
+        $planHeader = PlanHeaderManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($planHeader)) {
-            throw new CoreException(__('Plan header inconnu. Vérifiez l\'ID ') . Utils::init('id'));
+            throw new CoreException(__('Plan header inconnu. Vérifiez l\'ID ') . Utils::init(AjaxParams::ID));
         }
         if (trim($planHeader->getConfiguration('accessCode', '')) != '' && $planHeader->getConfiguration('accessCode', '') != sha512(Utils::init('code'))) {
             throw new CoreException(__('Code d\'acces invalide'), -32005);
         }
-        $return = Utils::o2a($planHeader);
-        $return['image'] = $planHeader->displayImage();
-        $this->ajax->success($return);
+        $result = Utils::o2a($planHeader);
+        $result['image'] = $planHeader->displayImage();
+        $this->ajax->success($result);
     }
 
     public function savePlanHeader()
@@ -174,9 +175,9 @@ class PlanAjax extends BaseAjax
     public function copyPlanHeader()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $planHeader = PlanHeaderManager::byId(Utils::init('id'));
+        $planHeader = PlanHeaderManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($planHeader)) {
-            throw new CoreException(__('Plan header inconnu. Vérifiez l\'ID ') . Utils::init('id'));
+            throw new CoreException(__('Plan header inconnu. Vérifiez l\'ID ') . Utils::init(AjaxParams::ID));
         }
         $this->ajax->success(Utils::o2a($planHeader->copy(Utils::init('name'))));
     }
@@ -184,9 +185,9 @@ class PlanAjax extends BaseAjax
     public function removeImageHeader()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $planHeader = PlanHeaderManager::byId(Utils::init('id'));
+        $planHeader = PlanHeaderManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($planHeader)) {
-            throw new CoreException(__('Plan header inconnu. Vérifiez l\'ID ') . Utils::init('id'));
+            throw new CoreException(__('Plan header inconnu. Vérifiez l\'ID ') . Utils::init(AjaxParams::ID));
         }
         $filename = 'planHeader' . $planHeader->getId() . '-' . $planHeader->getImage('sha512') . '.' . $planHeader->getImage('type');
         $planHeader->setImage('sha512', '');
@@ -198,7 +199,7 @@ class PlanAjax extends BaseAjax
     public function uploadImage()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $planHeader = PlanHeaderManager::byId(Utils::init('id'));
+        $planHeader = PlanHeaderManager::byId(Utils::init(AjaxParams::ID));
         if (!is_dir(NEXTDOM_DATA . '/data/custom/plans/')) {
             mkdir(NEXTDOM_DATA . '/data/custom/plans/');
         }
@@ -209,7 +210,7 @@ class PlanAjax extends BaseAjax
             throw new CoreException(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)'));
         }
         $extension = strtolower(strrchr($_FILES['file']['name'], '.'));
-        if (!in_array($extension, array('.jpg', '.jpeg', '.png'))) {
+        if (!in_array($extension, ['.jpg', '.jpeg', '.png'])) {
             throw new CoreException('Extension du fichier non valide (autorisé .jpg .jpeg .png) : ' . $extension);
         }
         if (filesize($_FILES['file']['tmp_name']) > 5000000) {
@@ -232,7 +233,7 @@ class PlanAjax extends BaseAjax
         $filepath = NEXTDOM_DATA . '/data/custom/plans/' . $filename;
         copy($_FILES['file']['tmp_name'], $filepath);
         if (!file_exists($filepath)) {
-            throw new CoreException(__('Impossible de sauvegarder l\'image', __FILE__));
+            throw new CoreException(__('Impossible de sauvegarder l\'image'));
         }
         $planHeader->setConfiguration('desktopSizeX', $imgSize[0]);
         $planHeader->setConfiguration('desktopSizeY', $imgSize[1]);
@@ -243,14 +244,14 @@ class PlanAjax extends BaseAjax
     public function uploadImagePlan()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $plan = PlanManager::byId(Utils::init('id'));
+        $plan = PlanManager::byId(Utils::init(AjaxParams::ID));
         if (false == is_object($plan)) {
             throw new CoreException(__('Objet inconnu. Vérifiez l\'ID'));
         }
         $uploadDir = sprintf("%s/data/custom/plans/plan_%s", NEXTDOM_DATA, $plan->getId());
         shell_exec('rm -rf ' . $uploadDir);
         mkdir($uploadDir, 0775, true);
-        $filename = Utils::readUploadedFile($_FILES, "file", $uploadDir, 5, array('.png', '.jpeg', '.jpg'), function ($file) {
+        $filename = Utils::readUploadedFile($_FILES, "file", $uploadDir, 5, ['.png', '.jpeg', '.jpg'], function ($file) {
             $content = file_get_contents($file['tmp_name']);
             return sha512(base64_encode($content));
         });

--- a/src/Ajax/ProfilsAjax.php
+++ b/src/Ajax/ProfilsAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Helpers\Utils;
 
@@ -33,7 +34,7 @@ class ProfilsAjax extends BaseAjax
     public function removeImage()
     {
         $uploaddir = sprintf("%s/public/img/profils", NEXTDOM_ROOT);
-        $pathInfo = pathinfo(init('image'));
+        $pathInfo = pathinfo(Utils::init(AjaxParams::IMAGE));
         $extension = Utils::array_key_default($pathInfo, "extension", "<no-ext>");
         $path = sprintf("%s/%s.%s", $uploaddir, $pathInfo['basename'], $extension);
         $this->ajax->success(unlink($path));
@@ -42,7 +43,7 @@ class ProfilsAjax extends BaseAjax
     public function imageUpload()
     {
         $uploadDir = sprintf("%s/public/img/profils", NEXTDOM_ROOT);
-        Utils::readUploadedFile($_FILES, "images", $uploadDir, 8, array('.png', '.jpg', '.jpeg'));
+        Utils::readUploadedFile($_FILES, "images", $uploadDir, 8, ['.png', '.jpg', '.jpeg']);
         $this->ajax->success();
     }
 }

--- a/src/Ajax/RepoAjax.php
+++ b/src/Ajax/RepoAjax.php
@@ -17,6 +17,8 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
+use NextDom\Enums\Common;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Utils;
@@ -36,70 +38,70 @@ class RepoAjax extends BaseAjax
 
     public function uploadCloud()
     {
-        RepoMarket::backup_send(Utils::init('backup'));
+        RepoMarket::backup_send(Utils::init(AjaxParams::BACKUP));
         $this->ajax->success();
     }
 
     public function restoreCloud()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
-            $repoClassData['phpClass']::backup_restore(Utils::init('backup'));
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
+            $repoClassData[Common::PHP_CLASS]::backup_restore(Utils::init(AjaxParams::BACKUP));
             $this->ajax->success();
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 
     public function sendReportBug()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
-            $this->ajax->success($repoClassData['phpClass']::saveTicket(json_decode(Utils::init('ticket'), true)));
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
+            $this->ajax->success($repoClassData[Common::PHP_CLASS]::saveTicket(json_decode(Utils::init('ticket'), true)));
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 
     public function install()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
-            $repo = $repoClassData['phpClass']::byId(Utils::init('id'));
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
+            $repo = $repoClassData[Common::PHP_CLASS]::byId(Utils::init(AjaxParams::ID));
             if (!is_object($repo)) {
-                throw new CoreException(__('Impossible de trouver l\'objet associé : ', __FILE__) . Utils::init('id'));
+                throw new CoreException(__('Impossible de trouver l\'objet associé : ') . Utils::init(AjaxParams::ID));
             }
             $update = UpdateManager::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
             if (!is_object($update)) {
                 $update = new Update();
             }
-            $update->setSource(Utils::init('repo'));
+            $update->setSource(Utils::initStr(AjaxParams::REPO));
             $update->setLogicalId($repo->getLogicalId());
             $update->setType($repo->getType());
-            $update->setLocalVersion($repo->getDatetime(Utils::init('version', 'stable')));
-            $update->setConfiguration('version', Utils::init('version', 'stable'));
+            $update->setLocalVersion($repo->getDatetime(Utils::init(AjaxParams::VERSION, 'stable')));
+            $update->setConfiguration('version', Utils::init(AjaxParams::VERSION, 'stable'));
             $update->save();
             $update->doUpdate();
             $this->ajax->success();
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 
     public function test()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
-            $repoClassData['phpClass']::test();
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
+            $repoClassData[Common::PHP_CLASS]::test();
             $this->ajax->success();
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 
     public function remove()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
-            $repo = $repoClassData['phpClass']::byId(Utils::init('id'));
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
+            $repo = $repoClassData[Common::PHP_CLASS]::byId(Utils::init(AjaxParams::ID));
             if (!is_object($repo)) {
-                throw new CoreException(__('Impossible de trouver l\'objet associé : ', __FILE__) . Utils::init('id'));
+                throw new CoreException(__('Impossible de trouver l\'objet associé : ') . Utils::init(AjaxParams::ID));
             }
             $update = UpdateManager::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
             try {
@@ -115,72 +117,72 @@ class RepoAjax extends BaseAjax
             }
             $this->ajax->success();
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 
     public function save()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
             $repo_ajax = json_decode(Utils::init('market'), true);
             try {
-                $repo = $repoClassData['phpClass']::byId($repo_ajax['id']);
+                $repo = $repoClassData[Common::PHP_CLASS]::byId($repo_ajax['id']);
             } catch (\Exception $e) {
-                $repo = new $repoClassData['phpClass']();
+                $repo = new $repoClassData[Common::PHP_CLASS]();
             }
             Utils::a2o($repo, $repo_ajax);
             $repo->save();
             $this->ajax->success();
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 
     public function getInfo()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
-            $this->ajax->success($repoClassData['phpClass']::getInfo(Utils::init('logicalId')));
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
+            $this->ajax->success($repoClassData[Common::PHP_CLASS]::getInfo(Utils::init(AjaxParams::LOGICAL_ID)));
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 
     public function byLogicalId()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
             if (Utils::init('noExecption', 0) == 1) {
                 try {
-                    $this->ajax->success(Utils::o2a($repoClassData['phpClass']::byLogicalIdAndType(Utils::init('logicalId'), Utils::init('type'))));
+                    $this->ajax->success(Utils::o2a($repoClassData[Common::PHP_CLASS]::byLogicalIdAndType(Utils::init(AjaxParams::LOGICAL_ID), Utils::init(AjaxParams::TYPE))));
                 } catch (\Exception $e) {
                     $this->ajax->success();
                 }
             } else {
-                $this->ajax->success(Utils::o2a($repoClassData['phpClass']::byLogicalIdAndType(Utils::init('logicalId'), Utils::init('type'))));
+                $this->ajax->success(Utils::o2a($repoClassData[Common::PHP_CLASS]::byLogicalIdAndType(Utils::init(AjaxParams::LOGICAL_ID), Utils::init(AjaxParams::TYPE))));
             }
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 
     public function setRating()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
-            $repo = $repoClassData['phpClass']::byId(Utils::init('id'));
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
+            $repo = $repoClassData[Common::PHP_CLASS]::byId(Utils::init(AjaxParams::ID));
             if (!is_object($repo)) {
-                throw new CoreException(__('Impossible de trouver l\'objet associé : ') . Utils::init('id'));
+                throw new CoreException(__('Impossible de trouver l\'objet associé : ') . Utils::init(AjaxParams::ID));
             }
             $repo->setRating(Utils::init('rating'));
             $this->ajax->success();
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 
     public function backupList()
     {
-        $repoClassData = UpdateManager::getRepoDataFromName(Utils::init('repo'));
-        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData['className'] . '.php')) {
-            $this->ajax->success($repoClassData['phpClass']::backup_list());
+        $repoClassData = UpdateManager::getRepoDataFromName(Utils::initStr(AjaxParams::REPO));
+        if (file_exists(NEXTDOM_ROOT . '/src/Repo/' . $repoClassData[Common::CLASS_NAME] . '.php')) {
+            $this->ajax->success($repoClassData[Common::PHP_CLASS]::backup_list());
         }
-        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData['className']));
+        $this->ajax->error(__('Le repo n\'existe pas : ' . $repoClassData[Common::CLASS_NAME]));
     }
 }

--- a/src/Ajax/ReportAjax.php
+++ b/src/Ajax/ReportAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\FileSystemHelper;
@@ -34,27 +35,27 @@ class ReportAjax extends BaseAjax
 
     public function list()
     {
-        $return = array();
-        $path = NEXTDOM_DATA . '/data/report/' . Utils::init('type') . '/' . Utils::init('id') . '/';
+        $return = [];
+        $path = NEXTDOM_DATA . '/data/report/' . Utils::init('type') . '/' . Utils::init(AjaxParams::ID) . '/';
         foreach (FileSystemHelper::ls($path, '*') as $value) {
-            $return[$value] = array('name' => $value);
+            $return[$value] = ['name' => $value];
         }
         $this->ajax->success($return);
     }
 
     public function get()
     {
-        $path = NEXTDOM_DATA . '/data/report/' . Utils::init('type') . '/' . Utils::init('id') . '/' . Utils::init('report');
+        $path = NEXTDOM_DATA . '/data/report/' . Utils::init('type') . '/' . Utils::init(AjaxParams::ID) . '/' . Utils::init('report');
         $return = pathinfo($path);
         $return['path'] = $path;
         $return['type'] = Utils::init('type');
-        $return['id'] = Utils::init('id');
+        $return['id'] = Utils::init(AjaxParams::ID);
         $this->ajax->success($return);
     }
 
     public function remove()
     {
-        $path = NEXTDOM_DATA . '/data/report/' . Utils::init('type') . '/' . Utils::init('id') . '/' . Utils::init('report');
+        $path = NEXTDOM_DATA . '/data/report/' . Utils::init('type') . '/' . Utils::init(AjaxParams::ID) . '/' . Utils::init('report');
         if (file_exists($path)) {
             unlink($path);
         }
@@ -66,7 +67,7 @@ class ReportAjax extends BaseAjax
 
     public function removeAll()
     {
-        $path = NEXTDOM_DATA . '/data/report/' . Utils::init('type') . '/' . Utils::init('id') . '/';
+        $path = NEXTDOM_DATA . '/data/report/' . Utils::init('type') . '/' . Utils::init(AjaxParams::ID) . '/';
         foreach (FileSystemHelper::ls($path, '*') as $value) {
             unlink($path . $value);
         }

--- a/src/Ajax/ScenarioAjax.php
+++ b/src/Ajax/ScenarioAjax.php
@@ -106,15 +106,15 @@ class ScenarioAjax extends BaseAjax
 
     public function testExpression()
     {
-        $return = [];
+        $result = [];
         $scenario = null;
-        $return['evaluate'] = ScenarioExpressionManager::setTags(NextDomHelper::fromHumanReadable(Utils::init(AjaxParams::EXPRESSION)), $scenario, true);
-        $return['result'] = Utils::evaluate($return['evaluate']);
-        $return['correct'] = 'ok';
-        if (trim($return['result']) == trim($return['evaluate'])) {
-            $return['correct'] = 'nok';
+        $result['evaluate'] = ScenarioExpressionManager::setTags(NextDomHelper::fromHumanReadable(Utils::init(AjaxParams::EXPRESSION)), $scenario, true);
+        $result['result'] = Utils::evaluate($result['evaluate']);
+        $result['correct'] = 'ok';
+        if (trim($result['result']) == trim($result['evaluate'])) {
+            $result['correct'] = 'nok';
         }
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     public function getTemplate()
@@ -162,17 +162,17 @@ class ScenarioAjax extends BaseAjax
         if (!file_exists($templateFile)) {
             throw new CoreException('Fichier non trouvé : ' . $templateFile);
         }
-        $return = [];
+        $result = [];
         foreach (preg_split("/((\r?\n)|(\r\n?))/", file_get_contents($templateFile)) as $line) {
             preg_match_all("/#\[(.*?)\]\[(.*?)\]\[(.*?)\]#/", $line, $matches, PREG_SET_ORDER);
             if (count($matches) > 0) {
                 foreach ($matches as $match) {
-                    $return[$match[0]] = '';
+                    $result[$match[0]] = '';
                     $cmd = null;
                     try {
                         $cmd = CmdManager::byString($match[0]);
                         if (is_object($cmd)) {
-                            $return[$match[0]] = '#' . $cmd->getHumanName() . '#';
+                            $result[$match[0]] = '#' . $cmd->getHumanName() . '#';
                         }
                     } catch (\Exception $e) {
 
@@ -182,11 +182,11 @@ class ScenarioAjax extends BaseAjax
             preg_match_all("/#\[(.*?)\]\[(.*?)\]#/", $line, $matches, PREG_SET_ORDER);
             if (count($matches) > 0) {
                 foreach ($matches as $match) {
-                    $return[$match[0]] = '';
+                    $result[$match[0]] = '';
                     try {
                         $eqLogic = EqLogicManager::byString($match[0]);
                         if (is_object($eqLogic)) {
-                            $return[$match[0]] = '#' . $eqLogic->getHumanName() . '#';
+                            $result[$match[0]] = '#' . $eqLogic->getHumanName() . '#';
                         }
                     } catch (\Exception $e) {
 
@@ -196,11 +196,11 @@ class ScenarioAjax extends BaseAjax
             preg_match_all("/variable\((.*?)\)/", $line, $matches, PREG_SET_ORDER);
             if (count($matches) > 0) {
                 foreach ($matches as $match) {
-                    $return[$match[1]] = $match[1];
+                    $result[$match[1]] = $match[1];
                 }
             }
         }
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     public function applyTemplate()
@@ -249,13 +249,13 @@ class ScenarioAjax extends BaseAjax
     public function all()
     {
         $scenarios = ScenarioManager::all();
-        $return = [];
+        $result = [];
         foreach ($scenarios as $scenario) {
             $info_scenario = Utils::o2a($scenario);
             $info_scenario['humanName'] = $scenario->getHumanName();
-            $return[] = $info_scenario;
+            $result[] = $info_scenario;
         }
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     public function saveAll()
@@ -277,11 +277,11 @@ class ScenarioAjax extends BaseAjax
     public function autoCompleteGroup()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $return = [];
+        $result = [];
         foreach (ScenarioManager::listGroup(Utils::init('term')) as $group) {
-            $return[] = $group['group'];
+            $result[] = $group['group'];
         }
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     public function toHtml()
@@ -297,15 +297,15 @@ class ScenarioAjax extends BaseAjax
             } else {
                 $scenarios = ScenarioManager::all();
             }
-            $return = [];
+            $result = [];
             foreach ($scenarios as $scenario) {
-                $return[] = $scenario->toHtml(Utils::init('version'));
+                $result[] = $scenario->toHtml(Utils::init(AjaxParams::VERSION));
             }
-            $this->ajax->success($return);
+            $this->ajax->success($result);
         } else {
             $scenario = ScenarioManager::byId($target);
             if (is_object($scenario)) {
-                $this->ajax->success($scenario->toHtml(Utils::init('version')));
+                $this->ajax->success($scenario->toHtml(Utils::init(AjaxParams::VERSION)));
             }
         }
         $this->ajax->success();
@@ -357,15 +357,15 @@ class ScenarioAjax extends BaseAjax
         if (!is_object($scenario)) {
             throw new CoreException(__('Scénario ID inconnu'));
         }
-        $return = Utils::o2a($scenario);
-        $return['trigger'] = NextDomHelper::toHumanReadable($return['trigger']);
-        $return['forecast'] = $scenario->calculateScheduleDate();
-        $return['elements'] = [];
+        $result = Utils::o2a($scenario);
+        $result['trigger'] = NextDomHelper::toHumanReadable($result['trigger']);
+        $result['forecast'] = $scenario->calculateScheduleDate();
+        $result['elements'] = [];
         foreach ($scenario->getElement() as $element) {
-            $return['elements'][] = $element->getAjaxElement();
+            $result['elements'][] = $element->getAjaxElement();
         }
 
-        $this->ajax->success($return);
+        $this->ajax->success($result);
     }
 
     /**
@@ -454,8 +454,7 @@ class ScenarioAjax extends BaseAjax
         }
         if ($result !== null) {
             $this->ajax->success($result);
-        }
-        else {
+        } else {
             $this->ajax->success(ScenarioExpressionManager::getExpressionOptions(Utils::init(AjaxParams::EXPRESSION), Utils::init(AjaxParams::OPTION)));
         }
     }

--- a/src/Ajax/ViewAjax.php
+++ b/src/Ajax/ViewAjax.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Ajax;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\UserRight;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\AuthentificationHelper;
@@ -44,7 +45,7 @@ class ViewAjax extends BaseAjax
     public function remove()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $view = ViewManager::byId(Utils::init('id'));
+        $view = ViewManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($view)) {
             throw new CoreException(__('Vue non trouvée. Vérifiez l\'iD'));
         }
@@ -59,27 +60,27 @@ class ViewAjax extends BaseAjax
 
     public function get()
     {
-        if (Utils::init('id') == 'all' || is_json(Utils::init('id'))) {
+        if (Utils::init(AjaxParams::ID) == 'all' || is_json(Utils::init(AjaxParams::ID))) {
             $views = [];
-            if (is_json(Utils::init('id'))) {
-                $view_ajax = json_decode(Utils::init('id'), true);
+            if (is_json(Utils::init(AjaxParams::ID))) {
+                $view_ajax = json_decode(Utils::init(AjaxParams::ID), true);
                 foreach ($view_ajax as $id) {
                     $views[] = ViewManager::byId($id);
                 }
             } else {
                 $views = ViewManager::all();
             }
-            $return = array();
+            $return = [];
             foreach ($views as $view) {
-                $return[$view->getId()] = $view->toAjax(Utils::init('version', 'dview'), Utils::init('html'));
+                $return[$view->getId()] = $view->toAjax(Utils::init(AjaxParams::VERSION, 'dview'), Utils::init('html'));
             }
             $this->ajax->success($return);
         } else {
-            $view = ViewManager::byId(Utils::init('id'));
+            $view = ViewManager::byId(Utils::init(AjaxParams::ID));
             if (!is_object($view)) {
                 throw new CoreException(__('Vue non trouvée. Vérifiez l\'ID'));
             }
-            $this->ajax->success($view->toAjax(Utils::init('version', 'dview'), Utils::init('html')));
+            $this->ajax->success($view->toAjax(Utils::init(AjaxParams::VERSION, 'dview'), Utils::init(AjaxParams::HTML)));
         }
     }
 
@@ -123,13 +124,13 @@ class ViewAjax extends BaseAjax
             throw new CoreException(__('Vue non trouvée. Vérifiez l\'ID'));
         }
         $return = Utils::o2a($viewZone);
-        $return['eqLogic'] = array();
+        $return['eqLogic'] = [];
         /**
          * @var ViewData $viewData
          */
         foreach ($viewZone->getViewData() as $viewData) {
             $infoViewDatat = Utils::o2a($viewData->getLinkObject());
-            $infoViewDatat['html'] = $viewData->getLinkObject()->toHtml(Utils::init('version'));
+            $infoViewDatat['html'] = $viewData->getLinkObject()->toHtml(Utils::init(AjaxParams::VERSION));
             $return['viewData'][] = $infoViewDatat;
         }
         $this->ajax->success($return);
@@ -176,9 +177,9 @@ class ViewAjax extends BaseAjax
     public function removeImage()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $view = ViewManager::byId(Utils::init('id'));
+        $view = ViewManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($view)) {
-            throw new CoreException(__('Vue inconnu. Vérifiez l\'ID ') . Utils::init('id'));
+            throw new CoreException(__('Vue inconnu. Vérifiez l\'ID ') . Utils::init(AjaxParams::ID));
         }
         $view->setImage('sha512', '');
         $view->save();
@@ -189,7 +190,7 @@ class ViewAjax extends BaseAjax
     public function uploadImage()
     {
         AuthentificationHelper::isConnectedAsAdminOrFail();
-        $view = ViewManager::byId(Utils::init('id'));
+        $view = ViewManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($view)) {
             throw new CoreException(__('Objet inconnu. Vérifiez l\'ID'));
         }
@@ -197,7 +198,7 @@ class ViewAjax extends BaseAjax
             throw new CoreException(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)'));
         }
         $extension = strtolower(strrchr($_FILES['file']['name'], '.'));
-        if (!in_array($extension, array('.jpg', '.jpeg', '.png'))) {
+        if (!in_array($extension, ['.jpg', '.jpeg', '.png'])) {
             throw new CoreException('Extension du fichier non valide (autorisé .jpg .jpeg .png) : ' . $extension);
         }
         if (filesize($_FILES['file']['tmp_name']) > 5000000) {

--- a/src/Api/downloadFile.php
+++ b/src/Api/downloadFile.php
@@ -60,7 +60,7 @@ try {
 
     // Block some kind of files for non-admin users
     if (!AuthentificationHelper::isConnectedWithRights('admin')) {
-        $adminFiles = array('backup', '.sql', 'scenario', '.tar', '.gz');
+        $adminFiles = ['backup', '.sql', 'scenario', '.tar', '.gz'];
         foreach ($adminFiles as $adminFile) {
             if (strpos($filePath, $adminFile) !== false) {
                 Router::showError401AndDie();

--- a/src/Api/proApi.php
+++ b/src/Api/proApi.php
@@ -86,7 +86,7 @@ try {
 
         /*             * ***********************Health********************************* */
         if ($jsonrpc->getMethod() == 'health') {
-            $health = array();
+            $health = [];
 
             $defaut = 0;
             $result = 'OK';
@@ -96,7 +96,7 @@ try {
                 $defaut = 1;
                 $result = $nbNeedUpdate;
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Système à jour', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Système à jour', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $result = 'OK';
@@ -106,7 +106,7 @@ try {
                 $result = 'NOK';
                 $advice = __('Erreur cron : les crons sont désactivés. Allez dans Administration -> Moteur de tâches pour les réactiver', __FILE__);
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Cron actif', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Cron actif', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $result = 'OK';
@@ -116,7 +116,7 @@ try {
                 $result = 'NOK';
                 $advice = __('Erreur scénario : tous les scénarios sont désactivés. Allez dans Outils -> Scénarios pour les réactiver', __FILE__);
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Scénario actif', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Scénario actif', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $result = 'OK';
@@ -125,7 +125,7 @@ try {
                 $defaut = 1;
                 $result = 'NOK';
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Démarré', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Démarré', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $result = 'OK';
@@ -134,7 +134,7 @@ try {
                 $defaut = 1;
                 $result = date('Y-m-d H:i:s');
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Date système', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Date système', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $result = 'OK';
@@ -144,12 +144,12 @@ try {
                 $result = 'NOK';
                 $advice = 'Donnez les droits root à NextDom.';
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Droits sudo', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Droits sudo', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $result = nextdom::version();
             $advice = '';
-            $health[] = array('plugin' => 'core', 'type' => 'Version NextDom', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Version NextDom', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $result = phpversion();
@@ -158,13 +158,13 @@ try {
                 $defaut = 1;
                 $advice = __('Si vous êtes en version 5.4.x, on vous indiquera quand la version 5.5 sera obligatoire', __FILE__);
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Version PHP', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Version PHP', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
-            $version = DB::Prepare('select version()', array(), DB::FETCH_TYPE_ROW);
+            $version = DB::Prepare('select version()', [], DB::FETCH_TYPE_ROW);
             $result = $version['version()'];
             $advice = '';
-            $health[] = array('plugin' => 'core', 'type' => 'Version database', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Version database', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $result = nextdom::checkSpaceLeft();
@@ -172,7 +172,7 @@ try {
             if ($result < 10) {
                 $defaut = 1;
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Espace disque libre', 'defaut' => $defaut, 'result' => $result . ' %', 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Espace disque libre', 'defaut' => $defaut, 'result' => $result . ' %', 'advice' => $advice];
 
             $defaut = 0;
             $result = 'OK';
@@ -182,7 +182,7 @@ try {
                 $result = 'NOK';
                 $advice = __('Allez sur Administration -> Configuration -> Réseaux, puis configurez correctement la partie réseau', __FILE__);
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Configuration réseau interne', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Configuration réseau interne', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $result = 'OK';
@@ -192,7 +192,7 @@ try {
                 $result = 'NOK';
                 $advice = __('Allez sur Administration -> Configuration -> Réseaux, puis configurez correctement la partie réseau', __FILE__);
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Configuration réseau externe', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Configuration réseau externe', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             $defaut = 0;
             $advice = '';
@@ -208,7 +208,7 @@ try {
                 $defaut = 1;
                 $advice = __('Votre cache n\'est pas sauvegardé. En cas de redémarrage, certaines informations peuvent être perdues. Essayez de lancer (à partir du moteur de tâches) la tâche cache::persist.', __FILE__);
             }
-            $health[] = array('plugin' => 'core', 'type' => 'Persistance du cache', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+            $health[] = ['plugin' => 'core', 'type' => 'Persistance du cache', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
             foreach (plugin::listPlugin(true) as $plugin) {
                 $plugin_id = $plugin->getId();
@@ -236,7 +236,7 @@ try {
                             default:
                                 break;
                         }
-                        $health[] = array('plugin' => $plugin_id, 'type' => 'dépendance', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+                        $health[] = ['plugin' => $plugin_id, 'type' => 'dépendance', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
                     }
                 } catch (Exception $e) {
 
@@ -261,7 +261,7 @@ try {
                                 }
                                 break;
                         }
-                        $health[] = array('plugin' => $plugin_id, 'type' => 'Configuration démon', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+                        $health[] = ['plugin' => $plugin_id, 'type' => 'Configuration démon', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
 
                         switch ($deamon_info['state']) {
                             case 'ok':
@@ -278,7 +278,7 @@ try {
                                 }
                                 break;
                         }
-                        $health[] = array('plugin' => $plugin_id, 'type' => 'Statut démon', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
+                        $health[] = ['plugin' => $plugin_id, 'type' => 'Statut démon', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice];
                     }
                 } catch (Exception $e) {
 
@@ -293,7 +293,7 @@ try {
                             } else {
                                 $defaut = 1;
                             }
-                            $health[] = array('plugin' => $plugin_id, 'type' => $result['test'], 'defaut' => $defaut, 'result' => $result['result'], 'advice' => $result['advice']);
+                            $health[] = ['plugin' => $plugin_id, 'type' => $result['test'], 'defaut' => $defaut, 'result' => $result['result'], 'advice' => $result['advice']];
                         }
                     }
                 } catch (Exception $e) {
@@ -334,10 +334,10 @@ try {
                 throw new Exception('Objet introuvable : ' . secureXSS($params['id']), -32601);
             }
             $return = utils::o2a($jeeObject);
-            $return['eqLogics'] = array();
+            $return['eqLogics'] = [];
             foreach ($jeeObject->getEqLogic() as $eqLogic) {
                 $eqLogic_return = utils::o2a($eqLogic);
-                $eqLogic_return['cmds'] = array();
+                $eqLogic_return['cmds'] = [];
                 foreach ($eqLogic->getCmd() as $cmd) {
                     $cmd_return = utils::o2a($cmd);
                     if ($cmd->getType() == 'info') {
@@ -393,7 +393,7 @@ try {
                 throw new Exception('EqLogic introuvable : ' . secureXSS($params['id']), -32602);
             }
             $return = utils::o2a($eqLogic);
-            $return['cmds'] = array();
+            $return['cmds'] = [];
             foreach ($eqLogic->getCmd() as $cmd) {
                 $cmd_return = utils::o2a($cmd);
                 if ($cmd->getType() == 'info') {
@@ -422,7 +422,7 @@ try {
             $eqLogic->save();
             $dbList = $typeCmd::byEqLogicId($eqLogic->getId());
             $eqLogic->save();
-            $enableList = array();
+            $enableList = [];
             if (isset($params['cmd'])) {
                 $cmd_order = 0;
                 foreach ($params['cmd'] as $cmd_info) {
@@ -452,11 +452,11 @@ try {
         }
 
         if ($jsonrpc->getMethod() == 'eqLogic::byTypeAndId') {
-            $return = array();
+            $return = [];
             foreach ($params['eqType'] as $eqType) {
-                $info_eqLogics = array();
+                $info_eqLogics = [];
                 foreach (eqLogic::byType($eqType) as $eqLogic) {
-                    $info_cmds = array();
+                    $info_cmds = [];
                     foreach ($eqLogic->getCmd() as $cmd) {
                         $info_cmd = utils::o2a($cmd);
                         if ($cmd->getType() == 'info') {
@@ -474,7 +474,7 @@ try {
 
             foreach ($params['id'] as $id) {
                 $eqLogic = eqLogic::byId($id);
-                $info_cmds = array();
+                $info_cmds = [];
                 foreach ($eqLogic->getCmd() as $cmd) {
                     $info_cmd = utils::o2a($cmd);
                     if ($cmd->getType() == 'info') {
@@ -511,20 +511,20 @@ try {
 
         if ($jsonrpc->getMethod() == 'cmd::execCmd') {
             if (is_array($params['id'])) {
-                $return = array();
+                $return = [];
                 foreach ($params['id'] as $id) {
                     $cmd = cmd::byId($id);
                     if (!is_object($cmd)) {
                         throw new Exception(__('Commande introuvable : ', __FILE__) . secureXSS($id), -32702);
                     }
-                    $return[$id] = array('value' => $cmd->execCmd($params['options']), 'collectDate' => $cmd->getCollectDate());
+                    $return[$id] = ['value' => $cmd->execCmd($params['options']), 'collectDate' => $cmd->getCollectDate()];
                 }
             } else {
                 $cmd = cmd::byId($params['id']);
                 if (!is_object($cmd)) {
                     throw new Exception(__('Commande introuvable : ', __FILE__) . secureXSS($params['id']), -32702);
                 }
-                $return = array('value' => $cmd->execCmd($params['options']), 'collectDate' => $cmd->getCollectDate());
+                $return = ['value' => $cmd->execCmd($params['options']), 'collectDate' => $cmd->getCollectDate()];
             }
             $jsonrpc->makeSuccess($return);
         }
@@ -598,7 +598,7 @@ try {
                 $auiKey = config::genKey(255);
                 config::save('auiKey', $auiKey);
             }
-            $return = array(
+            $return = [
                 'mode' => config::byKey('jeeNetwork::mode'),
                 'nbUpdate' => update::nbNeedUpdate(),
                 'version' => nextdom::version(),
@@ -606,7 +606,7 @@ try {
                 'auiKey' => $auiKey,
                 'nextdom::url' => config::byKey('nextdom::url'),
                 'ngrok::port' => config::byKey('ngrok::port'),
-            );
+            ];
             if (!filter_var(network::getNetworkAccess('external', 'ip'), FILTER_VALIDATE_IP) && network::getNetworkAccess('external', 'ip') != '') {
                 $return['nextdom::url'] = network::getNetworkAccess('internal');
             }
@@ -678,7 +678,7 @@ try {
                 $jeeNetwork->getConfiguration('version'),
                 date('Y-m-d_H\hi'));
             FileSystemHelper::mkdirIfNotExists($uploadDir, 0775, true);
-            Utils::readUploadedFile($_FILES, "file", $uploadDir, 50, array(".tar.gz", ".gz", ".tar"), function ($file) use ($format) {
+            Utils::readUploadedFile($_FILES, "file", $uploadDir, 50, [".tar.gz", ".gz", ".tar"], function ($file) use ($format) {
                 $extension = strtolower(strrchr($file['name'], '.'));
                 return sprintf($format, $extension);
             });
@@ -692,7 +692,7 @@ try {
                 throw new Exception(__('Seul un esclave peut restaurer une sauvegarde', __FILE__));
             }
             $uploadDir = BackupManager::getBackupDirectory();
-            $filename = Utils::readUploadedFile($_FILES, $uploadDir, 50, array('.tar.gz', '.gz', '.tar'), function ($file) {
+            $filename = Utils::readUploadedFile($_FILES, $uploadDir, 50, ['.tar.gz', '.gz', '.tar'], function ($file) {
                 // should probably use BackupManager::getBackupFilename
                 return sprintf("backup-%s-%s.tar.gz", nextdom::version(), date("d-m-Y-H\hi"));
             });
@@ -806,10 +806,10 @@ try {
         }
 
         if ($jsonrpc->getMethod() == 'plugin::specificInfos') {
-            $infos = array();
+            $infos = [];
             foreach (plugin::listPlugin() as $plugin) {
                 $pluginId = $plugin->getId();
-                if(method_exists($pluginId, 'proApi')){
+                if (method_exists($pluginId, 'proApi')) {
                     $infos[] = $pluginId::proApi();
                 }
             }
@@ -832,9 +832,9 @@ try {
         }
 
         if ($jsonrpc->getMethod() == 'update::nbNeedUpdate') {
-            $return = array(
+            $return = [
                 'nbUpdate' => update::nbNeedUpdate(),
-            );
+            ];
             $jsonrpc->makeSuccess($return);
         }
 

--- a/src/Api/tts.php
+++ b/src/Api/tts.php
@@ -38,11 +38,11 @@ if ($text == '') {
     echo __('Aucun texte à dire', __FILE__);
     die();
 }
-if(substr(init('text'), -1) == '#' && substr(init('text'), 0,1) == '#' && class_exists('songs_song')){
-    log::add('tts','debug',__('Tag detécté dans le tts et plugin song présent',__FILE__));
-    $song = songs_song::byLogicalId(strtolower(str_replace('#','',init('text'))));
-    if(is_object($song) && file_exists($song->getPath())){
-        log::add('tts','debug',__('Son trouvé path : ',__FILE__).$song->getPath());
+if (substr(init('text'), -1) == '#' && substr(init('text'), 0, 1) == '#' && class_exists('songs_song')) {
+    log::add('tts', 'debug', __('Tag detécté dans le tts et plugin song présent', __FILE__));
+    $song = songs_song::byLogicalId(strtolower(str_replace('#', '', init('text'))));
+    if (is_object($song) && file_exists($song->getPath())) {
+        log::add('tts', 'debug', __('Son trouvé path : ', __FILE__) . $song->getPath());
         if (init('path') == 1) {
             echo $song->getPath();
         } else {
@@ -53,7 +53,7 @@ if(substr(init('text'), -1) == '#' && substr(init('text'), 0,1) == '#' && class_
         die();
     }
 }
-$text = str_replace(array('[', ']', '#', '{', '}'), '', $text);
+$text = str_replace(['[', ']', '#', '{', '}'], '', $text);
 $md5 = md5($text);
 $tts_dir = jeedom::getTmpFolder('tts');
 $filename = $tts_dir . '/' . $md5 . '.mp3';
@@ -77,10 +77,10 @@ try {
         case 'espeak':
             $voice = init('voice', 'fr+f4');
             $avconv = 'avconv';
-            if(!com_shell::commandExists('avconv')){
+            if (!com_shell::commandExists('avconv')) {
                 $avconv = 'ffmpeg';
             }
-            $cmd = 'espeak -v' . $voice . ' "' . $text . '" --stdout | '.$avconv.' -i - -ar 44100 -ac 2 -ab 192k -f mp3 ' . $filename . ' > /dev/null 2>&1';
+            $cmd = 'espeak -v' . $voice . ' "' . $text . '" --stdout | ' . $avconv . ' -i - -ar 44100 -ac 2 -ab 192k -f mp3 ' . $filename . ' > /dev/null 2>&1';
             log::add('tts', 'debug', $cmd);
             shell_exec($cmd);
             break;
@@ -88,11 +88,11 @@ try {
             $volume = '-af "volume=' . init('volume', '6') . 'dB"';
             $lang = init('lang', 'fr-FR');
             $avconv = 'avconv';
-            if(!com_shell::commandExists('avconv')){
+            if (!com_shell::commandExists('avconv')) {
                 $avconv = 'ffmpeg';
             }
             $cmd = 'pico2wave -l=' . $lang . ' -w=' . $md5 . '.wav "' . $text . '" > /dev/null 2>&1;';
-            $cmd .= $avconv.' -i ' . $md5 . '.wav -ar 44100 ' . $volume . ' -ac 2 -ab 192k -f mp3 ' . $filename . ' > /dev/null 2>&1;rm ' . $md5 . '.wav';
+            $cmd .= $avconv . ' -i ' . $md5 . '.wav -ar 44100 ' . $volume . ' -ac 2 -ab 192k -f mp3 ' . $filename . ' > /dev/null 2>&1;rm ' . $md5 . '.wav';
             log::add('tts', 'debug', $cmd);
             shell_exec($cmd);
             break;
@@ -115,7 +115,7 @@ if (init('path') == 1) {
 }
 try {
     while (getDirectorySize($tts_dir) > (10 * 1024 * 1024)) {
-        $older = array('file' => null, 'datetime' => null);
+        $older = ['file' => null, 'datetime' => null];
         foreach (ls($tts_dir . '/', '*') as $file) {
             if ($older['datetime'] == null || $older['datetime'] > filemtime($tts_dir . '/' . $file)) {
                 $older['file'] = $tts_dir . '/' . $file;

--- a/src/Com/ComHttp.php
+++ b/src/Com/ComHttp.php
@@ -39,7 +39,7 @@ class ComHttp
     private $post = '';
     private $put = '';
     private $delete = '';
-    private $header = array('Connection: close');
+    private $header = ['Connection: close'];
     private $cookiesession = false;
     private $allowEmptyReponse = false;
     private $noReportError = false;
@@ -130,7 +130,7 @@ class ComHttp
                     return $response;
                 }
                 if ($this->getNoReportError() === false && $this->getLogError()) {
-                    LogHelper::add('http.com', 'error', __('Erreur cURL : ') . $curl_error . __(' sur la commande ') . $this->url . __(' après ') . $nbRetry . __(' relance(s)'));
+                    LogHelper::addError('http.com', __('Erreur cURL : ') . $curl_error . __(' sur la commande ') . $this->url . __(' après ') . $nbRetry . __(' relance(s)'));
                 }
                 if ($this->getNoReportError() === false) {
                     throw new CoreException(__('Echec de la requête HTTP : ') . $this->url . ' cURL error : ' . $curl_error, 404);
@@ -209,6 +209,17 @@ class ComHttp
         return $this;
     }
 
+    public function getDelete()
+    {
+        return $this->delete;
+    }
+
+    public function setDelete($delete = [])
+    {
+        $this->delete = $delete;
+        return $this;
+    }
+
     public function getUserAgent()
     {
         return $this->userAgent;
@@ -283,15 +294,6 @@ class ComHttp
     public function setUrl($url)
     {
         $this->url = $url;
-        return $this;
-    }
-
-    public function getDelete() {
-        return $this->delete;
-    }
-
-    public function setDelete($delete = []) {
-        $this->delete = $delete;
         return $this;
     }
 }

--- a/src/Com/ComShell.php
+++ b/src/Com/ComShell.php
@@ -28,10 +28,10 @@ class ComShell
 
     private static $instance;
 
-    private $cmds = array();
+    private $cmds = [];
     private $background;
-    private $cache = array();
-    private $history = array();
+    private $cache = [];
+    private $history = [];
 
     /*     * ********************Functions static********************* */
 
@@ -99,7 +99,7 @@ class ComShell
     public function clear()
     {
         $this->cache = array_merge($this->cache, $this->cmds);
-        $this->cmds = array();
+        $this->cmds = [];
     }
 
     /**
@@ -109,9 +109,9 @@ class ComShell
      */
     public function exec()
     {
-        $output = array();
+        $output = [];
         $retval = 0;
-        $return = array();
+        $return = [];
         foreach ($this->cmds as $cmd) {
             if (strpos($cmd, '2>&1') === false) {
                 $cmd .= ' 2>&1';
@@ -124,7 +124,7 @@ class ComShell
             $this->history[] = $cmd;
         }
         $this->cmds = $this->cache;
-        $this->cache = array();
+        $this->cache = [];
         return implode("\n", $return);
     }
 
@@ -156,7 +156,7 @@ class ComShell
 
     public function clearHistory()
     {
-        $this->history = array();
+        $this->history = [];
     }
 
     public function getCmd()

--- a/src/Controller/Admin/ApiController.php
+++ b/src/Controller/Admin/ApiController.php
@@ -23,7 +23,6 @@
 namespace NextDom\Controller\Admin;
 
 use NextDom\Controller\BaseController;
-use NextDom\Helpers\AuthentificationHelper;
 use NextDom\Helpers\Render;
 use NextDom\Managers\ConfigManager;
 use NextDom\Managers\PluginManager;

--- a/src/Controller/Admin/CacheController.php
+++ b/src/Controller/Admin/CacheController.php
@@ -25,7 +25,6 @@ namespace NextDom\Controller\Admin;
 use NextDom\Controller\BaseController;
 use NextDom\Helpers\Render;
 use NextDom\Managers\CacheManager;
-use NextDom\Managers\ConfigManager;
 
 /**
  * Class CacheController

--- a/src/Controller/Admin/NetworkController.php
+++ b/src/Controller/Admin/NetworkController.php
@@ -47,7 +47,7 @@ class NetworkController extends BaseController
     public static function get(&$pageData): string
     {
         $pageData['adminReposList'] = UpdateManager::listRepo();
-        $keys = array('dns::token', 'market::allowDNS');
+        $keys = ['dns::token', 'market::allowDNS'];
         foreach ($pageData['adminReposList'] as $key => $value) {
             $keys[] = $key . '::enable';
         }

--- a/src/Controller/Admin/SecurityController.php
+++ b/src/Controller/Admin/SecurityController.php
@@ -23,6 +23,7 @@
 namespace NextDom\Controller\Admin;
 
 use NextDom\Controller\BaseController;
+use NextDom\Enums\DateFormat;
 use NextDom\Helpers\Render;
 use NextDom\Managers\CacheManager;
 use NextDom\Managers\ConfigManager;
@@ -44,7 +45,7 @@ class SecurityController extends BaseController
      */
     public static function get(&$pageData): string
     {
-        $keys = array('security::bantime', 'ldap::enable');
+        $keys = ['security::bantime', 'ldap::enable'];
         $configs = ConfigManager::byKeys($keys);
 
         $pageData['JS_VARS']['ldapEnable'] = $configs['ldap::enable'];
@@ -61,11 +62,11 @@ class SecurityController extends BaseController
             foreach ($values as $value) {
                 $bannedData = [];
                 $bannedData['ip'] = $value['ip'];
-                $bannedData['startDate'] = date('Y-m-d H:i:s', $value['datetime']);
+                $bannedData['startDate'] = date(DateFormat::FULL, $value['datetime']);
                 if ($configs['security::bantime'] < 0) {
                     $bannedData['endDate'] = __('Jamais');
                 } else {
-                    $bannedData['endDate'] = date('Y-m-d H:i:s', $value['datetime'] + $pageData['adminConfigs']['security::bantime']);
+                    $bannedData['endDate'] = date(DateFormat::FULL, $value['datetime'] + $pageData['adminConfigs']['security::bantime']);
                 }
                 $pageData['adminBannedIp'][] = $bannedData;
             }

--- a/src/Controller/Admin/ServicesController.php
+++ b/src/Controller/Admin/ServicesController.php
@@ -23,14 +23,8 @@
 namespace NextDom\Controller\Admin;
 
 use NextDom\Controller\BaseController;
-use NextDom\Helpers\AuthentificationHelper;
-use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Render;
-use NextDom\Managers\CacheManager;
-use NextDom\Managers\ConfigManager;
-use NextDom\Managers\PluginManager;
 use NextDom\Managers\UpdateManager;
-use NextDom\Managers\UserManager;
 
 /**
  * Class ServicesController

--- a/src/Controller/Diagnostic/EqAnalyzeController.php
+++ b/src/Controller/Diagnostic/EqAnalyzeController.php
@@ -23,6 +23,7 @@
 namespace NextDom\Controller\Diagnostic;
 
 use NextDom\Controller\BaseController;
+use NextDom\Enums\CmdType;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Render;
 use NextDom\Managers\CmdManager;
@@ -77,9 +78,9 @@ class EqAnalyzeController extends BaseController
             $cmdData['infoCmds'] = [];
             $cmdData['actionCmds'] = [];
 
-            $eqlogicGetCmdInfo = $eqLogic->getCmd('info');
+            $eqlogicGetCmdInfo = $eqLogic->getCmd(CmdType::INFO);
             foreach ($eqlogicGetCmdInfo as $cmd) {
-                if (count($cmd->getConfiguration('actionCheckCmd', array())) > 0) {
+                if (count($cmd->getConfiguration('actionCheckCmd', [])) > 0) {
                     $data = [];
                     $data['cmd'] = $cmd;
                     $data['actions'] = [];
@@ -90,7 +91,7 @@ class EqAnalyzeController extends BaseController
                 }
             }
 
-            $eqLogicGetCmdAction = $eqLogic->getCmd('action');
+            $eqLogicGetCmdAction = $eqLogic->getCmd(CmdType::ACTION);
             foreach ($eqLogicGetCmdAction as $cmd) {
                 $actionCmdData = [];
                 $actionCmdData['cmd'] = $cmd;
@@ -123,7 +124,7 @@ class EqAnalyzeController extends BaseController
             $hasSomeAlerts = 0;
 
             $listCmds = [];
-            $eqLogicGetCmdInfo = $eqLogic->getCmd('info');
+            $eqLogicGetCmdInfo = $eqLogic->getCmd(CmdType::INFO);
             foreach ($eqLogicGetCmdInfo as $cmd) {
                 foreach ($NEXTDOM_INTERNAL_CONFIG['alerts'] as $level => $value) {
 

--- a/src/Controller/Diagnostic/HistoryController.php
+++ b/src/Controller/Diagnostic/HistoryController.php
@@ -23,12 +23,10 @@
 namespace NextDom\Controller\Diagnostic;
 
 use NextDom\Controller\BaseController;
-use NextDom\Helpers\NextDomHelper;
+use NextDom\Enums\DateFormat;
 use NextDom\Helpers\Render;
 use NextDom\Managers\CmdManager;
 use NextDom\Managers\ConfigManager;
-use NextDom\Managers\JeeObjectManager;
-use NextDom\Managers\PluginManager;
 
 /**
  * Class HistoryController
@@ -48,10 +46,10 @@ class HistoryController extends BaseController
     public static function get(&$pageData): string
     {
 
-        $pageData['historyDate'] = array(
-            'start' => date('Y-m-d', strtotime(ConfigManager::byKey('history::defautShowPeriod') . ' ' . date('Y-m-d'))),
-            'end' => date('Y-m-d'),
-        );
+        $pageData['historyDate'] = [
+            'start' => date(DateFormat::FULL_DAY, strtotime(ConfigManager::byKey('history::defautShowPeriod') . ' ' . date(DateFormat::FULL_DAY))),
+            'end' => date(DateFormat::FULL_DAY),
+        ];
         $pageData['historyCmdsList'] = CmdManager::allHistoryCmd();
         $pageData['JS_END_POOL'][] = '/public/js/desktop/diagnostic/history.js';
 

--- a/src/Controller/Diagnostic/ReportController.php
+++ b/src/Controller/Diagnostic/ReportController.php
@@ -48,7 +48,7 @@ class ReportController extends BaseController
     {
 
         $pageData['JS_END_POOL'][] = '/public/js/desktop/diagnostic/report.js';
-        $reportPath = NEXTDOM_DATA. '/data/custom/report/';
+        $reportPath = NEXTDOM_DATA . '/data/custom/report/';
         $pageData['reportViews'] = [];
         $allViews = ViewManager::all();
         foreach ($allViews as $view) {

--- a/src/Controller/Diagnostic/TimelineController.php
+++ b/src/Controller/Diagnostic/TimelineController.php
@@ -23,12 +23,7 @@
 namespace NextDom\Controller\Diagnostic;
 
 use NextDom\Controller\BaseController;
-use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Render;
-use NextDom\Managers\CmdManager;
-use NextDom\Managers\ConfigManager;
-use NextDom\Managers\JeeObjectManager;
-use NextDom\Managers\PluginManager;
 
 /**
  * Class TimelineController

--- a/src/Controller/Modals/ActionInsert.php
+++ b/src/Controller/Modals/ActionInsert.php
@@ -23,7 +23,6 @@
 namespace NextDom\Controller\Modals;
 
 use NextDom\Helpers\Render;
-use NextDom\Managers\ConfigManager;
 
 /**
  * Class ActionInsert

--- a/src/Controller/Modals/CmdConfigure.php
+++ b/src/Controller/Modals/CmdConfigure.php
@@ -22,6 +22,8 @@
 
 namespace NextDom\Controller\Modals;
 
+use NextDom\Enums\CmdSubType;
+use NextDom\Enums\CmdType;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Render;
@@ -51,7 +53,7 @@ class CmdConfigure extends BaseAbstractModal
             throw new CoreException(__('Commande non trouvé : ') . $cmdId);
         }
         $cmdInfo = NextDomHelper::toHumanReadable(Utils::o2a($cmd));
-        foreach (array('dashboard', 'dview', 'mview', 'dplan') as $value) {
+        foreach (['dashboard', 'dview', 'mview', 'dplan'] as $value) {
             if (!isset($cmdInfo['html'][$value]) || $cmdInfo['html'][$value] == '') {
                 $cmdInfo['html'][$value] = $cmd->getWidgetTemplateCode($value);
             }
@@ -72,7 +74,7 @@ class CmdConfigure extends BaseAbstractModal
             $pageData['cmdCacheValue'] = $cmd->getCache('value');
             $pageData['cmdCollectDate'] = $cmd->getCache('collectDate');
             $pageData['cmdValueDate'] = $cmd->getCache('valueDate');
-            if ($cmd->getSubType() == 'numeric') {
+            if ($cmd->isSubType(CmdSubType::NUMERIC)) {
                 $pageData['cmdShowMinMax'] = true;
             }
         }
@@ -80,7 +82,7 @@ class CmdConfigure extends BaseAbstractModal
         $pageData['cmdUsedBy'] = $cmd->getUsedBy();
         $pageData['cmdGenericTypes'] = NextDomHelper::getConfiguration('cmd::generic_type');
 
-        $pageData['cmdGenericTypeInformations'] = array();
+        $pageData['cmdGenericTypeInformations'] = [];
         foreach (NextDomHelper::getConfiguration('cmd::generic_type') as $key => $info) {
             if (strtolower($cmd->getType()) != strtolower($info['type'])) {
                 continue;
@@ -102,7 +104,7 @@ class CmdConfigure extends BaseAbstractModal
         }
         global $NEXTDOM_INTERNAL_CONFIG;
         $pageData['cmdTypeIsHistorized'] = false;
-        if ($cmd->getType() == 'info' && $NEXTDOM_INTERNAL_CONFIG['cmd']['type']['info']['subtype'][$cmd->getSubType()]['isHistorized']['visible']) {
+        if ($cmd->isType(CmdType::INFO) && $NEXTDOM_INTERNAL_CONFIG['cmd']['type']['info']['subtype'][$cmd->getSubType()]['isHistorized']['visible']) {
             $pageData['cmdIsHistorizedCanBeSmooth'] = $NEXTDOM_INTERNAL_CONFIG['cmd']['type']['info']['subtype'][$cmd->getSubType()]['isHistorized']['canBeSmooth'];
             $pageData['cmdTypeIsHistorized'] = true;
             $pageData['cmdIsHistorized'] = $cmd->getIsHistorized();
@@ -110,8 +112,8 @@ class CmdConfigure extends BaseAbstractModal
 
         $pageData['cmdWidgetCanCustomHtml'] = $cmd->widgetPossibility('custom::htmlCode');
         if ($pageData['cmdWidgetCanCustomHtml']) {
-            $html = array();
-            foreach (array('dashboard', 'dview', 'mview', 'dplan') as $value) {
+            $html = [];
+            foreach (['dashboard', 'dview', 'mview', 'dplan'] as $value) {
                 if ($cmd->getHtml($value) == '') {
                     $html[$value] = str_replace('textarea>', 'textarea$>', $cmd->getWidgetTemplateCode($value));
                 } else {

--- a/src/Controller/Modals/CmdHistory.php
+++ b/src/Controller/Modals/CmdHistory.php
@@ -22,6 +22,8 @@
 
 namespace NextDom\Controller\Modals;
 
+use NextDom\Enums\AjaxParams;
+use NextDom\Enums\DateFormat;
 use NextDom\Helpers\Render;
 use NextDom\Helpers\Utils;
 use NextDom\Managers\ConfigManager;
@@ -41,14 +43,14 @@ class CmdHistory extends BaseAbstractModal
     public static function get(): string
     {
         $pageData = [];
-        $pageData['dates'] = array(
-            'start' => Utils::init('startDate', date('Y-m-d', strtotime(ConfigManager::byKey('history::defautShowPeriod') . ' ' . date('Y-m-d')))),
-            'end' => Utils::init('endDate', date('Y-m-d')),
-        );
+        $pageData['dates'] = [
+            'start' => Utils::init('startDate', date(DateFormat::FULL_DAY, strtotime(ConfigManager::byKey('history::defautShowPeriod') . ' ' . date(DateFormat::FULL_DAY)))),
+            'end' => Utils::init('endDate', date(DateFormat::FULL_DAY)),
+        ];
         $pageData['derive'] = Utils::init('derive', 0);
         $pageData['step'] = Utils::init('step', 0);
-        $pageData['id'] = Utils::init('id');
-        Utils::sendVarsToJS(['historyId' => Utils::init('id')]);
+        $pageData['id'] = Utils::init(AjaxParams::ID);
+        Utils::sendVarsToJS(['historyId' => Utils::init(AjaxParams::ID)]);
 
         return Render::getInstance()->get('/modals/cmd.history.html.twig', $pageData);
     }

--- a/src/Controller/Modals/EqLogicConfigure.php
+++ b/src/Controller/Modals/EqLogicConfigure.php
@@ -46,109 +46,109 @@ class EqLogicConfigure extends BaseAbstractModal
     {
 
 
-      $eqLogicId = Utils::init('eqLogic_id');
-      $eqLogic = EqLogicManager::byId($eqLogicId);
-      if (!is_object($eqLogic)) {
-          throw new CoreException('EqLogic non trouvé : ' . $eqLogicId);
-      }
+        $eqLogicId = Utils::init('eqLogic_id');
+        $eqLogic = EqLogicManager::byId($eqLogicId);
+        if (!is_object($eqLogic)) {
+            throw new CoreException('EqLogic non trouvé : ' . $eqLogicId);
+        }
 
-      Utils::sendVarsToJS(
-          ['eqLogicInfo' => Utils::o2a($eqLogic),
-              'eqLogicInfoSearchString' => urlencode(str_replace('#', '', $eqLogic->getHumanName()))]);
+        Utils::sendVarsToJS(
+            ['eqLogicInfo' => Utils::o2a($eqLogic),
+                'eqLogicInfoSearchString' => urlencode(str_replace('#', '', $eqLogic->getHumanName()))]);
 
-      $pageData = [];
+        $pageData = [];
 
-      $widgetPossibilities = [
-          ['code' => 'customVisibility', 'key' => 'custom::visibility'],
-          ['code' => 'customDisplayName', 'key' => 'custom::displayName'],
-          ['code' => 'customDisplayObjectName', 'key' => 'custom::displayObjectName'],
-          ['code' => 'customBackgroundColor', 'key' => 'custom::background-color'],
-          ['code' => 'customBackgroundOpacity', 'key' => 'custom::background-opacity'],
-          ['code' => 'customTextColor', 'key' => 'custom::text-color'],
-          ['code' => 'customBorder', 'key' => 'custom::border'],
-          ['code' => 'customBorderRadius', 'key' => 'custom::border-radius'],
-          ['code' => 'custom', 'key' => 'custom'],
-          ['code' => 'customLayout', 'key' => 'custom::layout'],
-          ['code' => 'customOptionalParameters', 'key' => 'custom::optionalParameters']
-      ];
-      foreach ($widgetPossibilities as $widgetPossibility) {
-          $pageData[$widgetPossibility['code']] = $eqLogic->widgetPossibility($widgetPossibility['key']);
-      }
+        $widgetPossibilities = [
+            ['code' => 'customVisibility', 'key' => 'custom::visibility'],
+            ['code' => 'customDisplayName', 'key' => 'custom::displayName'],
+            ['code' => 'customDisplayObjectName', 'key' => 'custom::displayObjectName'],
+            ['code' => 'customBackgroundColor', 'key' => 'custom::background-color'],
+            ['code' => 'customBackgroundOpacity', 'key' => 'custom::background-opacity'],
+            ['code' => 'customTextColor', 'key' => 'custom::text-color'],
+            ['code' => 'customBorder', 'key' => 'custom::border'],
+            ['code' => 'customBorderRadius', 'key' => 'custom::border-radius'],
+            ['code' => 'custom', 'key' => 'custom'],
+            ['code' => 'customLayout', 'key' => 'custom::layout'],
+            ['code' => 'customOptionalParameters', 'key' => 'custom::optionalParameters']
+        ];
+        foreach ($widgetPossibilities as $widgetPossibility) {
+            $pageData[$widgetPossibility['code']] = $eqLogic->widgetPossibility($widgetPossibility['key']);
+        }
 
-      $pageData['statusNumberTryWithoutSuccess'] = $eqLogic->getStatus('numberTryWithoutSuccess', 0);
-      $pageData['statusLastCommunication'] = $eqLogic->getStatus('lastCommunication');
-      $pageData['cmdsList'] = $eqLogic->getCmd();
-      $pageData['eqLogicConfigurationDisplayType'] = [];
-      $pageData['eqLogicDisplayParameters'] = $eqLogic->getDisplay('parameters');
+        $pageData['statusNumberTryWithoutSuccess'] = $eqLogic->getStatus('numberTryWithoutSuccess', 0);
+        $pageData['statusLastCommunication'] = $eqLogic->getStatus('lastCommunication');
+        $pageData['cmdsList'] = $eqLogic->getCmd();
+        $pageData['eqLogicConfigurationDisplayType'] = [];
+        $pageData['eqLogicDisplayParameters'] = $eqLogic->getDisplay('parameters');
 
-      foreach (NextDomHelper::getConfiguration('eqLogic:displayType') as $key => $value) {
-          // TODO : A supprimer quand on aura trouvé où est initialisé eqLogic:displayType et retiré mobile
-              $eqLogicDisplayType = [];
-              $eqLogicDisplayType['key'] = $key;
-              $eqLogicDisplayType['name'] = $value['name'];
-              foreach ($widgetPossibilities as $widgetPossibility) {
-                  $eqLogicDisplayType[$widgetPossibility['code']] = false;
-                  if ($pageData[$widgetPossibility['code']] && $eqLogic->widgetPossibility($widgetPossibility['key'] . '::' . $key)) {
-                      if ($widgetPossibility['code'] == 'customBackgroundColor') {
-                          $eqLogicDisplayType['backgroundColor'] = $eqLogic->getBackgroundColor($key);
-                      }
-                      $eqLogicDisplayType[$widgetPossibility['code']] = true;
-                  }
-              }
-              array_push($pageData['eqLogicConfigurationDisplayType'], $eqLogicDisplayType);
-      }
-      if (is_array($eqLogic->widgetPossibility('parameters'))) {
-          $pageData['parameters'] = [];
-          foreach ($eqLogic->widgetPossibility('parameters') as $parameterKey => $parameterData) {
-              $param = [];
-              $param['key'] = $parameterKey;
-              $param['name'] = $parameterData['name'];
-              $param['advancedParam'] = false;
-              if (!isset($parameterData['allow_displayType'])) {
-                  continue;
-              }
-              if (!isset($parameterData['type'])) {
-                  continue;
-              }
-              if (is_array($parameterData['allow_displayType']) && !in_array($parameterKey, $parameterData['allow_displayType'])) {
-                  continue;
-              }
-              if ($parameterData['allow_displayType'] === false) {
-                  continue;
-              }
-              $param['advancedParam'] = true;
-              $param['display'] = '';
-              $param['default'] = '';
-              if (isset($parameterData['default'])) {
-                  $param['default'] = $parameterData['default'];
-                  $param['display'] = 'display:none;';
-              }
-              $param['type'] = $parameterData['type'];
-              if ($param['type'] == 'color') {
-                  $param['allowTransparent'] = $parameterData['allow_transparent'];
-              }
+        foreach (NextDomHelper::getConfiguration('eqLogic:displayType') as $key => $value) {
+            // TODO : A supprimer quand on aura trouvé où est initialisé eqLogic:displayType et retiré mobile
+            $eqLogicDisplayType = [];
+            $eqLogicDisplayType['key'] = $key;
+            $eqLogicDisplayType['name'] = $value['name'];
+            foreach ($widgetPossibilities as $widgetPossibility) {
+                $eqLogicDisplayType[$widgetPossibility['code']] = false;
+                if ($pageData[$widgetPossibility['code']] && $eqLogic->widgetPossibility($widgetPossibility['key'] . '::' . $key)) {
+                    if ($widgetPossibility['code'] == 'customBackgroundColor') {
+                        $eqLogicDisplayType['backgroundColor'] = $eqLogic->getBackgroundColor($key);
+                    }
+                    $eqLogicDisplayType[$widgetPossibility['code']] = true;
+                }
+            }
+            array_push($pageData['eqLogicConfigurationDisplayType'], $eqLogicDisplayType);
+        }
+        if (is_array($eqLogic->widgetPossibility('parameters'))) {
+            $pageData['parameters'] = [];
+            foreach ($eqLogic->widgetPossibility('parameters') as $parameterKey => $parameterData) {
+                $param = [];
+                $param['key'] = $parameterKey;
+                $param['name'] = $parameterData['name'];
+                $param['advancedParam'] = false;
+                if (!isset($parameterData['allow_displayType'])) {
+                    continue;
+                }
+                if (!isset($parameterData['type'])) {
+                    continue;
+                }
+                if (is_array($parameterData['allow_displayType']) && !in_array($parameterKey, $parameterData['allow_displayType'])) {
+                    continue;
+                }
+                if ($parameterData['allow_displayType'] === false) {
+                    continue;
+                }
+                $param['advancedParam'] = true;
+                $param['display'] = '';
+                $param['default'] = '';
+                if (isset($parameterData['default'])) {
+                    $param['default'] = $parameterData['default'];
+                    $param['display'] = 'display:none;';
+                }
+                $param['type'] = $parameterData['type'];
+                if ($param['type'] == 'color') {
+                    $param['allowTransparent'] = $parameterData['allow_transparent'];
+                }
 
-              array_push($pageData['parameters'], $param);
-          }
-      }
+                array_push($pageData['parameters'], $param);
+            }
+        }
 
-      $pageData['dashboardCmd'] = array();
+        $pageData['dashboardCmd'] = [];
 
-      foreach ($eqLogic->getCmd(null, null, true) as $cmd) {
-          $line = $eqLogic->getDisplay('layout::dashboard::table::cmd::' . $cmd->getId() . '::line', 1);
-          $column = $eqLogic->getDisplay('layout::dashboard::table::cmd::' . $cmd->getId() . '::column', 1);
-          if (!isset($pageData['dashboardCmd'][$line])) {
-              $pageData['dashboardCmd'][$line] = array();
-          }
-          if (!isset($pageData['dashboardCmd'][$line][$column])) {
-              $pageData['dashboardCmd'][$line][$column] = array();
-          }
-          $pageData['dashboardCmd'][$line][$column][] = $cmd;
-      }
-      $pageData['displayDashboardNbLines'] = $eqLogic->getDisplay('layout::dashboard::table::nbLine', 1);
-      $pageData['displayDashboardNbColumns'] = $eqLogic->getDisplay('layout::dashboard::table::nbColumn', 1);
+        foreach ($eqLogic->getCmd(null, null, true) as $cmd) {
+            $line = $eqLogic->getDisplay('layout::dashboard::table::cmd::' . $cmd->getId() . '::line', 1);
+            $column = $eqLogic->getDisplay('layout::dashboard::table::cmd::' . $cmd->getId() . '::column', 1);
+            if (!isset($pageData['dashboardCmd'][$line])) {
+                $pageData['dashboardCmd'][$line] = [];
+            }
+            if (!isset($pageData['dashboardCmd'][$line][$column])) {
+                $pageData['dashboardCmd'][$line][$column] = [];
+            }
+            $pageData['dashboardCmd'][$line][$column][] = $cmd;
+        }
+        $pageData['displayDashboardNbLines'] = $eqLogic->getDisplay('layout::dashboard::table::nbLine', 1);
+        $pageData['displayDashboardNbColumns'] = $eqLogic->getDisplay('layout::dashboard::table::nbColumn', 1);
 
-      return Render::getInstance()->get('/modals/eqLogic.configure.html.twig', $pageData);
-  }
+        return Render::getInstance()->get('/modals/eqLogic.configure.html.twig', $pageData);
+    }
 
 }

--- a/src/Controller/Modals/IconSelector.php
+++ b/src/Controller/Modals/IconSelector.php
@@ -100,9 +100,9 @@ class IconSelector extends BaseAbstractModal
         foreach ($matchResults as $result) {
             if (isset($result[0])) {
                 if ($cssClass === null) {
-                    $data['list'][] = str_replace(array(':', '.'), ' ', $result[0]);
+                    $data['list'][] = str_replace([':', '.'], ' ', $result[0]);
                 } else {
-                    $data['list'][] = $cssClass . str_replace(array(':', '.'), ' ', $result[0]);
+                    $data['list'][] = $cssClass . str_replace([':', '.'], ' ', $result[0]);
                 }
             }
         }

--- a/src/Controller/Modals/NoteManager.php
+++ b/src/Controller/Modals/NoteManager.php
@@ -22,7 +22,6 @@
 
 namespace NextDom\Controller\Modals;
 
-use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Render;
 
 /**

--- a/src/Controller/Modals/ObjectDisplay.php
+++ b/src/Controller/Modals/ObjectDisplay.php
@@ -22,6 +22,7 @@
 
 namespace NextDom\Controller\Modals;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Render;
 use NextDom\Helpers\Utils;
@@ -51,7 +52,7 @@ class ObjectDisplay extends BaseAbstractModal
             throw new CoreException(__('La classe demandée n\'a pas de méthode byId : ') . $cmdClass);
         }
 
-        $resultObject = $cmdClass::byId(Utils::init('id'));
+        $resultObject = $cmdClass::byId(Utils::init(AjaxParams::ID));
         if (!is_object($resultObject)) {
             throw new CoreException(__('L\'objet n\'existe pas : ') . $cmdClass);
         }
@@ -67,7 +68,7 @@ class ObjectDisplay extends BaseAbstractModal
             //TODO: $array ???
             $scenarioElement = ScenarioElementManager::byId($data['option']['scenarioElement_id']);
             if (is_object($scenarioElement) && is_object($scenario)) {
-                $otherInfo['doIn'] = __('Scénario : ') . $scenario->getName() . "\n" . str_replace(array('"'), array("'"), $scenarioElement->export());
+                $otherInfo['doIn'] = __('Scénario : ') . $scenario->getName() . "\n" . str_replace(['"'], ["'"], $scenarioElement->export());
             }
         }
 

--- a/src/Controller/Modals/PlanConfigure.php
+++ b/src/Controller/Modals/PlanConfigure.php
@@ -22,6 +22,7 @@
 
 namespace NextDom\Controller\Modals;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Render;
 use NextDom\Helpers\Utils;
@@ -47,7 +48,7 @@ class PlanConfigure extends BaseAbstractModal
     {
 
         $pageData = [];
-        $pageData['planObject'] = PlanManager::byId(Utils::init('id'));
+        $pageData['planObject'] = PlanManager::byId(Utils::init(AjaxParams::ID));
         if (!is_object($pageData['planObject'])) {
             throw new CoreException('Impossible de trouver le design');
         }

--- a/src/Controller/Modals/PluginDaemon.php
+++ b/src/Controller/Modals/PluginDaemon.php
@@ -49,7 +49,7 @@ class PluginDaemon extends BaseAbstractModal
         if (count($daemonInfo) == 0) {
             die();
         }
-        $refresh = array();
+        $refresh = [];
         $refresh[0] = 0;
         $pageData = [];
         $pageData['daemonInfoState'] = $daemonInfo['state'];

--- a/src/Controller/Modals/RemoveHistory.php
+++ b/src/Controller/Modals/RemoveHistory.php
@@ -43,7 +43,7 @@ class RemoveHistory extends BaseAbstractModal
             $removeHistory = json_decode(file_get_contents(NEXTDOM_DATA . '/data/remove_history.json'), true);
         }
         if (!is_array($removeHistory)) {
-            $removeHistory = array();
+            $removeHistory = [];
         }
 
         $pageData = [];

--- a/src/Controller/Modals/ScenarioJsonEdit.php
+++ b/src/Controller/Modals/ScenarioJsonEdit.php
@@ -22,6 +22,7 @@
 
 namespace NextDom\Controller\Modals;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Render;
 use NextDom\Helpers\Utils;
@@ -43,14 +44,14 @@ class ScenarioJsonEdit extends BaseAbstractModal
     public static function get(): string
     {
 
-        $scenarioId = Utils::init('id');
+        $scenarioId = Utils::init(AjaxParams::ID);
         $pageData = [];
         $scenario = ScenarioManager::byId($scenarioId);
         if (!is_object($scenario)) {
             throw new CoreException(__('Aucun scénario ne correspondant à : ') . $scenarioId);
         }
         Utils::sendVarToJs('scenarioJsonEdit_scenario_id', $scenarioId);
-        $json = array();
+        $json = [];
         foreach ($scenario->getElement() as $element) {
             $json[] = $element->getAjaxElement();
         }

--- a/src/Controller/Modals/TwoFactorAuthentification.php
+++ b/src/Controller/Modals/TwoFactorAuthentification.php
@@ -25,7 +25,6 @@ namespace NextDom\Controller\Modals;
 use NextDom\Helpers\Render;
 use NextDom\Managers\UserManager;
 use PragmaRX\Google2FA\Google2FA;
-use NextDom\Managers\ConfigManager;
 
 /**
  * Class TwoFactorAuthentification

--- a/src/Controller/Modals/UserRights.php
+++ b/src/Controller/Modals/UserRights.php
@@ -22,6 +22,7 @@
 
 namespace NextDom\Controller\Modals;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Render;
 use NextDom\Helpers\Utils;
@@ -44,7 +45,7 @@ class UserRights extends BaseAbstractModal
      */
     public static function get(): string
     {
-        $userId = Utils::init('id');
+        $userId = Utils::initInt(AjaxParams::ID);
         $user = UserManager::byId($userId);
 
         if (!is_object($user)) {

--- a/src/Controller/Modals/Welcome.php
+++ b/src/Controller/Modals/Welcome.php
@@ -23,7 +23,6 @@
 namespace NextDom\Controller\Modals;
 
 use NextDom\Helpers\Render;
-use NextDom\Managers\ConfigManager;
 
 /**
  * Class Welcome

--- a/src/Controller/Pages/DashBoardController.php
+++ b/src/Controller/Pages/DashBoardController.php
@@ -23,14 +23,16 @@
 namespace NextDom\Controller\Pages;
 
 use NextDom\Controller\BaseController;
+use NextDom\Enums\AjaxParams;
+use NextDom\Enums\Common;
+use NextDom\Enums\NextDomObj;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Render;
 use NextDom\Helpers\Utils;
 use NextDom\Managers\ConfigManager;
-use NextDom\Managers\EqLogicManager;
 use NextDom\Managers\JeeObjectManager;
 use NextDom\Managers\UserManager;
-use NextDom\Model\Entity\JeeObject;
 
 /**
  * Class DashboardController
@@ -49,17 +51,17 @@ class DashBoardController extends BaseController
      */
     public static function get(&$pageData): string
     {
-        $objectIdFromUrl = Utils::init('object_id', '');
-        $defaultDashboardObjectId ='';
+        $objectIdFromUrl = Utils::init(AjaxParams::OBJECT_ID, '');
+        $defaultDashboardObjectId = '';
         $currentJeeObjectId = '';
         $pageData['JS_VARS']['nextdom_Welcome'] = ConfigManager::byKey('nextdom::Welcome');
-        $pageData['JS_VARS']['SEL_CATEGORY'] = Utils::init('category', 'all');
-        $pageData['JS_VARS']['SEL_TAG'] = Utils::init('tag', 'all');
-        $pageData['JS_VARS']['SEL_SUMMARY'] = Utils::init('summary');
+        $pageData['JS_VARS']['SEL_CATEGORY'] = Utils::init(AjaxParams::CATEGORY, 'all');
+        $pageData['JS_VARS']['SEL_TAG'] = Utils::init(AjaxParams::TAG, 'all');
+        $pageData['JS_VARS']['SEL_SUMMARY'] = Utils::init(AjaxParams::SUMMARY);
 
         $defaultDashboardObjectName = UserManager::getStoredUser()->getOptions('defaultDashboardObject');
         $defaultDashboardObject = JeeObjectManager::byId($defaultDashboardObjectName);
-        if(!empty($defaultDashboardObject)) {
+        if (!empty($defaultDashboardObject)) {
             $defaultDashboardObjectId = $defaultDashboardObject->getId();
         }
 
@@ -72,18 +74,18 @@ class DashBoardController extends BaseController
                 $currentJeeObject = JeeObjectManager::getRootObjects();
             }
         }
-        if(!empty($currentJeeObject)){
+        if (!empty($currentJeeObject)) {
             $currentJeeObjectId = $currentJeeObject->getId();
         } else {
-            throw new \Exception(__('Aucun objet racine trouvé. Pour en créer un, allez dans dashboard -> <a href="/index.php?v=d&p=object">Liste objets et résumés</a>'));
+            throw new CoreException(__('Aucun objet racine trouvé. Pour en créer un, allez dans dashboard -> <a href="/index.php?v=d&p=object">Liste objets et résumés</a>'));
         }
 
         $pageData['JS_VARS']['SEL_OBJECT_ID'] = $currentJeeObjectId;
         $pageData['JS_VARS']['rootObjectId'] = $currentJeeObjectId;
         $pageData['JS_VARS']['serverTZoffsetMin'] = Utils::getTZoffsetMin();
 
-        $pageData['dashboardCategory'] = Utils::init('category', 'all');
-        $pageData['dashboardSummary'] = Utils::init('summary', 'all');
+        $pageData['dashboardCategory'] = Utils::init(AjaxParams::CATEGORY, Common::ALL);
+        $pageData['dashboardSummary'] = Utils::init(AjaxParams::SUMMARY, Common::ALL);
         $pageData['dashboardCategories'] = NextDomHelper::getConfiguration('eqLogic:category', true);
         $pageData['dashboardDefaultObjectId'] = $defaultDashboardObjectId;
         $pageData['dashboardObjectId'] = $currentJeeObjectId;
@@ -103,7 +105,7 @@ class DashBoardController extends BaseController
 
     /**
      * Get layers
-     * @param JeeObject $currentObjectId
+     * @param int $currentObjectId
      * @return array
      * @throws \Exception
      */
@@ -135,10 +137,10 @@ class DashBoardController extends BaseController
             }
             foreach ($layer as $item) {
                 $itemData = [];
-                $itemData['jeeObject'] = $item;
-                $itemData['active'] = false;
+                $itemData[NextDomObj::JEE_OBJECT] = $item;
+                $itemData[Common::ACTIVE] = false;
                 if ($item->getId() == $selectedLayerObject->getId()) {
-                    $itemData['active'] = true;
+                    $itemData[Common::ACTIVE] = true;
                 }
                 $layerResult[] = $itemData;
             }
@@ -149,8 +151,8 @@ class DashBoardController extends BaseController
         $childrenLayer = [];
         foreach ($children as $item) {
             $itemData = [];
-            $itemData['jeeObject'] = $item;
-            $itemData['active'] = false;
+            $itemData[NextDomObj::JEE_OBJECT] = $item;
+            $itemData[Common::ACTIVE] = false;
             $childrenLayer[] = $itemData;
         }
         $result[] = $childrenLayer;

--- a/src/Controller/Pages/FirstUseController.php
+++ b/src/Controller/Pages/FirstUseController.php
@@ -23,11 +23,11 @@
 namespace NextDom\Controller\Pages;
 
 use NextDom\Controller\BaseController;
+use NextDom\Helpers\FileSystemHelper;
 use NextDom\Helpers\Render;
 use NextDom\Helpers\Router;
 use NextDom\Helpers\Utils;
 use NextDom\Managers\ConfigManager;
-use NextDom\Helpers\FileSystemHelper;
 
 /**
  * Class FirstUseController
@@ -43,22 +43,22 @@ class FirstUseController extends BaseController
      */
     public static function get(&$pageData): string
     {
-        $configs = ConfigManager::byKeys(array(
+        $configs = ConfigManager::byKeys([
             'notify::status',
             'notify::position',
             'notify::timeout',
-            'nextdom::firstUse'));
+            'nextdom::firstUse']);
         if ($configs['nextdom::firstUse'] == 0) {
             Router::showError404AndDie();
         }
 
         $pageData['profilsWidgetThemes'] = [];
-        $lsDir = FileSystemHelper::ls(NEXTDOM_ROOT . '/core/template/dashboard/themes/','*',true);
+        $lsDir = FileSystemHelper::ls(NEXTDOM_ROOT . '/core/template/dashboard/themes/', '*', true);
         foreach ($lsDir as $themesDir) {
-            $lsThemes = FileSystemHelper::ls(NEXTDOM_ROOT . '/core/template/dashboard/themes/' .$themesDir, '*.png');
+            $lsThemes = FileSystemHelper::ls(NEXTDOM_ROOT . '/core/template/dashboard/themes/' . $themesDir, '*.png');
             foreach ($lsThemes as $themeFile) {
                 $themeData = [];
-                $themeData['dir'] = '/core/template/dashboard/themes/' .$themesDir . $themeFile;
+                $themeData['dir'] = '/core/template/dashboard/themes/' . $themesDir . $themeFile;
                 $themeData['name'] = $themeFile;
                 $pageData['profilsWidgetThemes'][] = $themeData;
             }

--- a/src/Controller/Pages/PlanController.php
+++ b/src/Controller/Pages/PlanController.php
@@ -46,9 +46,9 @@ class PlanController extends BaseController
     {
         $planHeader = null;
         $planHeaders = PlanHeaderManager::all();
-        $planHeadersSendToJS = array();
+        $planHeadersSendToJS = [];
         foreach ($planHeaders as $planHeader_select) {
-            $planHeadersSendToJS[] = array('id' => $planHeader_select->getId(), 'name' => $planHeader_select->getName());
+            $planHeadersSendToJS[] = ['id' => $planHeader_select->getId(), 'name' => $planHeader_select->getName()];
         }
         $pageData['JS_VARS_RAW']['planHeader'] = Utils::getArrayToJQueryJson($planHeadersSendToJS);
         if (Utils::init('plan_id') == '') {

--- a/src/Controller/Pages/ViewController.php
+++ b/src/Controller/Pages/ViewController.php
@@ -23,6 +23,7 @@
 namespace NextDom\Controller\Pages;
 
 use NextDom\Controller\BaseController;
+use NextDom\Enums\AjaxParams;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\AuthentificationHelper;
 use NextDom\Helpers\Render;
@@ -54,7 +55,7 @@ class ViewController extends BaseController
         $pageData['viewNoControl'] = Utils::init('noControl');
 
         $currentView = null;
-        if (Utils::init('view_id') == '') {
+        if (Utils::init(AjaxParams::VIEW_ID) == '') {
 
             if (UserManager::getStoredUser()->getOptions('defaultDesktopView') != '') {
                 $currentView = ViewManager::byId(UserManager::getStoredUser()->getOptions('defaultDesktopView'));
@@ -64,10 +65,10 @@ class ViewController extends BaseController
                 $currentView = $pageData['viewsList'][0];
             }
         } else {
-            $currentView = ViewManager::byId(init('view_id'));
+            $currentView = ViewManager::byId(Utils::init(AjaxParams::VIEW_ID));
 
             if (!is_object($currentView)) {
-                throw new \Exception('{{Vue inconnue. Vérifier l\'ID.}}');
+                throw new CoreException('{{Vue inconnue. Vérifier l\'ID.}}');
             }
         }
 
@@ -79,7 +80,7 @@ class ViewController extends BaseController
         if (UserManager::getStoredUser()->getOptions('displayViewByDefault') == 1 && Utils::init('report') != 1) {
             $pageData['viewHideList'] = false;
         }
-        $pageData['JS_VARS']['view_id'] = $currentView->getId();
+        $pageData['JS_VARS'][AjaxParams::VIEW_ID] = $currentView->getId();
         $pageData['CSS_POOL'][] = '/public/css/pages/view.css';
         $pageData['JS_END_POOL'][] = '/public/js/desktop/pages/view.js';
 

--- a/src/Controller/Params/LogConfigController.php
+++ b/src/Controller/Params/LogConfigController.php
@@ -23,7 +23,6 @@
 namespace NextDom\Controller\Params;
 
 use NextDom\Controller\BaseController;
-use NextDom\Helpers\AuthentificationHelper;
 use NextDom\Helpers\Render;
 use NextDom\Managers\ConfigManager;
 use NextDom\Managers\PluginManager;
@@ -48,7 +47,7 @@ class LogConfigController extends BaseController
 
         global $NEXTDOM_INTERNAL_CONFIG;
         $pageData['adminAlerts'] = $NEXTDOM_INTERNAL_CONFIG['alerts'];
-        $pageData['adminOthersLogs'] = array('scenario', 'plugin', 'market', 'api', 'connection', 'interact', 'tts', 'report', 'event');
+        $pageData['adminOthersLogs'] = ['scenario', 'plugin', 'market', 'api', 'connection', 'interact', 'tts', 'report', 'event'];
         $pageData['adminPluginsList'] = [];
         $pluginsList = PluginManager::listPlugin(true);
         foreach ($pluginsList as $plugin) {

--- a/src/Controller/Params/ProfilsController.php
+++ b/src/Controller/Params/ProfilsController.php
@@ -26,7 +26,6 @@ use NextDom\Controller\BaseController;
 use NextDom\Helpers\FileSystemHelper;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Render;
-use NextDom\Helpers\SessionHelper;
 use NextDom\Managers\ConfigManager;
 use NextDom\Managers\JeeObjectManager;
 use NextDom\Managers\Plan3dHeaderManager;
@@ -56,12 +55,12 @@ class ProfilsController extends BaseController
         UserManager::getStoredUser()->refresh();
         $pageData['profilsUser'] = UserManager::getStoredUser();
         @session_write_close();
-        $pageData['profilsHomePageDesktop'] = array(
+        $pageData['profilsHomePageDesktop'] = [
             'core::dashboard' => __('Dashboard'),
             'core::view' => __('Vue'),
             'core::plan' => __('Design'),
             'core::plan3d' => __('Design 3D'),
-        );
+        ];
         $pluginManagerList = PluginManager::listPlugin();
         foreach ($pluginManagerList as $pluginList) {
             if ($pluginList->isActive() == 1 && $pluginList->getDisplay() != '' && ConfigManager::byKey('displayDesktopPanel', $pluginList->getId(), 0) != 0) {
@@ -103,12 +102,12 @@ class ProfilsController extends BaseController
         }
 
         $pageData['profilsWidgetThemes'] = [];
-        $lsDir = FileSystemHelper::ls(NEXTDOM_ROOT . '/core/template/dashboard/themes/','*',true);
+        $lsDir = FileSystemHelper::ls(NEXTDOM_ROOT . '/core/template/dashboard/themes/', '*', true);
         foreach ($lsDir as $themesDir) {
-            $lsThemes = FileSystemHelper::ls(NEXTDOM_ROOT . '/core/template/dashboard/themes/' .$themesDir, '*.png');
+            $lsThemes = FileSystemHelper::ls(NEXTDOM_ROOT . '/core/template/dashboard/themes/' . $themesDir, '*.png');
             foreach ($lsThemes as $themeFile) {
                 $themeData = [];
-                $themeData['dir'] = '/core/template/dashboard/themes/' .$themesDir . $themeFile;
+                $themeData['dir'] = '/core/template/dashboard/themes/' . $themesDir . $themeFile;
                 $themeData['name'] = $themeFile;
                 $pageData['profilsWidgetThemes'][] = $themeData;
             }
@@ -116,9 +115,9 @@ class ProfilsController extends BaseController
 
         $pageData['profilsDisplayTypes'] = NextDomHelper::getConfiguration('eqLogic:displayType');
         foreach ($pageData['profilsDisplayTypes'] as $key => $value) {
-            if (isset($_SESSION) && is_object(UserManager::getStoredUser()) && UserManager::getStoredUser()->getOptions('widget::background-opacity::'.$key, null) == null) {
+            if (isset($_SESSION) && is_object(UserManager::getStoredUser()) && UserManager::getStoredUser()->getOptions('widget::background-opacity::' . $key, null) == null) {
                 @session_start();
-                UserManager::getStoredUser()->setOptions('widget::background-opacity::'.$key, 1);
+                UserManager::getStoredUser()->setOptions('widget::background-opacity::' . $key, 1);
                 UserManager::getStoredUser()->save();
                 @session_write_close();
             }

--- a/src/Controller/Tools/InteractController.php
+++ b/src/Controller/Tools/InteractController.php
@@ -48,7 +48,7 @@ class InteractController extends BaseController
     public static function get(&$pageData): string
     {
 
-        $interacts = array();
+        $interacts = [];
         $pageData['interactTotal'] = InteractDefManager::all();
         $interacts[-1] = InteractDefManager::all(null);
         $interactListGroup = InteractDefManager::listGroup();

--- a/src/Controller/Tools/Markets/MarketJeeController.php
+++ b/src/Controller/Tools/Markets/MarketJeeController.php
@@ -65,20 +65,20 @@ class MarketJeeController extends BaseController
         /* Lecture market */
         if ($author == null && $name === null && $categorie === null && Utils::init('certification', null) === null && Utils::init('cost', null) === null && $type == 'plugin') {
             $news = true;
-            $markets = RepoMarket::byFilter(array(
+            $markets = RepoMarket::byFilter([
                 'status' => 'stable',
                 'type' => 'plugin',
                 'timeState' => 'popular'
-            ));
-            $markets2 = RepoMarket::byFilter(array(
+            ]);
+            $markets2 = RepoMarket::byFilter([
                 'status' => 'stable',
                 'type' => 'plugin',
                 'timeState' => 'newest'
-            ));
+            ]);
             $markets = array_merge($markets, $markets2);
         } else {
             $news = false;
-            $markets = RepoMarket::byFilter(array(
+            $markets = RepoMarket::byFilter([
                 'status' => null,
                 'type' => $type,
                 'categorie' => $categorie,
@@ -88,7 +88,7 @@ class MarketJeeController extends BaseController
                 'timeState' => Utils::init('timeState', null),
                 'certification' => Utils::init('certification', null),
                 'limit' => $searchLimit
-            ));
+            ]);
         }
 
         $pageData['marketObjectsByCategory'] = [];

--- a/src/Controller/Tools/ObjectController.php
+++ b/src/Controller/Tools/ObjectController.php
@@ -23,6 +23,7 @@
 namespace NextDom\Controller\Tools;
 
 use NextDom\Controller\BaseController;
+use NextDom\Enums\ConfigKey;
 use NextDom\Helpers\Render;
 use NextDom\Helpers\Utils;
 use NextDom\Managers\ConfigManager;
@@ -47,7 +48,7 @@ class ObjectController extends BaseController
     {
         $pageData['JS_VARS']['select_id'] = Utils::init('id', '-1');
         $pageData['objectList'] = JeeObjectManager::buildTree(null, false);
-        $pageData['objectSummary'] = ConfigManager::byKey('object:summary');
+        $pageData['objectSummary'] = ConfigManager::byKey(ConfigKey::OBJECT_SUMMARY);
 
         $pageData['JS_END_POOL'][] = '/public/js/desktop/tools/object.js';
 

--- a/src/Controller/Tools/OsDbController.php
+++ b/src/Controller/Tools/OsDbController.php
@@ -24,7 +24,6 @@ namespace NextDom\Controller\Tools;
 
 use NextDom\Controller\BaseController;
 use NextDom\Helpers\Render;
-use NextDom\Managers\ConfigManager;
 
 /**
  * Class OsDbController

--- a/src/Controller/Tools/UpdateController.php
+++ b/src/Controller/Tools/UpdateController.php
@@ -42,9 +42,9 @@ class UpdateController extends BaseController
      */
     public static function get(&$pageData): string
     {
-        $updates = array();
+        $updates = [];
         foreach (UpdateManager::listCoreUpdate() as $udpate) {
-            $updates[str_replace(array('.php', '.sql'), '', $udpate)] = str_replace(array('.php', '.sql'), '', $udpate);
+            $updates[str_replace(['.php', '.sql'], '', $udpate)] = str_replace(['.php', '.sql'], '', $udpate);
         }
         usort($updates, 'version_compare');
         $pageData['numberOfUpdates'] = UpdateManager::nbNeedUpdate();

--- a/src/Enums/ActionRight.php
+++ b/src/Enums/ActionRight.php
@@ -1,0 +1,29 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace NextDom\Enums;
+
+/**
+ * Class ObjectRight
+ * @package NextDom\Enums
+ */
+class ActionRight extends Enum
+{
+    const EXECUTE = 'x';
+    const READ = 'r';
+    const WRITE = 'w';
+}

--- a/src/Enums/AjaxParams.php
+++ b/src/Enums/AjaxParams.php
@@ -24,22 +24,44 @@ namespace NextDom\Enums;
  */
 class AjaxParams extends Enum
 {
+    const ACTION = 'action';
+    const BACKUP = 'backup';
     const CMD_ID = 'cmd_id';
     const CATEGORY = 'category';
+    const CODE = 'code';
     const COMMAND = 'command';
     const DEFAULT = 'default';
+    const ENABLE = 'enable';
     const EXPRESSION = 'expression';
+    const FORCE_RESTART = 'forceRestart';
+    const HTML = 'html';
     const ID = 'id';
+    const IDS = 'ids';
+    const IMAGE = 'image';
     const KEY = 'key';
+    const LOGICAL_ID = 'logicalId';
+    const LOG = 'log';
+    const MODAL = 'modal';
+    const MODE = 'mode';
     const OBJECT = 'object';
+    const OBJECT_ID = 'object_id';
     const OPTION = 'option';
+    const NAME = 'name';
     const PARAMS = 'params';
+    const PLUGIN = 'plugin';
     const PROFILS = 'profils';
+    const REPO = 'repo';
     const SCENARIO = 'scenario';
     const SCENARIOS = 'scenarios';
+    const START = 'start';
     const STATE = 'state';
     const SUMMARY = 'summary';
+    const TAG = 'tag';
     const TEMPLATE = 'template';
+    const TEST = 'test';
+    const TYPE = 'type';
+    const USED_BY = 'usedBy';
     const USER_ID = 'user_id';
     const VERSION = 'version';
+    const VIEW_ID = 'view_id';
 }

--- a/src/Enums/Common.php
+++ b/src/Enums/Common.php
@@ -1,0 +1,64 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace NextDom\Enums;
+
+/**
+ * Common string
+ * @package NextDom\Enums
+ */
+class Common extends Enum
+{
+    const ACTION = 'action';
+    const ACTIVE = 'active';
+    const ALL = 'all';
+    const CATEGORY = 'category';
+    const CHANGED = 'changed';
+    const CLASS_NAME = 'className';
+    const CMD_PARAMETERS = 'cmd_parameters';
+    const CONFIGURATION = 'configuration';
+    const CORE = 'core';
+    const CUSTOM = 'custom';
+    const DASH_VALUE = 'dashvalue';
+    const DETAIL = 'detail';
+    const DISPLAY = 'display';
+    const HUMAN_NAME = 'humanName';
+    const ICON = 'icon';
+    const ID = 'id';
+    const INFO = 'info';
+    const IS_HISTORIZED = 'isHistorized';
+    const KEY = 'key';
+    const KEYS = 'keys';
+    const HTML = 'html';
+    const LENGTH_FACTOR = 'lengthfactor';
+    const NAME = 'name';
+    const OBJECT_ID = 'object_id';
+    const ORDER = 'order';
+    const PHP_CLASS = 'phpClass';
+    const PROFILE = 'profile';
+    const QUERY = 'query';
+    const REPLY_CMD = 'reply_cmd';
+    const STATUS = 'status';
+    const SUB_PROCESS = 'subprocess';
+    const SUBTYPE = 'subtype';
+    const SUMMARY = 'summary';
+    const TIMELINE_ONLY = 'timelineOnly';
+    const TYPE = 'type';
+    const USED_BY = 'usedBy';
+    const VERSION = 'version';
+    const VIEW_DATA = 'viewData';
+}

--- a/src/Enums/ConfigKey.php
+++ b/src/Enums/ConfigKey.php
@@ -30,6 +30,7 @@ class ConfigKey extends Enum
     const LOG_LEVEL = 'log::level';
     const MARKET_ADDRESS = 'market::address';
     const NEXTDOM_INSTALL_KEY = 'nextdom::installKey';
+    const OBJECT_SUMMARY = 'object:summary';
     const TMP_FOLDER = 'folder::tmp';
     const WIDGET_BACKGROUND_OPACITY = 'widget::background-opacity';
 }

--- a/src/Enums/FoldersReferential.php
+++ b/src/Enums/FoldersReferential.php
@@ -21,12 +21,12 @@ namespace NextDom\Enums;
 class FoldersReferential extends Enum
 {
 
-    const NEXTDOMFOLDERS = ['api','assets','backup','core','data','docs','install','log','mobile','node_modules','plugins','public','scripts','src','tests','tmp','translations','vendor','views','var','.github','.sass-cache','.git','.idea'];
-    const NEXTDOMFILES = ['cache.tar.gz' ,'CHANGELOG.md','composer.json','composer.lock','COPYING','DB_backup.sql','index.php','LICENSE','manifest.json','manifest.webmanifest','mobile.manifest.php','package.json','package-lock.json','phpunit.xml.dist','README.md','robots.txt','.travis.yml','.htaccess','.coveralls.yml','.gitignore','.sonarcloud.properties'];
+    const NEXTDOMFOLDERS = ['api', 'assets', 'backup', 'core', 'data', 'docs', 'install', 'log', 'mobile', 'node_modules', 'plugins', 'public', 'scripts', 'src', 'tests', 'tmp', 'translations', 'vendor', 'views', 'var', '.github', '.sass-cache', '.git', '.idea'];
+    const NEXTDOMFILES = ['cache.tar.gz', 'CHANGELOG.md', 'composer.json', 'composer.lock', 'COPYING', 'DB_backup.sql', 'index.php', 'LICENSE', 'manifest.json', 'manifest.webmanifest', 'mobile.manifest.php', 'package.json', 'package-lock.json', 'phpunit.xml.dist', 'README.md', 'robots.txt', '.travis.yml', '.htaccess', '.coveralls.yml', '.gitignore', '.sonarcloud.properties'];
 
     const PUBLICFOLDERS = ['css', 'icon', 'img', 'js', 'themes'];
-    const PUBLICFILES = ['403.html','404.html','500.html', 'here.html'];
+    const PUBLICFILES = ['403.html', '404.html', '500.html', 'here.html'];
 
-    const JEEDOMFOLDERS = ['3rdparty','core','data','desktop','install','mobile','script','.github','.sass-cache','.git','.idea'];
-    const JEEDOMFILES = ['cache.tar.gz' ,'composer.json','composer.lock','COPYING','Dockerfile','DB_backup.sql','health.sh','here.html','index.php','index-1.php','LICENSE','manifest.json','manifest.webmanifest','mobile.manifest.php','README.md','robots.txt','sick.php','.htaccess','.gitignore'];
+    const JEEDOMFOLDERS = ['3rdparty', 'core', 'data', 'desktop', 'install', 'mobile', 'script', '.github', '.sass-cache', '.git', '.idea'];
+    const JEEDOMFILES = ['cache.tar.gz', 'composer.json', 'composer.lock', 'COPYING', 'Dockerfile', 'DB_backup.sql', 'health.sh', 'here.html', 'index.php', 'index-1.php', 'LICENSE', 'manifest.json', 'manifest.webmanifest', 'mobile.manifest.php', 'README.md', 'robots.txt', 'sick.php', '.htaccess', '.gitignore'];
 }

--- a/src/Enums/LogTarget.php
+++ b/src/Enums/LogTarget.php
@@ -25,10 +25,20 @@ class LogTarget extends Enum
 {
     const BACKUP = 'backup';
     const CMD = 'cmd';
+    const CONNECTION = 'connection';
+    const CRON = 'cron';
     const EVENT = 'event';
+    const INTERACT = 'interact';
+    const JEE_EVENT = 'jeeEvent';
+    const LISTENER = 'listener';
+    const MARKET = 'market';
     const MIGRATION = 'migration';
+    const NETWORK = 'network';
     const NEXTDOM = 'nextdom';
+    const PLUGIN = 'plugin';
+    const REPORT = 'report';
     const RESTORE = 'restore';
     const STARTING = 'starting';
     const SCENARIO = 'scenario';
+    const UPDATE = 'update';
 }

--- a/src/Enums/NextDomObj.php
+++ b/src/Enums/NextDomObj.php
@@ -27,7 +27,13 @@ class NextDomObj extends Enum
     const SCENARIO = 'scenario';
     const EQLOGIC = 'eqLogic';
     const DATASTORE = 'dataStore';
+    const INTERACT = 'interact';
     const INTERACT_DEF = 'interactDef';
+    const INTERACT_QUERY = 'interactQuery';
+    const JEE_OBJECT = 'jeeObject';
+    const OBJECT = 'object';
     const PLAN = 'plan';
+    const PLAN_OBJECT = 'planObject';
+    const PLUGIN = 'plugin';
     const VIEW = 'view';
 }

--- a/src/Enums/UserOption.php
+++ b/src/Enums/UserOption.php
@@ -1,0 +1,28 @@
+<?php
+/* This file is part of NextDom.
+ *
+ * NextDom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NextDom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NextDom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace NextDom\Enums;
+
+/**
+ * Class UserRight
+ * @package NextDom\Enums
+ */
+class UserOption extends Enum
+{
+    const REGISTER_DEVICE = 'registerDevice';
+    const TWO_FACTOR_AUTH = 'twoFactorAuthentification';
+}

--- a/src/Enums/ViewType.php
+++ b/src/Enums/ViewType.php
@@ -24,5 +24,5 @@ namespace NextDom\Enums;
 class ViewType extends Enum
 {
     const DESKTOP_VIEW = 'd';
-    const STATIC_VIEW  = 's';
+    const STATIC_VIEW = 's';
 }

--- a/src/Helpers/AjaxHelper.php
+++ b/src/Helpers/AjaxHelper.php
@@ -107,19 +107,6 @@ class AjaxHelper
     }
 
     /**
-     * Send answer
-     *
-     * @param string $answer Answer to send
-     */
-    public function success($answer = '')
-    {
-        if (!$this->answerSended) {
-            echo $this->getResponse($answer);
-            $this->answerSended = true;
-        }
-    }
-
-    /**
      * Convert data to JSON response
      *
      * @param string $data Data to convert
@@ -140,5 +127,18 @@ class AjaxHelper
             $response['code'] = $errorCode;
         }
         return json_encode($response, JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * Send answer
+     *
+     * @param string $answer Answer to send
+     */
+    public function success($answer = '')
+    {
+        if (!$this->answerSended) {
+            echo $this->getResponse($answer);
+            $this->answerSended = true;
+        }
     }
 }

--- a/src/Helpers/Api.php
+++ b/src/Helpers/Api.php
@@ -18,6 +18,7 @@
 namespace NextDom\Helpers;
 
 use NextDom\Enums\ApiMode;
+use NextDom\Enums\LogTarget;
 use NextDom\Managers\ConfigManager;
 use NextDom\Managers\UserManager;
 
@@ -59,7 +60,7 @@ class Api
             }
             GLOBAL $_USER_GLOBAL;
             $_USER_GLOBAL = $user;
-            LogHelper::add('connection', 'info', __('core.api-connection') . $user->getLogin());
+            LogHelper::addInfo(LogTarget::CONNECTION, __('core.api-connection') . $user->getLogin());
             return true;
         }
         return false;

--- a/src/Helpers/AuthentificationHelper.php
+++ b/src/Helpers/AuthentificationHelper.php
@@ -33,6 +33,8 @@
 
 namespace NextDom\Helpers;
 
+use NextDom\Enums\DateFormat;
+use NextDom\Enums\LogTarget;
 use NextDom\Exceptions\CoreException;
 use NextDom\Managers\ConfigManager;
 use NextDom\Managers\UserManager;
@@ -100,7 +102,7 @@ class AuthentificationHelper
                 @session_start();
                 UserManager::storeUserInSession($user);
                 @session_write_close();
-                LogHelper::add('connection', 'info', __('Connexion de l\'utilisateur par REMOTE_USER : ') . $user->getLogin());
+                LogHelper::addInfo(LogTarget::CONNECTION, __('Connexion de l\'utilisateur par REMOTE_USER : ') . $user->getLogin());
             }
         }
 
@@ -171,7 +173,7 @@ class AuthentificationHelper
             $registeredDevices = [];
         }
         $registeredDevices[$currentDeviceHash] = [];
-        $registeredDevices[$currentDeviceHash]['datetime'] = date('Y-m-d H:i:s');
+        $registeredDevices[$currentDeviceHash]['datetime'] = date(DateFormat::FULL);
         $registeredDevices[$currentDeviceHash]['ip'] = NetworkHelper::getClientIp();
         $registeredDevices[$currentDeviceHash]['session_id'] = session_id();
         @session_start();
@@ -181,7 +183,7 @@ class AuthentificationHelper
         if (!isset($_COOKIE['nextdom_token'])) {
             setcookie('nextdom_token', AjaxHelper::getToken(), time() + 365 * 24 * 3600, "/", '', false, true);
         }
-        LogHelper::add('connection', 'info', __('Connexion de l\'utilisateur par clé : ') . $user->getLogin());
+        LogHelper::addInfo(LogTarget::CONNECTION, __('Connexion de l\'utilisateur par clé : ') . $user->getLogin());
         return true;
     }
 
@@ -216,13 +218,11 @@ class AuthentificationHelper
 
         if (!is_object($user) || session_status() == PHP_SESSION_DISABLED) {
             $result = false;
-        }
-        else {
+        } else {
             // Check cache
             if (isset(self::$rightsCache[$rightsKey]) && self::$rightsCache[$rightsKey]) {
                 $result = self::$rightsCache[$rightsKey];
-            }
-            elseif ($user->isConnected()) {
+            } elseif ($user->isConnected()) {
                 // Check specific rights
                 if (!empty($rights)) {
                     if (UserManager::getStoredUser()->getProfils() == $rights) {
@@ -266,7 +266,7 @@ class AuthentificationHelper
         @session_start();
         UserManager::storeUserInSession($user);
         @session_write_close();
-        LogHelper::add('connection', 'info', __('Connexion de l\'utilisateur : ') . $login);
+        LogHelper::addInfo(LogTarget::CONNECTION, __('Connexion de l\'utilisateur : ') . $login);
         return true;
     }
 

--- a/src/Helpers/ConsoleHelper.php
+++ b/src/Helpers/ConsoleHelper.php
@@ -20,7 +20,6 @@ namespace NextDom\Helpers;
 
 
 use NextDom\Exceptions\CoreException;
-use phpDocumentor\Reflection\Types\Boolean;
 
 class ConsoleHelper
 {
@@ -33,7 +32,7 @@ class ConsoleHelper
      */
     public static function title(string $title, $ending)
     {
-        if($ending){
+        if ($ending) {
             printf("[ / $title ]\n");
         } else {
             printf("[ $title ]\n");
@@ -84,6 +83,7 @@ class ConsoleHelper
     {
         printf("\n");
     }
+
     /**
      * Show ok message
      */
@@ -108,6 +108,6 @@ class ConsoleHelper
     public static function error($exceptionData)
     {
         printf(">> *** ERROR *** " . Utils::br2nl($exceptionData->getMessage()) . "\n");
-        printf(">> *** TRACE *** " . Utils::br2nl($exceptionData->getTrace() ) . "\n");
+        printf(">> *** TRACE *** " . Utils::br2nl($exceptionData->getTrace()) . "\n");
     }
 }

--- a/src/Helpers/DBHelper.php
+++ b/src/Helpers/DBHelper.php
@@ -35,7 +35,6 @@
 namespace NextDom\Helpers;
 
 use NextDom\Exceptions\CoreException;
-use NextDom\Model\Entity\EntityInterface;
 
 /**
  * Class DBHelper
@@ -59,9 +58,9 @@ class DBHelper
     {
         global $CONFIG;
         if (isset($CONFIG['db']['unix_socket'])) {
-            $this->connection = new \PDO('mysql:unix_socket=' . $CONFIG['db']['unix_socket'] . ';dbname=' . $CONFIG['db']['dbname'], $CONFIG['db']['username'], $CONFIG['db']['password'], array(\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8', \PDO::ATTR_PERSISTENT => true));
+            $this->connection = new \PDO('mysql:unix_socket=' . $CONFIG['db']['unix_socket'] . ';dbname=' . $CONFIG['db']['dbname'], $CONFIG['db']['username'], $CONFIG['db']['password'], [\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8', \PDO::ATTR_PERSISTENT => true]);
         } else {
-            $this->connection = new \PDO('mysql:host=' . $CONFIG['db']['host'] . ';port=' . $CONFIG['db']['port'] . ';dbname=' . $CONFIG['db']['dbname'], $CONFIG['db']['username'], $CONFIG['db']['password'], array(\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8', \PDO::ATTR_PERSISTENT => true));
+            $this->connection = new \PDO('mysql:host=' . $CONFIG['db']['host'] . ';port=' . $CONFIG['db']['port'] . ';dbname=' . $CONFIG['db']['dbname'], $CONFIG['db']['username'], $CONFIG['db']['password'], [\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8', \PDO::ATTR_PERSISTENT => true]);
         }
     }
 
@@ -92,90 +91,6 @@ class DBHelper
             return self::Prepare("CALL $procName($bindParams)", $params, $fetchType);
         }
 
-    }
-
-    /**
-     * Get one object from database
-     *
-     * @param string $query SQL query
-     * @param array $params Query params
-     * @param string $objectClassName Class of object
-     *
-     * @return mixed|null Instance of the class
-     *
-     * @throws CoreException
-     */
-    public static function &getOneObject(string $query, array $params, string $objectClassName)
-    {
-        return self::Prepare($query, $params, self::FETCH_TYPE_ROW, \PDO::FETCH_CLASS, $objectClassName);
-    }
-
-    /**
-     * Get objects from database
-     *
-     * @param string $query SQL query
-     * @param array $params Query params
-     * @param string $objectClassName Class of object
-     *
-     * @return mixed|null Array of instances of the class
-     *
-     * @throws CoreException
-     */
-    public static function &getAllObjects(string $query, array $params, string $objectClassName)
-    {
-        return self::Prepare($query, $params, self::FETCH_TYPE_ALL, \PDO::FETCH_CLASS, $objectClassName);
-    }
-
-    /**
-     * Get one row data from database
-     *
-     * @param string $query SQL query
-     * @param array $params Query params
-     *
-     * @return mixed Associative array with data
-     *
-     * @throws CoreException
-     */
-    public static function &getOne(string $query, array $params = [])
-    {
-        return self::Prepare($query, $params, self::FETCH_TYPE_ROW, \PDO::FETCH_ASSOC);
-    }
-
-    /**
-     * Get data from database
-     *
-     * @param string $query SQL query
-     * @param array $params Query params
-     *
-     * @return mixed Associative array with data
-     *
-     * @throws CoreException
-     */
-    public static function &getAll(string $query, array $params = [])
-    {
-        return self::Prepare($query, $params, self::FETCH_TYPE_ALL, \PDO::FETCH_ASSOC);
-    }
-
-    /**
-     * Execute a query without result (DELETE, UPDATE, INSERT, etc.)
-     *
-     * @param string $query SQL query
-     * @param array $params Query params
-     *
-     * @return bool True on success
-     */
-    public static function exec(string $query, array $params = [])
-    {
-        $statement = self::getConnection()->prepare($query);
-        if ($statement !== false && $statement->execute($params) !== false) {
-            $errorInfo = $statement->errorInfo();
-            // TODO: Revoir cette chaine
-            if ($errorInfo[0] != 0000) {
-                return false;
-            }
-            return true;
-        }
-        return false;
     }
 
     /**
@@ -237,6 +152,22 @@ class DBHelper
     }
 
     /**
+     * Get objects from database
+     *
+     * @param string $query SQL query
+     * @param array $params Query params
+     * @param string $objectClassName Class of object
+     *
+     * @return mixed|null Array of instances of the class
+     *
+     * @throws CoreException
+     */
+    public static function &getAllObjects(string $query, array $params, string $objectClassName)
+    {
+        return self::Prepare($query, $params, self::FETCH_TYPE_ALL, \PDO::FETCH_CLASS, $objectClassName);
+    }
+
+    /**
      * Optimize all tables
      *
      * @throws CoreException
@@ -249,6 +180,43 @@ class DBHelper
             $table = $table[0];
             self::exec('OPTIMIZE TABLE `' . $table . '`');
         }
+    }
+
+    /**
+     * Get data from database
+     *
+     * @param string $query SQL query
+     * @param array $params Query params
+     *
+     * @return mixed Associative array with data
+     *
+     * @throws CoreException
+     */
+    public static function &getAll(string $query, array $params = [])
+    {
+        return self::Prepare($query, $params, self::FETCH_TYPE_ALL, \PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Execute a query without result (DELETE, UPDATE, INSERT, etc.)
+     *
+     * @param string $query SQL query
+     * @param array $params Query params
+     *
+     * @return bool True on success
+     */
+    public static function exec(string $query, array $params = [])
+    {
+        $statement = self::getConnection()->prepare($query);
+        if ($statement !== false && $statement->execute($params) !== false) {
+            $errorInfo = $statement->errorInfo();
+            // TODO: Revoir cette chaine
+            if ($errorInfo[0] != 0000) {
+                return false;
+            }
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -486,7 +454,22 @@ class DBHelper
             $sql[] = '`' . $field . '` = :' . $field;
             $parameters[$field] = self::getField($targetObject, $field);
         }
-        return array($sql, $parameters);
+        return [$sql, $parameters];
+    }
+
+    /**
+     * Get one row data from database
+     *
+     * @param string $query SQL query
+     * @param array $params Query params
+     *
+     * @return mixed Associative array with data
+     *
+     * @throws CoreException
+     */
+    public static function &getOne(string $query, array $params = [])
+    {
+        return self::Prepare($query, $params, self::FETCH_TYPE_ROW, \PDO::FETCH_ASSOC);
     }
 
     /**
@@ -518,7 +501,7 @@ class DBHelper
         if (is_subclass_of($objectToRefresh, 'EntityInterface') || !self::getField($objectToRefresh, 'id')) {
             throw new CoreException('DB ne peut rafraîchir l\'objet sans son ID');
         }
-        $parameters = array('id' => self::getField($objectToRefresh, 'id'));
+        $parameters = ['id' => self::getField($objectToRefresh, 'id')];
         $sql = 'SELECT ' . self::buildField(get_class($objectToRefresh)) .
             ' FROM `' . self::getTableName($objectToRefresh) . '` ' .
             ' WHERE ';
@@ -578,6 +561,22 @@ class DBHelper
     }
 
     /**
+     * Get one object from database
+     *
+     * @param string $query SQL query
+     * @param array $params Query params
+     * @param string $objectClassName Class of object
+     *
+     * @return mixed|null Instance of the class
+     *
+     * @throws CoreException
+     */
+    public static function &getOneObject(string $query, array $params, string $objectClassName)
+    {
+        return self::Prepare($query, $params, self::FETCH_TYPE_ROW, \PDO::FETCH_CLASS, $objectClassName);
+    }
+
+    /**
      * Get list of objects filtered
      *
      * @param array $filters Filtres à appliquer
@@ -589,7 +588,7 @@ class DBHelper
     public static function getWithFilter(array $filters, $objectType)
     {
         // operators have to remain in this order. If you put '<' before '<=', algorithm won't make the difference & will think a '<=' is a '<'
-        $operators = array('!=', '<=', '>=', '<', '>', 'NOT LIKE', 'LIKE', '=');
+        $operators = ['!=', '<=', '>=', '<', '>', 'NOT LIKE', 'LIKE', '='];
         $fields = self::getFields($objectType);
         $reflectedClass = self::getReflectionClass($objectType)->getName();
         // create query
@@ -601,11 +600,11 @@ class DBHelper
                 if ($property == $key && $value != '') {
                     // traitement à faire sur value pour obtenir l'opérateur
                     $thereIsOperator = false;
-                    $operatorInformation = array(
+                    $operatorInformation = [
                         'index' => -1,
                         'value' => '=', // by default '='
                         'length' => 0,
-                    );
+                    ];
                     foreach ($operators as $operator) {
                         if (($index = strpos($value, $operator)) !== false) {
                             $thereIsOperator = true;
@@ -619,7 +618,7 @@ class DBHelper
                         // extract operator from value
                         $value = substr($value, $operatorInformation['length'] + 1); // +1 because of space
                         // add % % to LIKE operator
-                        if (in_array($operatorInformation['value'], array('LIKE', 'NOT LIKE'))) {
+                        if (in_array($operatorInformation['value'], ['LIKE', 'NOT LIKE'])) {
                             $value = '%' . $value . '%';
                         }
                     }
@@ -657,7 +656,7 @@ class DBHelper
         $sql = 'DELETE FROM `' . self::getTableName($objectToRemove) . '` WHERE ';
         if (isset($parameters['id'])) {
             $sql .= '`id` = :id AND ';
-            $parameters = array('id' => $parameters['id']);
+            $parameters = ['id' => $parameters['id']];
         } else {
             foreach ($parameters as $field => $value) {
                 if ($value != '') {
@@ -811,7 +810,7 @@ class DBHelper
             if ($_loop < 1) {
                 return self::compareAndFix($_database, $_table, $_verbose, ($_loop + 1));
             }
-            throw new \Exception($error);
+            throw new CoreException($error);
         }
         return true;
     }
@@ -833,11 +832,11 @@ class DBHelper
      */
     private static function compareDatabase($database)
     {
-        $return = [];
+        $result = [];
         foreach ($database['tables'] as $table) {
-            $return = array_merge($return, self::compareTable($table));
+            $result = array_merge($result, self::compareTable($table));
         }
-        return $return;
+        return $result;
     }
 
     /**
@@ -863,36 +862,36 @@ class DBHelper
             $describes = [];
         }
 
-        $return = array($_table['name'] => array('status' => 'ok', 'fields' => [], 'indexes' => [], 'sql' => ''));
+        $result = [$_table['name'] => ['status' => 'ok', 'fields' => [], 'indexes' => [], 'sql' => '']];
         if (count($describes) == 0) {
-            $return = array($_table['name'] => array(
+            $result = [$_table['name'] => [
                 'status' => 'nok',
                 'message' => 'Not found',
                 'sql' => 'CREATE TABLE IF NOT EXISTS ' . '`' . $_table['name'] . '` (',
-            ));
+            ]];
             foreach ($_table['fields'] as $field) {
-                $return[$_table['name']]['sql'] .= "\n" . '`' . $field['name'] . '`';
-                $return[$_table['name']]['sql'] .= self::buildDefinitionField($field);
-                $return[$_table['name']]['sql'] .= ',';
+                $result[$_table['name']]['sql'] .= "\n" . '`' . $field['name'] . '`';
+                $result[$_table['name']]['sql'] .= self::buildDefinitionField($field);
+                $result[$_table['name']]['sql'] .= ',';
             }
-            $return[$_table['name']]['sql'] .= "\n" . 'primary key(';
+            $result[$_table['name']]['sql'] .= "\n" . 'primary key(';
             foreach ($_table['fields'] as $field) {
                 if (isset($field['key']) && $field['key'] == 'PRI') {
-                    $return[$_table['name']]['sql'] .= '`' . $field['name'] . '`,';
+                    $result[$_table['name']]['sql'] .= '`' . $field['name'] . '`,';
                 }
             }
-            $return[$_table['name']]['sql'] = trim($return[$_table['name']]['sql'], ',');
-            $return[$_table['name']]['sql'] .= ')';
-            $return[$_table['name']]['sql'] .= ')' . "\n";
+            $result[$_table['name']]['sql'] = trim($result[$_table['name']]['sql'], ',');
+            $result[$_table['name']]['sql'] .= ')';
+            $result[$_table['name']]['sql'] .= ')' . "\n";
             if (!isset($_table['engine'])) {
                 $_table['engine'] = 'InnoDB';
             }
-            $return[$_table['name']]['sql'] .= ' ENGINE ' . $_table['engine'] . ";\n";
+            $result[$_table['name']]['sql'] .= ' ENGINE ' . $_table['engine'] . ";\n";
             foreach ($_table['indexes'] as $index) {
-                $return[$_table['name']]['sql'] .= "\n" . self::buildDefinitionIndex($index, $_table['name']) . ';';
+                $result[$_table['name']]['sql'] .= "\n" . self::buildDefinitionIndex($index, $_table['name']) . ';';
             }
-            $return[$_table['name']]['sql'] = trim($return[$_table['name']]['sql'], ';');
-            return $return;
+            $result[$_table['name']]['sql'] = trim($result[$_table['name']]['sql'], ';');
+            return $result;
         }
         $forceRebuildIndex = false;
         foreach ($_table['fields'] as $field) {
@@ -901,19 +900,19 @@ class DBHelper
                 if ($describe['Field'] != $field['name']) {
                     continue;
                 }
-                $return[$_table['name']]['fields'] = array_merge($return[$_table['name']]['fields'], self::compareField($field, $describe, $_table['name']));
-                if (isset($return[$_table['name']]['fields'][$field['name']]) && $return[$_table['name']]['fields'][$field['name']]['status'] == 'nok') {
+                $result[$_table['name']]['fields'] = array_merge($result[$_table['name']]['fields'], self::compareField($field, $describe, $_table['name']));
+                if (isset($result[$_table['name']]['fields'][$field['name']]) && $result[$_table['name']]['fields'][$field['name']]['status'] == 'nok') {
                     $forceRebuildIndex = true;
                 }
                 $found = true;
             }
             if (!$found) {
-                $return[$_table['name']]['fields'][$field['name']] = array(
+                $result[$_table['name']]['fields'][$field['name']] = [
                     'status' => 'nok',
                     'message' => 'Not found',
                     'sql' => 'ALTER TABLE `' . $_table['name'] . '` ADD `' . $field['name'] . '`'
-                );
-                $return[$_table['name']]['fields'][$field['name']]['sql'] .= self::buildDefinitionField($field);
+                ];
+                $result[$_table['name']]['fields'][$field['name']]['sql'] .= self::buildDefinitionField($field);
             }
         }
         foreach ($describes as $describe) {
@@ -925,11 +924,11 @@ class DBHelper
                 }
             }
             if (!$found) {
-                $return[$_table['name']]['fields'][$describe['Field']] = array(
+                $result[$_table['name']]['fields'][$describe['Field']] = [
                     'status' => 'nok',
                     'message' => 'Should not exist',
                     'sql' => 'ALTER TABLE `' . $_table['name'] . '` DROP `' . $describe['Field'] . '`'
-                );
+                ];
             }
         }
         $showIndexes = self::prepareIndexCompare(self::getAll('show index from `' . $_table['name'] . '`', []));
@@ -939,16 +938,16 @@ class DBHelper
                 if ($showIndex['Key_name'] != $index['Key_name']) {
                     continue;
                 }
-                $return[$_table['name']]['indexes'] = array_merge($return[$_table['name']]['indexes'], self::compareIndex($index, $showIndex, $_table['name'], $forceRebuildIndex));
+                $result[$_table['name']]['indexes'] = array_merge($result[$_table['name']]['indexes'], self::compareIndex($index, $showIndex, $_table['name'], $forceRebuildIndex));
                 $found = true;
             }
             if (!$found) {
-                $return[$_table['name']]['indexes'][$index['Key_name']] = array(
+                $result[$_table['name']]['indexes'][$index['Key_name']] = [
                     'status' => 'nok',
                     'message' => 'Not found',
                     'sql' => ''
-                );
-                $return[$_table['name']]['indexes'][$index['Key_name']]['sql'] .= self::buildDefinitionIndex($index, $_table['name']);
+                ];
+                $result[$_table['name']]['indexes'][$index['Key_name']]['sql'] .= self::buildDefinitionIndex($index, $_table['name']);
             }
         }
         foreach ($showIndexes as $showIndex) {
@@ -960,14 +959,14 @@ class DBHelper
                 }
             }
             if (!$found) {
-                $return[$_table['name']]['indexes'][$showIndex['Key_name']] = array(
+                $result[$_table['name']]['indexes'][$showIndex['Key_name']] = [
                     'status' => 'nok',
                     'message' => 'Should not exist',
                     'sql' => 'ALTER TABLE `' . $_table['name'] . '` DROP INDEX `' . $showIndex['Key_name'] . '`;'
-                );
+                ];
             }
         }
-        return $return;
+        return $result;
     }
 
     /**
@@ -1053,7 +1052,7 @@ class DBHelper
      */
     private static function compareField($_ref_field, $_real_field, $_table_name)
     {
-        $return = array($_ref_field['name'] => array('status' => 'ok', 'sql' => ''));
+        $return = [$_ref_field['name'] => ['status' => 'ok', 'sql' => '']];
         if ($_ref_field['type'] != $_real_field['Type']) {
             $return[$_ref_field['name']]['status'] = 'nok';
             $return[$_ref_field['name']]['message'] = 'Type nok';
@@ -1097,14 +1096,14 @@ class DBHelper
                 continue;
             }
             if (!isset($return[$index['Key_name']])) {
-                $return[$index['Key_name']] = array(
+                $return[$index['Key_name']] = [
                     'Key_name' => $index['Key_name'],
                     'Non_unique' => 0,
                     'columns' => [],
-                );
+                ];
             }
             $return[$index['Key_name']]['Non_unique'] = $index['Non_unique'];
-            $return[$index['Key_name']]['columns'][$index['Seq_in_index']] = array('column' => $index['Column_name'], 'Sub_part' => $index['Sub_part']);
+            $return[$index['Key_name']]['columns'][$index['Seq_in_index']] = ['column' => $index['Column_name'], 'Sub_part' => $index['Sub_part']];
         }
         return $return;
     }
@@ -1118,7 +1117,7 @@ class DBHelper
      */
     private static function compareIndex($_ref_index, $_real_index, $_table_name, $_forceRebuild = false)
     {
-        $return = array($_ref_index['Key_name'] => array('status' => 'ok', 'presql' => '', 'sql' => ''));
+        $return = [$_ref_index['Key_name'] => ['status' => 'ok', 'presql' => '', 'sql' => '']];
         if ($_ref_index['Non_unique'] != $_real_index['Non_unique']) {
             $return[$_ref_index['Key_name']]['status'] = 'nok';
             $return[$_ref_index['Key_name']]['message'] = 'Non_unique nok';

--- a/src/Helpers/DataStorage.php
+++ b/src/Helpers/DataStorage.php
@@ -59,7 +59,7 @@ class DataStorage
     {
         $returnValue = false;
         $statement = DBHelper::getConnection()->prepare("SHOW TABLES LIKE ?");
-        $statement->execute(array($this->dataTableName));
+        $statement->execute([$this->dataTableName]);
         $dbResult = $statement->fetchAll(\PDO::FETCH_ASSOC);
         if (count($dbResult) > 0) {
             $returnValue = true;
@@ -83,7 +83,7 @@ class DataStorage
     public function deleteData(string $code)
     {
         $statement = DBHelper::getConnection()->prepare("DELETE FROM `" . $this->dataTableName . "` WHERE `code` = ?");
-        $statement->execute(array($code));
+        $statement->execute([$code]);
     }
 
     /**
@@ -140,7 +140,7 @@ class DataStorage
     {
         $returnValue = null;
         $statement = DBHelper::getConnection()->prepare("SELECT `data` FROM `" . $this->dataTableName . "` WHERE `code` = ?");
-        $statement->execute(array($code));
+        $statement->execute([$code]);
         $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
         if (count($result) > 0) {
             $returnValue = $result[0]['data'];
@@ -157,7 +157,7 @@ class DataStorage
     public function updateRawData(string $code, $data)
     {
         $statement = DBHelper::getConnection()->prepare("UPDATE `" . $this->dataTableName . "` SET `data` = ? WHERE `code` = ?");
-        $statement->execute(array($data, $code));
+        $statement->execute([$data, $code]);
 
     }
 
@@ -170,7 +170,7 @@ class DataStorage
     public function addRawData(string $code, $data)
     {
         $statement = DBHelper::getConnection()->prepare("INSERT INTO `" . $this->dataTableName . "` (`code`, `data`) VALUES (?, ?)");
-        $statement->execute(array($code, $data));
+        $statement->execute([$code, $data]);
     }
 
     /**
@@ -193,7 +193,7 @@ class DataStorage
     public function remove(string $code)
     {
         $statement = DBHelper::getConnection()->prepare("DELETE FROM `" . $this->dataTableName . "` WHERE `code` LIKE ?");
-        $statement->execute(array($code));
+        $statement->execute([$code]);
     }
 
     /**
@@ -206,7 +206,7 @@ class DataStorage
     public function getAllByPrefix(string $prefix): array
     {
         $statement = DBHelper::getConnection()->prepare("SELECT `data` FROM `" . $this->dataTableName . "` WHERE `code` LIKE ?");
-        $statement->execute(array($prefix . '%'));
+        $statement->execute([$prefix . '%']);
         $returnValue = $statement->fetchAll(\PDO::FETCH_ASSOC);
         return $returnValue;
     }

--- a/src/Helpers/DateHelper.php
+++ b/src/Helpers/DateHelper.php
@@ -52,48 +52,48 @@ class DateHelper
         if (ConfigManager::byKey('language', 'core', 'fr_FR') == 'en_US') {
             return $dateEn;
         }
-        $longTextEn = array(
+        $longTextEn = [
             '/(^| )Monday($| )/', '/(^| )Tuesday($| )/', '/(^| )Wednesday($| )/', '/(^| )Thursday($| )/',
             '/(^| )Friday($| )/', '/(^| )Saturday($| )/', '/(^| )Sunday($| )/', '/(^| )January($| )/',
             '/(^| )February($| )/', '/(^| )March($| )/', '/(^| )April($| )/', '/(^| )May($| )/',
             '/(^| )June($| )/', '/(^| )July($| )/', '/(^| )August($| )/', '/(^| )September($| )/',
             '/(^| )October($| )/', '/(^| )November($| )/', '/(^| )December($| )/',
-            );
-        $shortTextEn = array(
+        ];
+        $shortTextEn = [
             '/(^| )Mon($| )/', '/(^| )Tue($| )/', '/(^| )Wed($| )/', '/(^| )Thu($| )/', '/(^| )Fri($| )/', '/(^| )Sat($| )/', '/(^| )Sun($| )/',
             '/(^| )Jan($| )/', '/(^| )Feb($| )/', '/(^| )Mar($| )/', '/(^| )Apr($| )/', '/(^| )May($| )/', '/(^| )Jun($| )/', '/(^| )Jul($| )/',
             '/(^| )Aug($| )/', '/(^| )Sep($| )/', '/(^| )Oct($| )/', '/(^| )Nov($| )/', '/(^| )Dec($| )/',
-        );
+        ];
 
         switch (ConfigManager::byKey('language', 'core', 'fr_FR')) {
             case 'fr_FR':
-                $longText = array(
+                $longText = [
                     'Lundi', 'Mardi', 'Mercredi', 'Jeudi',
                     'Vendredi', 'Samedi', 'Dimanche', 'Janvier',
                     'Février', 'Mars', 'Avril', 'Mai',
                     'Juin', 'Juillet', 'Août', 'Septembre',
                     'Octobre', 'Novembre', 'Décembre',
-                );
-                $shortText = array(
+                ];
+                $shortText = [
                     'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim',
                     'Janv.', 'Févr.', 'Mars', 'Avril', 'Mai', 'Juin',
                     'Juil.', 'Août', 'Sept.', 'Oct.', 'Nov.', 'Déc.',
-                );
+                ];
                 break;
             case 'de_DE':
-                $longText = array(
+                $longText = [
                     'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag',
                     'Freitag', 'Samstag', 'Sonntag', 'Januar',
                     'Februar', 'März', 'April', 'May',
                     'Juni', 'July', 'August', 'September',
                     'October', 'November', 'December',
-                );
+                ];
 
-                $shortText = array(
+                $shortText = [
                     'Mon', 'Die', 'Mit', 'Thu', 'Don', 'Sam', 'Son',
                     'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
                     'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-                );
+                ];
                 break;
             default:
                 return $dateEn;
@@ -110,8 +110,8 @@ class DateHelper
     public static function convertDayFromEn($_day)
     {
         $result = $_day;
-        $daysMapping = array(
-            'fr_FR' => array(
+        $daysMapping = [
+            'fr_FR' => [
                 'Monday' => 'Lundi', 'Mon' => 'Lundi',
                 'monday' => 'lundi', 'mon' => 'lundi',
                 'Tuesday' => 'Mardi', 'Tue' => 'Mardi',
@@ -126,8 +126,8 @@ class DateHelper
                 'saturday' => 'samedi', 'sat' => 'samedi',
                 'Sunday' => 'Dimanche', 'Sun' => 'Dimanche',
                 'sunday' => 'dimanche', 'sun' => 'dimanche',
-            ),
-            'de_DE' => array(
+            ],
+            'de_DE' => [
                 'Monday' => 'Montag', 'Mon' => 'Montag',
                 'monday' => 'montag', 'mon' => 'montag',
                 'Tuesday' => 'Dienstag', 'Tue' => 'Dienstag',
@@ -142,8 +142,8 @@ class DateHelper
                 'saturday' => 'samstag', 'sat' => 'samstag',
                 'Sunday' => 'Sonntag', 'Sun' => 'Sonntag',
                 'sunday' => 'sonntag', 'sun' => 'sonntag',
-            ),
-        );
+            ],
+        ];
         $language = ConfigManager::byKey('language', 'core', 'fr_FR');
         if (array_key_exists($language, $daysMapping)) {
             $daysArray = $daysMapping[$language];
@@ -160,13 +160,13 @@ class DateHelper
      */
     public static function getNtpTime()
     {
-        $time_servers = array(
+        $time_servers = [
             'ntp2.emn.fr',
             'time-a.timefreq.bldrdoc.gov',
             'utcnist.colorado.edu',
             'time.nist.gov',
             'ntp.pads.ufrj.br',
-        );
+        ];
         $time_adjustment = 0;
         foreach ($time_servers as $time_server) {
             $fp = fsockopen($time_server, 37, $errno, $errstr, 1);

--- a/src/Helpers/FileSystemHelper.php
+++ b/src/Helpers/FileSystemHelper.php
@@ -54,7 +54,7 @@ class FileSystemHelper
      */
     public static function includeFile($_folder, $_filename, $_type, $_plugin = '', $translate = false)
     {
-        if(strpos($_folder,'..') !== false || strpos($_filename,'..') !== false){
+        if (strpos($_folder, '..') !== false || strpos($_filename, '..') !== false) {
             return;
         }        // Aucune particularité pour les 3rdparty
         if ($_folder == '3rdparty') {
@@ -71,25 +71,25 @@ class FileSystemHelper
             $type = $_type;
         } else {
             // Tableau de mappage des fichiers
-            $config = array(
-                'class' => array('/class', '.class.php', 'php'),
-                'com' => array('/com', '.com.php', 'php'),
-                'repo' => array('/repo', '.repo.php', 'php'),
-                'config' => array('/config', '.config.php', 'php'),
-                'modal' => array('/modal', '.php', 'php'),
-                'modalhtml' => array('/modal', '.html', 'php'),
-                'php' => array('/php', '.php', 'php'),
-                'css' => array('/css', '.css', 'css'),
-                'js' => array('/js', '.js', 'js'),
-                'class.js' => array('/js', '.class.js', 'js'),
-                'custom.js' => array('/custom', 'custom.js', 'js'),
-                'custom.css' => array('/custom', 'custom.css', 'css'),
-                'themes.js' => array('/themes', '.js', 'js'),
-                'themes.css' => array('/themes', '.css', 'css'),
-                'api' => array('/api', '.api.php', 'php'),
-                'html' => array('/html', '.html', 'php'),
-                'configuration' => array('', '.php', 'php'),
-            );
+            $config = [
+                'class' => ['/class', '.class.php', 'php'],
+                'com' => ['/com', '.com.php', 'php'],
+                'repo' => ['/repo', '.repo.php', 'php'],
+                'config' => ['/config', '.config.php', 'php'],
+                'modal' => ['/modal', '.php', 'php'],
+                'modalhtml' => ['/modal', '.html', 'php'],
+                'php' => ['/php', '.php', 'php'],
+                'css' => ['/css', '.css', 'css'],
+                'js' => ['/js', '.js', 'js'],
+                'class.js' => ['/js', '.class.js', 'js'],
+                'custom.js' => ['/custom', 'custom.js', 'js'],
+                'custom.css' => ['/custom', 'custom.css', 'css'],
+                'themes.js' => ['/themes', '.js', 'js'],
+                'themes.css' => ['/themes', '.css', 'css'],
+                'api' => ['/api', '.api.php', 'php'],
+                'html' => ['/html', '.html', 'php'],
+                'configuration' => ['', '.php', 'php'],
+            ];
             $_folder .= $config[$_type][0];
             $_filename .= $config[$_type][1];
             $type = $config[$_type][2];
@@ -116,11 +116,11 @@ class FileSystemHelper
             if ($_type != 'class') {
                 ob_start();
                 require_once $path;
-                    if ($translate) {
-                        echo TranslateHelper::exec(ob_get_clean(), $_folder . '/' . $_filename);
-                    } else {
-                        echo ob_get_clean();
-                    }
+                if ($translate) {
+                    echo TranslateHelper::exec(ob_get_clean(), $_folder . '/' . $_filename);
+                } else {
+                    echo ob_get_clean();
+                }
             } else {
                 require_once $path;
             }
@@ -205,6 +205,19 @@ class FileSystemHelper
     }
 
     /**
+     * Read content of a core template file
+     * @param string $version View version
+     * @param string $filename Name of the template file
+     * @param string $pluginId Plugin (todo: remove)
+     * @param string $theme Theme if necessary
+     * @return string
+     */
+    public static function getCoreTemplateFileContent($version, $filename, $pluginId = '', $theme = ''): string
+    {
+        return self::getTemplateFileContent('views', $version, $filename, $pluginId, $theme);
+    }
+
+    /**
      * Obtenir le contenu d'un fichier template.
      *
      * @param string $folder Répertoire dans lequel se trouve le fichier de template
@@ -215,7 +228,7 @@ class FileSystemHelper
      *
      * @return string Contenu du fichier ou une chaine vide.
      */
-    public static function getTemplateFileContent($folder, $version, $filename, $pluginId = '' , $theme = ''): string
+    public static function getTemplateFileContent($folder, $version, $filename, $pluginId = '', $theme = ''): string
     {
         $result = '';
         $filePath = NEXTDOM_ROOT . '/';
@@ -235,19 +248,6 @@ class FileSystemHelper
             $result = file_get_contents($filePath);
         }
         return $result;
-    }
-
-    /**
-     * Read content of a core template file
-     * @param string $version View version
-     * @param string $filename Name of the template file
-     * @param string $pluginId Plugin (todo: remove)
-     * @param string $theme Theme if necessary
-     * @return string
-     */
-    public static function getCoreTemplateFileContent($version, $filename, $pluginId = '', $theme = ''): string
-    {
-        return self::getTemplateFileContent('views', $version, $filename, $pluginId, $theme);
     }
 
     /**
@@ -285,7 +285,7 @@ class FileSystemHelper
      *
      * @return array Content list
      */
-    public static function ls($folder = "", $pattern = "*", $recursivly = false, $options = array('files', 'folders'))
+    public static function ls($folder = "", $pattern = "*", $recursivly = false, $options = ['files', 'folders'])
     {
         $currentFolder = '';
         if ($folder) {
@@ -293,22 +293,22 @@ class FileSystemHelper
             if (in_array('quiet', $options)) {
                 // If quiet is on, we will suppress the 'no such folder' error
                 if (!file_exists($folder)) {
-                    return array();
+                    return [];
                 }
 
             }
             if (!is_dir($folder) || !chdir($folder)) {
-                return array();
+                return [];
             }
 
         }
         $getFiles = in_array('files', $options);
         $getFolders = in_array('folders', $options);
-        $both = array();
-        $folders = array();
+        $both = [];
+        $folders = [];
         // Get the all files and folders in the given directory.
         if ($getFiles) {
-            $both = array();
+            $both = [];
             foreach (Utils::globBrace($pattern, GLOB_MARK) as $file) {
                 if (!is_dir($folder . '/' . $file)) {
                     $both[] = $file;
@@ -320,7 +320,7 @@ class FileSystemHelper
         }
 
         //If a pattern is specified, make sure even the folders match that pattern.
-        $matching_folders = array();
+        $matching_folders = [];
         if ($pattern !== '*') {
             $matching_folders = glob($pattern, GLOB_ONLYDIR + GLOB_MARK);
         }
@@ -383,7 +383,7 @@ class FileSystemHelper
      * @param array $_params
      * @return bool
      */
-    public static function rcopy($src, $dst, $_emptyDest = true, $_exclude = array(), $_noError = false, $_params = array())
+    public static function rcopy($src, $dst, $_emptyDest = true, $_exclude = [], $_noError = false, $_params = [])
     {
         if (!file_exists($src)) {
             return true;
@@ -425,7 +425,7 @@ class FileSystemHelper
                     return true;
                 }
                 if (!copy($src, $dst)) {
-                    $output = array();
+                    $output = [];
                     $retval = 0;
                     exec('sudo cp ' . $src . ' ' . $dst, $output, $retval);
                     if ($retval != 0) {
@@ -457,11 +457,11 @@ class FileSystemHelper
     public static function rrmdir($dir): bool
     {
         // Check if we remove our own folders/files only
-        if(!(substr($dir, 0, strlen(NEXTDOM_ROOT)) === NEXTDOM_ROOT
+        if (!(substr($dir, 0, strlen(NEXTDOM_ROOT)) === NEXTDOM_ROOT
             || substr($dir, 0, strlen(NEXTDOM_DATA)) === NEXTDOM_DATA
             || substr($dir, 0, strlen(NEXTDOM_LOG)) === NEXTDOM_LOG
             || substr($dir, 0, strlen(NEXTDOM_TMP)) === NEXTDOM_TMP
-            || substr($dir, 0, strlen('/tmp')) === '/tmp')){
+            || substr($dir, 0, strlen('/tmp')) === '/tmp')) {
 
             return false;
         }
@@ -474,7 +474,7 @@ class FileSystemHelper
                 }
             }
             if (!rmdir($dir)) {
-                $output = array();
+                $output = [];
                 $retval = 0;
                 exec('sudo rm -rf ' . $dir, $output, $retval);
                 if ($retval != 0) {
@@ -483,7 +483,7 @@ class FileSystemHelper
             }
         } elseif (file_exists($dir)) {
             if (!unlink($dir)) {
-                $output = array();
+                $output = [];
                 $retval = 0;
                 exec('sudo rm -rf ' . $dir, $output, $retval);
                 if ($retval != 0) {
@@ -516,7 +516,7 @@ class FileSystemHelper
      * @param array $_params
      * @return bool
      */
-    public static function rmove($src, $dst, $_emptyDest = true, $_exclude = array(), $_noError = false, $_params = array())
+    public static function rmove($src, $dst, $_emptyDest = true, $_exclude = [], $_noError = false, $_params = [])
     {
         if (!file_exists($src)) {
             return true;
@@ -558,7 +558,7 @@ class FileSystemHelper
                     return true;
                 }
                 if (!rename($src, $dst)) {
-                    $output = array();
+                    $output = [];
                     $retval = 0;
                     exec('sudo mv ' . $src . ' ' . $dst, $output, $retval);
                     if ($retval != 0) {
@@ -589,10 +589,10 @@ class FileSystemHelper
      * @return bool
      * @throws CoreException
      */
-    public static function createZip($source_arr, $destination, $_excludes = array())
+    public static function createZip($source_arr, $destination, $_excludes = [])
     {
         if (is_string($source_arr)) {
-            $source_arr = array($source_arr);
+            $source_arr = [$source_arr];
         }
         if (!extension_loaded('zip')) {
             throw new CoreException('Extension php ZIP non chargée');
@@ -664,7 +664,7 @@ class FileSystemHelper
      */
     public static function getDirectoryFreeSpace($directory)
     {
-        return disk_free_space ( $directory );
+        return disk_free_space($directory);
     }
 
 
@@ -675,7 +675,7 @@ class FileSystemHelper
      */
     public static function isFileExists($file)
     {
-        return file_exists ( $file );
+        return file_exists($file);
     }
 
     /**

--- a/src/Helpers/LogHelper.php
+++ b/src/Helpers/LogHelper.php
@@ -39,6 +39,7 @@ use Monolog\Handler\SyslogHandler;
 use Monolog\Handler\SyslogUdpHandler;
 use Monolog\Logger;
 use NextDom\Com\ComShell;
+use NextDom\Exceptions\CoreException;
 use NextDom\Managers\ConfigManager;
 use NextDom\Managers\MessageManager;
 use SplFileObject;
@@ -74,54 +75,6 @@ class LogHelper
     public static function addError($targetLog, $message, $logicalId = '')
     {
         return self::add($targetLog, 'error', $message, $logicalId);
-    }
-
-    /**
-     * Log an information
-     *
-     * @param string $targetLog Target log file
-     * @param string $message Message to log
-     * @param string $logicalId Logical id linked to this log (optional)
-     *
-     * @return bool
-     *
-     * @throws \Exception
-     */
-    public static function addInfo($targetLog, $message, $logicalId = '')
-    {
-        return self::add($targetLog, 'info', $message, $logicalId);
-    }
-
-    /**
-     * Log a debug
-     *
-     * @param string $targetLog Target log file
-     * @param string $message Message to log
-     * @param string $logicalId Logical id linked to this log (optional)
-     *
-     * @return bool
-     *
-     * @throws \Exception
-     */
-    public static function addDebug($targetLog, $message, $logicalId = '')
-    {
-        return self::add($targetLog, 'debug', $message, $logicalId);
-    }
-
-    /**
-     * Log a critical message
-     *
-     * @param string $targetLog Target log file
-     * @param string $message Message to log
-     * @param string $logicalId Logical id linked to this log (optional)
-     *
-     * @return bool
-     *
-     * @throws \Exception
-     */
-    public static function addCritical($targetLog, $message, $logicalId = '')
-    {
-        return self::add($targetLog, 'critical', $message, $logicalId);
     }
 
     /**
@@ -202,7 +155,7 @@ class LogHelper
     {
         // Load config data
         if (self::$config === null) {
-            self::$config = array_merge(ConfigManager::getLogLevelPlugin(), ConfigManager::byKeys(array('log::engine', 'log::formatter', 'log::level', 'addMessageForErrorLog', 'maxLineLog')));
+            self::$config = array_merge(ConfigManager::getLogLevelPlugin(), ConfigManager::byKeys(['log::engine', 'log::formatter', 'log::level', 'addMessageForErrorLog', 'maxLineLog']));
         }
         if (isset(self::$config[$configKey])) {
             return self::$config[$configKey];
@@ -248,6 +201,86 @@ class LogHelper
     public static function getPathToLog($targetLog = 'core'): string
     {
         return NEXTDOM_LOG . '/' . $targetLog;
+    }
+
+    /**
+     * Log an information
+     *
+     * @param string $targetLog Target log file
+     * @param string $message Message to log
+     * @param string $logicalId Logical id linked to this log (optional)
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    public static function addInfo($targetLog, $message, $logicalId = '')
+    {
+        return self::add($targetLog, 'info', $message, $logicalId);
+    }
+
+    /**
+     * Log a debug
+     *
+     * @param string $targetLog Target log file
+     * @param string $message Message to log
+     * @param string $logicalId Logical id linked to this log (optional)
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    public static function addDebug($targetLog, $message, $logicalId = '')
+    {
+        return self::add($targetLog, 'debug', $message, $logicalId);
+    }
+
+    /**
+     * Log a critical message
+     *
+     * @param string $targetLog Target log file
+     * @param string $message Message to log
+     * @param string $logicalId Logical id linked to this log (optional)
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    public static function addCritical($targetLog, $message, $logicalId = '')
+    {
+        return self::add($targetLog, 'critical', $message, $logicalId);
+    }
+
+    /**
+     * Log an update message
+     *
+     * @param string $targetLog Target log file
+     * @param string $message Message to log
+     * @param string $logicalId Logical id linked to this log (optional)
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    public static function addUpdate($targetLog, $message, $logicalId = '')
+    {
+        return self::add($targetLog, 'update', $message, $logicalId);
+    }
+
+    /**
+     * Log an alert message
+     *
+     * @param string $targetLog Target log file
+     * @param string $message Message to log
+     * @param string $logicalId Logical id linked to this log (optional)
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    public static function addAlert($targetLog, $message, $logicalId = '')
+    {
+        return self::add($targetLog, 'alert', $message, $logicalId);
     }
 
     /**
@@ -353,9 +386,9 @@ class LogHelper
             while ($log->valid() && $linesRead != $nbLines) {
                 $line = trim($log->current()); //get current line
                 if ($line != '') {
-                    if(function_exists('mb_convert_encoding')){
+                    if (function_exists('mb_convert_encoding')) {
                         array_unshift($page, mb_convert_encoding($line, 'UTF-8'));
-                    }else {
+                    } else {
                         array_unshift($page, $line);
                     }
                 }
@@ -379,7 +412,7 @@ class LogHelper
         if ($targetLog != '') {
             $paths[] = self::getPathToLog($targetLog);
         } else {
-            $relativeLogPaths = array('', 'scenarioLog/');
+            $relativeLogPaths = ['', 'scenarioLog/'];
             foreach ($relativeLogPaths as $relativeLogPath) {
                 $logPath = self::getPathToLog($relativeLogPath);
                 $logs = FileSystemHelper::ls($logPath, '*');
@@ -438,7 +471,7 @@ class LogHelper
      *
      * @return array List of files
      */
-    public static function liste($filter = null) 
+    public static function liste($filter = null)
     {
         trigger_error('This method is deprecated', E_USER_DEPRECATED);
         return self::getLogFileList($filter);
@@ -516,7 +549,7 @@ class LogHelper
                 error_reporting(E_ERROR | E_PARSE);
                 break;
             default:
-                throw new \Exception('log::level invalide ("' . $log_level . '")');
+                throw new CoreException('log::level invalide ("' . $log_level . '")');
                 break;
         }
     }

--- a/src/Helpers/MigrationHelper.php
+++ b/src/Helpers/MigrationHelper.php
@@ -463,20 +463,22 @@ class MigrationHelper
      */
     private static function migrate_0_5_2($logFile = LogTarget::MIGRATION)
     {
-          if (is_dir(NEXTDOM_DATA . '/data/php')) {
-              FileSystemHelper::rrmfile(NEXTDOM_DATA . '/data/php/user.function.class.php');
-              FileSystemHelper::rrmfile(NEXTDOM_DATA . '/data/php/user.function.class.sample.php');
-          }
-          $message = 'user.function files removed';
-          if ($logFile == LogTarget::MIGRATION) {
-              LogHelper::addInfo($logFile, $message, '');
-          } else {
-              ConsoleHelper::process($message);
-          }
+        if (is_dir(NEXTDOM_DATA . '/data/php')) {
+            FileSystemHelper::rrmfile(NEXTDOM_DATA . '/data/php/user.function.class.php');
+            FileSystemHelper::rrmfile(NEXTDOM_DATA . '/data/php/user.function.class.sample.php');
+        }
+        $message = 'user.function files removed';
+        if ($logFile == LogTarget::MIGRATION) {
+            LogHelper::addInfo($logFile, $message, '');
+        } else {
+            ConsoleHelper::process($message);
+        }
     }
+
     /***********************************************************************************************************************************************************/
 
-    private static function migrate_0_6_1($logFile = LogTarget::MIGRATION) {
+    private static function migrate_0_6_1($logFile = LogTarget::MIGRATION)
+    {
         exec("sudo sed -i '/vm.swappiness=/d' /etc/sysctl.d/99-sysctl.conf");
         exec("sudo echo 'vm.swappiness=10' >> /etc/sysctl.d/99-sysctl.conf");
     }

--- a/src/Helpers/NetworkHelper.php
+++ b/src/Helpers/NetworkHelper.php
@@ -34,6 +34,7 @@
 
 namespace NextDom\Helpers;
 
+use NextDom\Enums\LogTarget;
 use NextDom\Enums\UserLocation;
 use NextDom\Exceptions\CoreException;
 use NextDom\Managers\ConfigManager;
@@ -130,7 +131,7 @@ class NetworkHelper
         }
         if ($_mode == UserLocation::INTERNAL) {
             if (strpos(ConfigManager::byKey('internalAddr', 'core', $_default), 'http://') !== false || strpos(ConfigManager::byKey('internalAddr', 'core', $_default), 'https://') !== false) {
-                ConfigManager::save('internalAddr', str_replace(array('http://', 'https://'), '', ConfigManager::byKey('internalAddr', 'core', $_default)));
+                ConfigManager::save('internalAddr', str_replace(['http://', 'https://'], '', ConfigManager::byKey('internalAddr', 'core', $_default)));
             }
             if ($_protocol == 'ip' || $_protocol == 'dns') {
                 return ConfigManager::byKey('internalAddr', 'core', $_default);
@@ -395,13 +396,13 @@ class NetworkHelper
         }
         $data = curl_exec($ch);
         if (curl_errno($ch)) {
-            LogHelper::add('network', 'debug', 'Erreur sur ' . $url . ' => ' . curl_errno($ch));
+            LogHelper::addDebug(LogTarget::NETWORK, 'Erreur sur ' . $url . ' => ' . curl_errno($ch));
             curl_close($ch);
             return false;
         }
         curl_close($ch);
         if (trim($data) != 'ok') {
-            LogHelper::add('network', 'debug', 'Retour NOK sur ' . $url . ' => ' . $data);
+            LogHelper::addDebug(LogTarget::NETWORK, 'Retour NOK sur ' . $url . ' => ' . $data);
             return false;
         }
         return true;
@@ -417,7 +418,7 @@ class NetworkHelper
         if (isset($result['host'])) {
             $_string = $result['host'];
         } else {
-            $_string = str_replace(array('https://', 'http://'), '', $_string);
+            $_string = str_replace(['https://', 'http://'], '', $_string);
             if (strpos($_string, '/') !== false) {
                 $_string = substr($_string, 0, strpos($_string, '/'));
             }
@@ -522,9 +523,9 @@ class NetworkHelper
         $openvpn->setEqType_name('openvpn');
         $openvpn->setConfiguration('dev', 'tun');
         $openvpn->setConfiguration('proto', 'udp');
-        if(ConfigManager::byKey('dns::vpnurl') != ''){
+        if (ConfigManager::byKey('dns::vpnurl') != '') {
             $openvpn->setConfiguration('remote_host', ConfigManager::byKey('dns::vpnurl'));
-        }else{
+        } else {
             $openvpn->setConfiguration('remote_host', 'vpn.dns' . ConfigManager::byKey('dns::number', 'core', 1) . '.jeedom.com');
         }
         $openvpn->setConfiguration('username', NextDomHelper::getHardwareKey());
@@ -532,9 +533,9 @@ class NetworkHelper
         $openvpn->setConfiguration('compression', 'comp-lzo');
         $openvpn->setConfiguration('remote_port', ConfigManager::byKey('vpn::port', 'core', 1194));
         $openvpn->setConfiguration('auth_mode', 'password');
-        if(ConfigManager::byKey('connection::4g') == 1){
+        if (ConfigManager::byKey('connection::4g') == 1) {
             $openvpn->setConfiguration('optionsAfterStart', 'sudo ip link set dev #interface# mtu 1300');
-        }else{
+        } else {
             $openvpn->setConfiguration('optionsAfterStart', '');
         }
         $openvpn->save(true);

--- a/src/Helpers/NextDomHelper.php
+++ b/src/Helpers/NextDomHelper.php
@@ -54,6 +54,7 @@ use NextDom\Managers\ScenarioExpressionManager;
 use NextDom\Managers\ScenarioManager;
 use NextDom\Managers\UpdateManager;
 use NextDom\Managers\ViewManager;
+use NextDom\Model\DataClass\SystemHealth;
 use NextDom\Repo\RepoMarket;
 
 /**
@@ -73,7 +74,7 @@ class NextDomHelper
      */
     public static function addRemoveHistory($data)
     {
-        $removeHistory = array();
+        $removeHistory = [];
         $removeHistoryPath = NEXTDOM_DATA . '/data/remove_history.json';
         if (file_exists($removeHistoryPath)) {
             $removeHistory = json_decode(file_get_contents($removeHistoryPath), true);
@@ -92,21 +93,21 @@ class NextDomHelper
     public static function getDeadCmd()
     {
         global $NEXTDOM_INTERNAL_CONFIG;
-        $result = array();
+        $result = [];
         $cmd = ConfigManager::byKey('interact::warnme::defaultreturncmd', 'core', '');
         if ($cmd != '' && !CmdManager::byId(str_replace('#', '', $cmd))) {
-            $result[] = array('detail' => 'Administration', 'help' => __('Commande retour interactions'), 'who' => $cmd);
+            $result[] = ['detail' => 'Administration', 'help' => __('Commande retour interactions'), 'who' => $cmd];
         }
         $cmd = ConfigManager::byKey('emailAdmin', 'core', '');
         if ($cmd != '' && !CmdManager::byId(str_replace('#', '', $cmd))) {
-            $result[] = array('detail' => 'Administration', 'help' => __('Commande information utilisateur'), 'who' => $cmd);
+            $result[] = ['detail' => 'Administration', 'help' => __('Commande information utilisateur'), 'who' => $cmd];
         }
         foreach ($NEXTDOM_INTERNAL_CONFIG['alerts'] as $level => $value) {
             $cmds = ConfigManager::byKey('alert::' . $level . 'Cmd', 'core', '');
             preg_match_all("/#([0-9]*)#/", $cmds, $matches);
             foreach ($matches[1] as $cmd_id) {
                 if (CmdManager::byId($cmd_id)) {
-                    $result[] = array('detail' => 'Administration', 'help' => __('Commande sur ') . $value['name'], 'who' => '#' . $cmd_id . '#');
+                    $result[] = ['detail' => 'Administration', 'help' => __('Commande sur ') . $value['name'], 'who' => '#' . $cmd_id . '#'];
                 }
             }
         }
@@ -125,11 +126,11 @@ class NextDomHelper
         $okStr = __('common.ok');
         $nokStr = __('common.nok');
 
-        $systemHealth = array();
+        $systemHealth = [];
 
         $state = true;
         $version = '';
-        $uname = shell_exec('uname -a');
+        $uname = SystemHelper::getSystemInformations();
         if (SystemHelper::getDistrib() != 'debian') {
             $state = false;
         } else {
@@ -139,278 +140,107 @@ class NextDomHelper
                 && strpos($version, 'stretch') === false
                 && strpos($version, 'buster') === false) {
                 $state = false;
-            }   
+            }
         }
-        $systemHealth[] = array(
-            'icon' => 'fa-cogs',
-            'name' => __('health.os-version'),
-            'state' => $state,
-            'result' => ($state) ? $uname . ' [' . $version . ']' : $uname,
-            'comment' => ($state) ? '' : __('health.os-not-supported'),
-        );
+        $systemHealth[] = new SystemHealth(
+            'fa-cogs',
+            'health.os-version',
+            $state,
+            ($state) ? $uname . ' [' . $version . ']' : $uname,
+            ($state) ? '' : __('health.os-not-supported'),
+            'os::version');
 
         $nbNeededUpdate = UpdateManager::nbNeedUpdate();
         $state = ($nbNeededUpdate == 0) ? true : false;
-        $systemHealth[] = array(
-            'icon' => 'fa-heartbeat',
-            'name' => __('health.update-to-date'),
-            'state' => $state,
-            'result' => ($state) ? $okStr : $nbNeededUpdate . ' ' . __('health.updates'),
-            'comment' => '',
-            'key' => 'uptodate'
-        );
+        $systemHealth[] = new SystemHealth('fa-heartbeat', 'health.update-to-date', $state, ($state) ? $okStr : $nbNeededUpdate . ' ' . __('health.updates'), '', 'uptodate');
 
         $state = ConfigManager::byKey(ConfigKey::ENABLE_CRON, 'core', 1, true) != 0;
-        $systemHealth[] = array(
-            'icon' => 'fa-calendar-alt',
-            'name' => __('health.cron-enabled'),
-            'state' => $state,
-            'result' => ($state) ? $okStr : $nokStr,
-            'comment' => ($state) ? '' : __('health.cron-disabled'),
-            'key' => 'cron::enable'
-        );
+        $systemHealth[] = new SystemHealth('fa-calendar-alt', 'health.cron-enabled', $state, ($state) ? $okStr : $nokStr, ($state) ? '' : __('health.cron-disabled'), 'cron::enable');
 
         $state = !(ConfigManager::byKey(ConfigKey::ENABLE_SCENARIO) == 0 && count(ScenarioManager::all()) > 0);
-        $systemHealth[] = array(
-            'icon' => 'fa-film',
-            'name' => __('health.scenario-enabled'),
-            'state' => $state,
-            'result' => ($state) ? $okStr : $nokStr,
-            'comment' => ($state) ? '' : __('health.scenario-disabled'),
-            'key' => 'scenario::enable'
-        );
+        $systemHealth[] = new SystemHealth('fa-film', 'health.scenario-enabled', $state, ($state) ? $okStr : $nokStr, ($state) ? '' : __('health.scenario-disabled'), 'scenario::enable');
 
         $state = self::isStarted();
-        $systemHealth[] = array(
-            'icon' => 'fa-play',
-            'name' => __('health.product-started'),
-            'state' => $state,
-            'result' => ($state) ? $okStr . ' - ' . file_get_contents(self::getStartedFilePath()) : $nokStr,
-            'comment' => '',
-            'key' => 'isStarted'
-        );
+        $systemHealth[] = new SystemHealth('fa-play', 'health.product-started', $state, ($state) ? $okStr . ' - ' . file_get_contents(self::getStartedFilePath()) : $nokStr, '', 'isStarted');
 
         $state = self::isDateOk();
         $cache = CacheManager::byKey('hour');
         $lastKnowDate = $cache->getValue();
-        $systemHealth[] = array(
-            'icon' => 'fa-clock',
-            'name' => __('health.system-date'),
-            'state' => $state,
-            'result' => ($state) ? $okStr . ' - ' . date(DateFormat::FULL) . ' (' . $lastKnowDate . ')' : date(DateFormat::FULL),
-            'comment' => ($state) ? '' : __('health.system-date-error'),
-            'key' => 'hour'
-        );
+        $systemHealth[] = new SystemHealth('fa-clock', 'health.system-date', $state, ($state) ? $okStr . ' - ' . date(DateFormat::FULL) . ' (' . $lastKnowDate . ')' : date(DateFormat::FULL), ($state) ? '' : __('health.system-date-error'), 'hour');
 
         $state = self::isCapable('sudo', true);
-        $systemHealth[] = array(
-            'icon' => 'fa-user-secret',
-            'name' => __('health.sudo-rights'),
-            'state' => ($state) ? 1 : 2,
-            'result' => ($state) ? $okStr : $nokStr,
-            'comment' => ($state) ? '' : __('sudo-error'),
-            'key' => 'sudo::right'
-        );
+        $systemHealth[] = new SystemHealth('fa-user-secret', 'health.sudo-rights', ($state) ? 1 : 2, ($state) ? $okStr : $nokStr, ($state) ? '' : __('sudo-error'), 'sudo::right');
 
-        $systemHealth[] = array(
-            'icon' => 'fa-code-branch',
-            'name' => __('health.product-version'),
-            'state' => true,
-            'result' => self::getNextdomVersion(),
-            'comment' => '',
-            'key' => 'nextdom::version'
-        );
+        $systemHealth[] = new SystemHealth('fa-code-branch', 'health.product-version', true, self::getNextdomVersion(), '', 'nextdom::version');
 
         $state = version_compare(phpversion(), '7.0', '>=');
-        $systemHealth[] = array(
-            'icon' => 'fa-code',
-            'name' => __('health.php-version'),
-            'state' => $state,
-            'result' => phpversion(),
-            'comment' => ($state) ? '' : __('health.php-error'),
-        );
-
-        $state = version_compare(phpversion(), '5.5', '>=');
-        $systemHealth[] = array(
-            'name' => __('Version PHP'),
-            'state' => $state,
-            'result' => phpversion(),
-            'comment' => ($state) ? '' : __('Si vous êtes en version 5.4.x on vous indiquera quand la version 5.5 sera obligatoire'),
-            'key' => 'php::version'
-        );
-
-        $state = true;
-        $version = '';
-        $uname = shell_exec('uname -a');
-        if (SystemHelper::getDistrib() != 'debian') {
-            $state = false;
-        } else {
-            $version = trim(strtolower(file_get_contents('/etc/debian_version')));
-            if (version_compare($version, '8', '<')) {
-                if (strpos($version, 'jessie') === false && strpos($version, 'stretch') === false) {
-                    $state = false;
-                }
-            }
-        }
-        $systemHealth[] = array(
-            'name' => __('Version OS'),
-            'state' => $state,
-            'result' => ($state) ? $uname . ' [' . $version . ']' : $uname,
-            'comment' => ($state) ? '' : __('Vous n\'êtes pas sur un OS officiellement supporté par l\'équipe Jeedom (toute demande de support pourra donc être refusée). Les OS officiellement supporté sont Debian Jessie et Debian Strech (voir <a href="https://jeedom.github.io/documentation/compatibility/fr_FR/index" target="_blank">ici</a>)'),
-            'key' => 'os::version'
-        );
+        $systemHealth[] = new SystemHealth('fa-code', 'health.php-version', $state, phpversion(), ($state) ? '' : __('health.php-error'), 'php::version');
 
         $version = DBHelper::getOne('select version()');
-        $systemHealth[] = array(
-            'icon' => 'fa-database',
-            'name' => __('health.database-version'),
-            'state' => true,
-            'result' => $version['version()'],
-            'comment' => '',
-            'key' => 'database::version'
-
-        );
+        $systemHealth[] = new SystemHealth('fa-database', 'health.database-version', true, $version['version()'], ($state) ? '' : __('health.php-error'), 'database::version');
 
         $value = self::checkSpaceLeft();
-        $systemHealth[] = array(
-            'icon' => 'fa-hdd',
-            'name' => __('health.harddisk-freespace'),
-            'state' => ($value > 10),
-            'result' => $value . ' %',
-            'comment' => __('health.need-more-than') . ': 10%',
-            'key' => 'space::root'
-        );
+        $systemHealth[] = new SystemHealth('fa-hdd', 'health.harddisk-freespace', ($value > 10), $value . ' %', __('health.need-more-than') . ': 10%', 'space::root');
 
         $value = self::checkSpaceLeft(self::getTmpFolder());
-        $systemHealth[] = array(
-            'name' => __('Espace disque libre tmp'),
-            'state' => ($value > 10),
-            'result' => $value . ' %',
-            'comment' => __('En cas d\'erreur essayez de redémarrer. Si le problème persiste, testez en désactivant les plugins un à un jusqu\'à trouver le coupable'),
-            'key' => 'space::tmp'
-        );
+        $systemHealth[] = new SystemHealth('fa-hdd', 'health.tmp-space-left', ($value > 10), $value . ' %', __('health.tmp-problem') . ': 10%', 'space::tmp');
 
         $values = SystemHelper::getMemInfo();
         $value = round(($values['MemAvailable'] / $values['MemTotal']) * 100);
-        $systemHealth[] = array(
-            'icon' => 'fa-th',
-            'name' => __('health.available-memory'),
-            'state' => ($value > 15),
-            'result' => $value . ' %',
-            'comment' => __('health.need-more-than') . ': 15%',
-            'key' => 'meminfo'
-        );
+        $systemHealth[] = new SystemHealth('fa-th', 'health.available-memory', ($value > 15), $value . ' %', __('health.need-more-than') . ': 15%', 'meminfo');
 
         $value = shell_exec('sudo dmesg | grep oom | grep -v deprecated | wc -l');
-        $systemHealth[] = array(
-            'icon' => 'fa-th-large',
-            'name' => __('health.enough-memory'),
-            'state' => ($value == 0),
-            'result' => ($state == 0) ? $nokStr : $okStr,
-            'comment' => ($value == 0) ? '' : __('health.processes-killed'),
-            'key' => 'oom'
-        );
+        $systemHealth[] = new SystemHealth('fa-th-large', 'health.enough-memory', ($value == 0), ($state == 0) ? $nokStr : $okStr, ($value == 0) ? '' : __('health.processes-killed'), 'oom');
 
         $value = shell_exec('sudo dmesg | grep "CRC error" | grep "mmcblk0" | grep "card status" | wc -l');
-        if(!is_numeric($value)){
+        if (!is_numeric($value)) {
             $value = 0;
         }
         $value2 = @shell_exec('sudo dmesg | grep "I/O error" | wc -l');
-        if(is_numeric($value2)){
+        if (is_numeric($value2)) {
             $value += $value2;
         }
-        $systemHealth[] = array(
-            'name' => __('Erreur I/O'),
-            'state' => ($value == 0),
-            'result' => $value,
-            'comment' => ($value == 0) ? '' : __('Il y a des erreurs disque, cela peut indiquer un soucis avec le disque ou un problème d\'alimentation'),
-            'key' => 'io_error'
-        );
+        $systemHealth[] = new SystemHealth('fa fa-hearth', __('Erreur I/O'), $value == 0, $value, ($value == 0) ? '' : __('Il y a des erreurs disque, cela peut indiquer un soucis avec le disque ou un problème d\'alimentation'), 'io_error');
 
         if ($values['SwapTotal'] != 0 && $values['SwapTotal'] !== null) {
             $value = round(($values['SwapFree'] / $values['SwapTotal']) * 100);
-            $systemHealth[] = array(
-                'icon' => 'fa-hdd',
-                'name' => __('health.available-swap'),
-                'state' => ($value > 15),
-                'result' => $value . ' %',
-                'comment' => __('health.need-more-than') . ': 15%',
-                'key' => 'swap'
-            );
+            $systemHealth[] = new SystemHealth('fa-hdd', 'health.available-swap', ($value > 15), $value . ' %', __('health.need-more-than') . ': 15%', 'swap');
         } else {
-            $systemHealth[] = array(
-                'icon' => 'fa-hdd',
-                'name' => __('health.available-swap'),
-                'state' => 2,
-                'result' => __('health.unknow'),
-                'comment' => '',
-                'key' => 'swap'
-            );
+            $systemHealth[] = new SystemHealth('fa-hdd', 'health.available-swap', 2, __('health.unknow'), '', 'swap');
         }
 
         $values = sys_getloadavg();
-        $systemHealth[] = array(
-            'icon' => 'fa-fire',
-            'name' => __('health.load'),
-            'state' => ($values[2] < 20),
-            'result' => $values[0] . ' - ' . $values[1] . ' - ' . $values[2],
-            'comment' => __('health.need-less-than') . ': 20',
-            'key' => 'load'
-        );
+        $systemHealth[] = new SystemHealth('fa-fire', 'health.load', ($values[2] < 20), $values[0] . ' - ' . $values[1] . ' - ' . $values[2], __('health.need-less-than') . ': 20', 'load');
 
         $state = NetworkHelper::test('internal');
-        $systemHealth[] = array(
-            'icon' => 'fa-plug',
-            'name' => __('health.internal-network-conf'),
-            'state' => $state,
-            'result' => ($state) ? $okStr : $nokStr,
-            'comment' => ($state) ? '' : __('health.network-config'),
-            'key' => 'network::internal'
-        );
+        $systemHealth[] = new SystemHealth('fa-plug', 'health.internal-network-conf', $state, ($state) ? $okStr : $nokStr, ($state) ? '' : __('health.network-config'), 'network::internal');
 
         $state = NetworkHelper::test('external');
-        $systemHealth[] = array(
-            'icon' => 'fa-globe',
-            'name' => __('health.external-network-conf'),
-            'state' => $state,
-            'result' => ($state) ? $okStr : $nokStr,
-            'comment' => ($state) ? '' : __('health.network-config'),
-            'key' => 'network::external'
-        );
+        $systemHealth[] = new SystemHealth('fa-globe', 'health.external-network-conf', $state, ($state) ? $okStr : $nokStr, ($state) ? '' : __('health.network-config'), 'network::external');
 
-        $cache_health = array(
-            'icon' => 'fa-inbox',
-            'comment' => '',
-            'name' => __('health.cache-persistence'));
+        $cacheHealth = new SystemHealth('fa-inbox', 'health.cache-persistence', false, '', '', 'cache::persit');
 
         if (CacheManager::isPersistOk()) {
             if ((ConfigManager::byKey('cache::engine') != 'FilesystemCache') &&
                 (ConfigManager::byKey('cache::engine') != 'PhpFileCache')) {
-                $cache_health['state'] = true;
-                $cache_health['result'] = $okStr;
+                $cacheHealth->setState(true);
+                $cacheHealth['result'] = $okStr;
             } else {
                 $cache_path = CacheManager::getArchivePath();
                 $cache_time = date(DateFormat::FULL, filemtime($cache_path));
-                $cache_health['state'] = true;
-                $cache_health['result'] = sprintf("%s (%s)", $okStr, $cache_time);
+                $cacheHealth->setState(true);
+                $cacheHealth->setResult(sprintf("%s (%s)", $okStr, $cache_time));
             }
         } else {
-            $cache_health['state'] = false;
-            $cache_health['result'] = $nokStr;
-            $cache_health['comment'] = __('health.cache-not-saved');
+            $cacheHealth->setState(false)
+                ->setResult($nokStr)
+                ->setComment(__('health.cache-not-saved'));
         }
 
-        $systemHealth[] = $cache_health;
+        $systemHealth[] = $cacheHealth;
 
         $state = shell_exec('systemctl show apache2 | grep  PrivateTmp | grep yes | wc -l');
-        $systemHealth[] = array(
-            'icon' => 'fa-folder',
-            'name' => __('health.apache-private-tmp'),
-            'state' => $state,
-            'result' => ($state) ? $okStr : $nokStr,
-            'comment' => ($state) ? '' : __('health.apache-private-tmp-disabled'),
-            'key' => 'apache2::privateTmp'
-        );
+        $systemHealth[] = new SystemHealth('fa-folder', 'health.apache-private-tmp', $state, ($state) ? $okStr : $nokStr, ($state) ? '' : __('health.apache-private-tmp-disabled'), 'apache2::privateTmp');
 
         foreach (UpdateManager::listRepo() as $repo) {
             if ($repo['enable']) {
@@ -552,7 +382,7 @@ class NextDomHelper
             return ConfigManager::byKey(ConfigKey::HARDWARE_NAME);
         }
         $result = 'diy';
-        $uname = shell_exec('uname -a');
+        $uname = SystemHelper::getSystemInformations();
         if (strpos(shell_exec('sudo cat /proc/1/cgroup'), 'docker') !== false) {
             $result = 'docker';
         } else if (file_exists('/usr/bin/raspi-config')) {
@@ -561,7 +391,7 @@ class NextDomHelper
             global $NEXTDOM_RPI_HARDWARE;
             foreach ($NEXTDOM_RPI_HARDWARE as $key => $values) {
                 foreach ($values as $value) {
-                    if(strpos($hardware_revision,$value) !== false){
+                    if (strpos($hardware_revision, $value) !== false) {
                         $result = $key;
                     }
                 }
@@ -598,8 +428,7 @@ class NextDomHelper
     {
         if ($directory == null) {
             $pathToCheck = NEXTDOM_ROOT;
-        }
-        else {
+        } else {
             $pathToCheck = $directory;
         }
         return round(disk_free_space($pathToCheck) / disk_total_space($pathToCheck) * 100);
@@ -673,7 +502,7 @@ class NextDomHelper
             return $NEXTDOM_INTERNAL_CONFIG;
         }
         if (!is_array(self::$nextdomConfiguration)) {
-            self::$nextdomConfiguration = array();
+            self::$nextdomConfiguration = [];
         }
         // TODO: Bizarre
         if (!$defaultValue && isset(self::$nextdomConfiguration[$askedKey])) {
@@ -706,7 +535,7 @@ class NextDomHelper
     public static function checkValueInConfiguration($configKey, $configValue)
     {
         if (!is_array(self::$nextdomConfiguration)) {
-            self::$nextdomConfiguration = array();
+            self::$nextdomConfiguration = [];
         }
         if (isset(self::$nextdomConfiguration[$configKey])) {
             return self::$nextdomConfiguration[$configKey];
@@ -793,7 +622,7 @@ class NextDomHelper
                         try {
                             $cron->halt();
                         } catch (\Exception $e) {
-                            LogHelper::addError('starting', __('Erreur sur l\'arrêt d\'une tâche cron : ') . LogHelper::exception($e));
+                            LogHelper::addError(LogTarget::STARTING, __('Erreur sur l\'arrêt d\'une tâche cron : ') . LogHelper::exception($e));
                         }
                     }
                 }
@@ -817,27 +646,27 @@ class NextDomHelper
             }
 
             try {
-                LogHelper::addDebug('starting', __('Nettoyage du cache des péripheriques Bluetooth'));
+                LogHelper::addDebug(LogTarget::STARTING, __('Nettoyage du cache des péripheriques Bluetooth'));
                 $cache = CacheManager::byKey('nextdom::bluetoothMapping');
                 $cache->remove();
             } catch (\Exception $e) {
-                LogHelper::addError('starting', __('Erreur sur le nettoyage du CacheManager des péripheriques Bluetooth : ') . LogHelper::exception($e));
+                LogHelper::addError(LogTarget::STARTING, __('Erreur sur le nettoyage du CacheManager des péripheriques Bluetooth : ') . LogHelper::exception($e));
             }
 
             try {
-                LogHelper::addDebug('starting', __('Démarrage des processus Internet de NextDom'));
+                LogHelper::addDebug(LogTarget::STARTING, __('Démarrage des processus Internet de NextDom'));
                 self::startSystem();
             } catch (\Exception $e) {
-                LogHelper::addError('starting', __('Erreur sur le démarrage interne de NextDom : ') . LogHelper::exception($e));
+                LogHelper::addError(LogTarget::STARTING, __('Erreur sur le démarrage interne de NextDom : ') . LogHelper::exception($e));
             }
 
             try {
-                LogHelper::addDebug('starting', __('Ecriture du fichier ') . self::getStartedFilePath());
+                LogHelper::addDebug(LogTarget::STARTING, __('Ecriture du fichier ') . self::getStartedFilePath());
                 if (file_put_contents(self::getStartedFilePath(), date(DateFormat::FULL)) === false) {
-                    LogHelper::addError('starting', __('Impossible d\'écrire ' . self::getStartedFilePath()));
+                    LogHelper::addError(LogTarget::STARTING, __('Impossible d\'écrire ' . self::getStartedFilePath()));
                 }
             } catch (\Exception $e) {
-                LogHelper::addError('starting', __('Impossible d\'écrire ' . self::getStartedFilePath() . ' : ') . LogHelper::exception($e));
+                LogHelper::addError(LogTarget::STARTING, __('Impossible d\'écrire ' . self::getStartedFilePath() . ' : ') . LogHelper::exception($e));
             }
 
             if (!file_exists(self::getStartedFilePath())) {
@@ -938,7 +767,8 @@ class NextDomHelper
         }
     }
 
-    public static function cron10() {
+    public static function cron10()
+    {
         try {
             foreach (UpdateManager::listRepo() as $name => $repo) {
                 $repoClass = 'Repo' . $name;
@@ -1024,12 +854,12 @@ class NextDomHelper
      */
     public static function replaceTag(array $_replaces)
     {
-        $datas = array();
+        $datas = [];
         foreach ($_replaces as $key => $value) {
             $datas = array_merge($datas, CmdManager::searchConfiguration($key));
             $datas = array_merge($datas, EqLogicManager::searchConfiguration($key));
             $datas = array_merge($datas, JeeObjectManager::searchConfiguration($key));
-            $datas = array_merge($datas, ScenarioManager::searchByUse(array(array('action' => '#' . $key . '#'))));
+            $datas = array_merge($datas, ScenarioManager::searchByUse([['action' => '#' . $key . '#']]));
             $datas = array_merge($datas, ScenarioExpressionManager::searchExpression($key, $key, false));
             $datas = array_merge($datas, ScenarioExpressionManager::searchExpression('variable(' . str_replace('#', '', $key) . ')'));
             $datas = array_merge($datas, ScenarioExpressionManager::searchExpression('variable', str_replace('#', '', $key), true));
@@ -1085,10 +915,10 @@ class NextDomHelper
                 return 'view';
             }
         }
-        $alias = array(
+        $alias = [
             'dview' => 'dashboard',
             'dplan' => 'dashboard',
-        );
+        ];
         return (isset($alias[$version])) ? $alias[$version] : $version;
     }
 
@@ -1171,7 +1001,7 @@ class NextDomHelper
      */
     public static function getTypeUse($testString = '')
     {
-        $results = array(NextDomObj::CMD => [], NextDomObj::SCENARIO => [], NextDomObj::EQLOGIC => [], NextDomObj::DATASTORE => [], NextDomObj::PLAN => [], NextDomObj::VIEW => []);
+        $results = [NextDomObj::CMD => [], NextDomObj::SCENARIO => [], NextDomObj::EQLOGIC => [], NextDomObj::DATASTORE => [], NextDomObj::PLAN => [], NextDomObj::VIEW => []];
         // Look for human readable strings
         preg_match_all('/#(eqLogic|scenario)?(\d+)#/', $testString, $humanReadableResults);
         self::addTypeUseResults($humanReadableResults, $results);
@@ -1232,7 +1062,7 @@ class NextDomHelper
      */
     public static function getTypeUseOld($testString = '')
     {
-        $result = array(NextDomObj::CMD => [], NextDomObj::SCENARIO => [], NextDomObj::EQLOGIC => [], NextDomObj::DATASTORE => [], NextDomObj::PLAN => [], NextDomObj::VIEW => []);
+        $result = [NextDomObj::CMD => [], NextDomObj::SCENARIO => [], NextDomObj::EQLOGIC => [], NextDomObj::DATASTORE => [], NextDomObj::PLAN => [], NextDomObj::VIEW => []];
         // Test commands human readable
         preg_match_all("/#([0-9]*)#/", $testString, $matches);
         foreach ($matches[1] as $cmdId) {
@@ -1391,9 +1221,9 @@ class NextDomHelper
      */
     public static function benchmark()
     {
-        $result = array();
+        $result = [];
 
-        $param = array('cache_write' => 5000, 'cache_read' => 5000, 'database_write_delete' => 1000, 'database_update' => 1000, 'database_replace' => 1000, 'database_read' => 50000, 'subprocess' => 200);
+        $param = ['cache_write' => 5000, 'cache_read' => 5000, 'database_write_delete' => 1000, 'database_update' => 1000, 'database_replace' => 1000, 'database_read' => 50000, 'subprocess' => 200];
 
         $starttime = Utils::getMicrotime();
         for ($i = 0; $i < $param['cache_write']; $i++) {

--- a/src/Helpers/PrepareView.php
+++ b/src/Helpers/PrepareView.php
@@ -17,11 +17,14 @@
 
 namespace NextDom\Helpers;
 
+use NextDom\Enums\AjaxParams;
+use NextDom\Enums\Common;
 use NextDom\Enums\GetParams;
+use NextDom\Enums\NextDomObj;
 use NextDom\Enums\ViewType;
 use NextDom\Managers\ConfigManager;
-use NextDom\Managers\MessageManager;
 use NextDom\Managers\JeeObjectManager;
+use NextDom\Managers\MessageManager;
 use NextDom\Managers\Plan3dHeaderManager;
 use NextDom\Managers\PlanHeaderManager;
 use NextDom\Managers\PluginManager;
@@ -46,7 +49,7 @@ class PrepareView
      */
     public function initConfig()
     {
-        $this->currentConfig = ConfigManager::byKeys(array(
+        $this->currentConfig = ConfigManager::byKeys([
             'language',
             'nextdom::firstUse',
             'nextdom::Welcome',
@@ -57,7 +60,7 @@ class PrepareView
             'widget::margin',
             'widget::padding',
             'widget::radius',
-            'default_bootstrap_theme'));
+            'default_bootstrap_theme']);
     }
 
     /**
@@ -73,8 +76,7 @@ class PrepareView
         $result = false;
         if (isset($this->currentConfig['nextdom::firstUse']) && $this->currentConfig['nextdom::firstUse'] == 0) {
             $result = true;
-        }
-        else {
+        } else {
             // Prevent F5 bug on second step
             $user = UserManager::byLogin('admin');
             if (is_object($user) && $user->getPassword() !== Utils::sha512('admin')) {
@@ -346,8 +348,8 @@ class PrepareView
      */
     public function showModal()
     {
-        $plugin = Utils::init('plugin', '');
-        $modalCode = Utils::init('modal', '');
+        $plugin = Utils::init(AjaxParams::PLUGIN, '');
+        $modalCode = Utils::init(AjaxParams::MODAL, '');
         // Show modal from plugin (old way)
         if ($plugin !== '') {
             try {
@@ -434,7 +436,7 @@ class PrepareView
 
         $currentJeeObject = JeeObjectManager::getRootObjects();
         $currentJeeObjectId = '';
-        if(!empty($currentJeeObject)){
+        if (!empty($currentJeeObject)) {
             $currentJeeObjectId = $currentJeeObject->getId();
         }
 
@@ -489,8 +491,8 @@ class PrepareView
         $defaultDashboardObjectId = '';
         $defaultDashboardObjectName = UserManager::getStoredUser()->getOptions('defaultDashboardObject');
         $defaultDashboardObject = JeeObjectManager::byId($defaultDashboardObjectName);
-        if(!empty($defaultDashboardObject)) {
-          $defaultDashboardObjectId = $defaultDashboardObject->getId();
+        if (!empty($defaultDashboardObject)) {
+            $defaultDashboardObjectId = $defaultDashboardObject->getId();
         }
         $homePage = explode('::', UserManager::getStoredUser()->getOptions('homePage', 'core::dashboard'));
         if (count($homePage) == 2) {
@@ -499,7 +501,7 @@ class PrepareView
                         GetParams::VIEW_TYPE => ViewType::DESKTOP_VIEW,
                         GetParams::PAGE => $homePage[1],
                     ]);
-                if($defaultDashboardObjectId != '') {
+                if ($defaultDashboardObjectId != '') {
                     $homeLink .= '&object_id=' . $defaultDashboardObjectId;
                 }
             } else {
@@ -515,8 +517,8 @@ class PrepareView
             }
         } else {
             $homeLink = 'index.php?v=d&p=dashboard';
-            if($defaultDashboardObjectId != '') {
-              $homeLink .= '&object_id=' . $defaultDashboardObjectId;
+            if ($defaultDashboardObjectId != '') {
+                $homeLink .= '&object_id=' . $defaultDashboardObjectId;
             }
         }
         return $homeLink;
@@ -552,13 +554,13 @@ class PrepareView
                 $icon = '';
                 $name = $categoryCode;
 
-                if (isset($NEXTDOM_INTERNAL_CONFIG['plugin']['category'][$categoryCode])) {
-                    $icon = $NEXTDOM_INTERNAL_CONFIG['plugin']['category'][$categoryCode]['icon'];
-                    $name = $NEXTDOM_INTERNAL_CONFIG['plugin']['category'][$categoryCode]['name'];
+                if (isset($NEXTDOM_INTERNAL_CONFIG[NextDomObj::PLUGIN][Common::CATEGORY][$categoryCode])) {
+                    $icon = $NEXTDOM_INTERNAL_CONFIG[NextDomObj::PLUGIN][Common::CATEGORY][$categoryCode][Common::ICON];
+                    $name = $NEXTDOM_INTERNAL_CONFIG[NextDomObj::PLUGIN][Common::CATEGORY][$categoryCode][Common::NAME];
                 }
 
-                $pageData['MENU_PLUGIN_CATEGORY'][$categoryCode]['name'] = Render::getInstance()->getTranslation($name);
-                $pageData['MENU_PLUGIN_CATEGORY'][$categoryCode]['icon'] = $icon;
+                $pageData['MENU_PLUGIN_CATEGORY'][$categoryCode][Common::NAME] = Render::getInstance()->getTranslation($name);
+                $pageData['MENU_PLUGIN_CATEGORY'][$categoryCode][Common::ICON] = $icon;
 
                 /** @var Plugin $plugin */
                 foreach ($pluginsList as $plugin) {

--- a/src/Helpers/Render.php
+++ b/src/Helpers/Render.php
@@ -121,7 +121,7 @@ class Render
      * @param string $view
      * @param array $data
      */
-    public function show($view, $data = array())
+    public function show($view, $data = [])
     {
         echo $this->get($view, $data);
     }
@@ -131,7 +131,7 @@ class Render
      * @param array $data
      * @return mixed
      */
-    public function get($view, $data = array())
+    public function get($view, $data = [])
     {
         $data['debugbar'] = $this->showDebugBar();
         try {

--- a/src/Helpers/ReportHelper.php
+++ b/src/Helpers/ReportHelper.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Helpers;
 
+use NextDom\Enums\LogTarget;
 use NextDom\Managers\ConfigManager;
 use NextDom\Managers\UserManager;
 
@@ -43,7 +44,7 @@ class ReportHelper
      * @return string
      * @throws \Exception
      */
-    public static function generate($_url, $_type, $_name, $_format = 'png', $_parameter = array())
+    public static function generate($_url, $_type, $_name, $_format = 'png', $_parameter = [])
     {
         if (!is_string($_format)) {
             $_format = 'png';
@@ -62,7 +63,7 @@ class ReportHelper
         $cmd = 'xvfb-run --server-args="-screen 0, 1920x1280x24" cutycapt --min-width=' . $min_width . ' --min-height=' . $min_height . ' --url="' . $_url . '" --out="' . $out . '"';
         $cmd .= ' --delay=' . $delay;
         $cmd .= ' --print-backgrounds=on';
-        LogHelper::add('report', 'debug', $cmd);
+        LogHelper::addDebug(LogTarget::REPORT, $cmd);
         \com_shell::execute($cmd);
         return $out;
     }

--- a/src/Helpers/Router.php
+++ b/src/Helpers/Router.php
@@ -36,7 +36,6 @@ namespace NextDom\Helpers;
 
 use NextDom\Enums\GetParams;
 use NextDom\Enums\ViewType;
-use NextDom\Managers\ConfigManager;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -101,34 +100,6 @@ class Router
     }
 
     /**
-     * Test if modal window is requested
-     *
-     * @return bool True if modal window is requested
-     */
-    private function isModalRequest()
-    {
-        return isset($_GET[GetParams::MODAL]);
-    }
-
-    /**
-     * Test if plugin configuration page is requested
-     *
-     * @return bool True if plugin configuration page is requested
-     */
-    private function isPluginConfRequest()
-    {
-        return isset($_GET[GetParams::PLUGIN_CONF]);
-    }
-
-    /**
-     * Test if page is requested by Ajax query
-     *
-     * @return bool True if page is requested by Ajax query
-     */
-    private function isAjaxQuery() {
-        return isset($_GET[GetParams::AJAX_QUERY]) && $_GET[GetParams::AJAX_QUERY] == 1;
-    }
-    /**
      * Display for a computer
      *
      * @throws \Exception
@@ -155,6 +126,36 @@ class Router
                 $prepareView->showContent();
             }
         }
+    }
+
+    /**
+     * Test if modal window is requested
+     *
+     * @return bool True if modal window is requested
+     */
+    private function isModalRequest()
+    {
+        return isset($_GET[GetParams::MODAL]);
+    }
+
+    /**
+     * Test if plugin configuration page is requested
+     *
+     * @return bool True if plugin configuration page is requested
+     */
+    private function isPluginConfRequest()
+    {
+        return isset($_GET[GetParams::PLUGIN_CONF]);
+    }
+
+    /**
+     * Test if page is requested by Ajax query
+     *
+     * @return bool True if page is requested by Ajax query
+     */
+    private function isAjaxQuery()
+    {
+        return isset($_GET[GetParams::AJAX_QUERY]) && $_GET[GetParams::AJAX_QUERY] == 1;
     }
 
     /**

--- a/src/Helpers/Samba.php
+++ b/src/Helpers/Samba.php
@@ -127,6 +127,28 @@ class Samba
     }
 
     /**
+     * Get current share
+     *
+     * @param string|null $name Share name
+     *
+     * @return \Icewind\SMB\IShare|null Current share
+     *
+     * @throws CoreException
+     */
+    public function getShare(string $name = null)
+    {
+        if ($name === null) {
+            $name = $this->share;
+        }
+        try {
+            return $this->client->getShare($name);
+        } catch (\Exception $e) {
+            CoreException::do_throw('{repo.samba.error.connect}: %s', $e->getMessage());
+        }
+        return null;
+    }
+
+    /**
      * Copy file on the server
      *
      * @param string $src Path of the file to copy
@@ -146,27 +168,6 @@ class Samba
     }
 
     /**
-     * List folder content on the server
-     *
-     * @param string $path Path of the folder
-     *
-     * @return IFileInfo[]|null Content of the folder
-     *
-     * @throws CoreException
-     */
-    public function dir($path)
-    {
-        try {
-            return $this->getShare()->dir($path);
-        } catch (\Icewind\SMB\Exception\NotFoundException $e) {
-            CoreException::do_throw('{repo.samba.error.not-found}: %s', $path);
-        } catch (\Throwable $e) {
-            CoreException::do_throw('{repo.samba.error.unknown}: %s', $e->getMessage());
-        }
-        return null;
-    }
-
-    /**
      * Delete a file from the server
      *
      * @param string $path Path of the file
@@ -183,28 +184,6 @@ class Samba
             CoreException::do_throw('{repo.samba.error.not-found}: %s', $path);
         } catch (\Throwable $e) {
             CoreException::do_throw('{repo.samba.error.unknown}: %s', $e->getMessage());
-        }
-        return null;
-    }
-
-    /**
-     * Get current share
-     *
-     * @param string|null $name Share name
-     *
-     * @return \Icewind\SMB\IShare|null Current share
-     *
-     * @throws CoreException
-     */
-    public function getShare(string $name = null)
-    {
-        if ($name === null) {
-            $name = $this->share;
-        }
-        try {
-            return $this->client->getShare($name);
-        } catch (\Exception $e) {
-            CoreException::do_throw('{repo.samba.error.connect}: %s', $e->getMessage());
         }
         return null;
     }
@@ -258,6 +237,27 @@ class Samba
             }
         }
         return $entries;
+    }
+
+    /**
+     * List folder content on the server
+     *
+     * @param string $path Path of the folder
+     *
+     * @return IFileInfo[]|null Content of the folder
+     *
+     * @throws CoreException
+     */
+    public function dir($path)
+    {
+        try {
+            return $this->getShare()->dir($path);
+        } catch (\Icewind\SMB\Exception\NotFoundException $e) {
+            CoreException::do_throw('{repo.samba.error.not-found}: %s', $path);
+        } catch (\Throwable $e) {
+            CoreException::do_throw('{repo.samba.error.unknown}: %s', $e->getMessage());
+        }
+        return null;
     }
 
     /**

--- a/src/Helpers/SessionHelper.php
+++ b/src/Helpers/SessionHelper.php
@@ -34,6 +34,7 @@
 
 namespace NextDom\Helpers;
 
+use NextDom\Enums\DateFormat;
 use NextDom\Exceptions\CoreException;
 use NextDom\Managers\ConfigManager;
 
@@ -49,7 +50,7 @@ class SessionHelper
      */
     public static function getSessionsList()
     {
-        $result = array();
+        $result = [];
         try {
             $sessions = explode("\n", \com_shell::execute(SystemHelper::getCmdSudo() . ' ls ' . session_save_path()));
             foreach ($sessions as $session) {
@@ -62,9 +63,9 @@ class SessionHelper
                     continue;
                 }
                 $session_id = str_replace('sess_', '', $session);
-                $result[$session_id] = array(
-                    'datetime' => date('Y-m-d H:i:s', \com_shell::execute(SystemHelper::getCmdSudo() . ' stat -c "%Y" ' . session_save_path() . '/' . $session)),
-                );
+                $result[$session_id] = [
+                    'datetime' => date(DateFormat::FULL, \com_shell::execute(SystemHelper::getCmdSudo() . ' stat -c "%Y" ' . session_save_path() . '/' . $session)),
+                ];
                 $result[$session_id]['login'] = $data_session['user']->getLogin();
                 $result[$session_id]['user_id'] = $data_session['user']->getId();
                 $result[$session_id]['ip'] = (isset($data_session['ip'])) ? $data_session['ip'] : '';
@@ -82,7 +83,7 @@ class SessionHelper
      */
     public static function decodeSessionData($srcData)
     {
-        $resultData = array();
+        $resultData = [];
         $offset = 0;
         while ($offset < strlen($srcData)) {
             if (!strstr(substr($srcData, $offset), "|")) {
@@ -120,8 +121,9 @@ class SessionHelper
      *
      * @throws \Exception
      */
-    public static function startSession() {
-        if(session_status() == PHP_SESSION_NONE) {
+    public static function startSession()
+    {
+        if (session_status() == PHP_SESSION_NONE) {
             $sessionLifetime = ConfigManager::byKey('session_lifetime');
             if (!is_numeric($sessionLifetime)) {
                 $sessionLifetime = 24;

--- a/src/Helpers/SystemHelper.php
+++ b/src/Helpers/SystemHelper.php
@@ -30,13 +30,13 @@ class SystemHelper
     /**
      * @var array Distribution specific commands
      */
-    private static $commands = array(
-        'suse' => array('cmd_check' => ' rpm -qa | grep ', 'cmd_install' => ' zypper in --non-interactive ', 'www-uid' => 'wwwrun', 'www-gid' => 'www', 'type' => 'zypper'),
-        'sles' => array('cmd_check' => ' rpm -qa | grep ', 'cmd_install' => ' zypper in --non-interactive ', 'www-uid' => 'wwwrun', 'www-gid' => 'www', 'type' => 'zypper'),
-        'redhat' => array('cmd_check' => ' rpm -qa | grep ', 'cmd_install' => ' yum install ', 'www-uid' => 'www-data', 'www-gid' => 'www-data', 'type' => 'yum'),
-        'fedora' => array('cmd_check' => ' rpm -qa | grep ', 'cmd_install' => ' dnf install ', 'www-uid' => 'www-data', 'www-gid' => 'www-data', 'type' => 'dnf'),
-        'debian' => array('cmd_check' => ' dpkg --get-selections | grep -v deinstall | grep ', 'cmd_install' => ' apt-get install -y ', 'www-uid' => 'www-data', 'www-gid' => 'www-data', 'type' => 'apt'),
-    );
+    private static $commands = [
+        'suse' => ['cmd_check' => ' rpm -qa | grep ', 'cmd_install' => ' zypper in --non-interactive ', 'www-uid' => 'wwwrun', 'www-gid' => 'www', 'type' => 'zypper'],
+        'sles' => ['cmd_check' => ' rpm -qa | grep ', 'cmd_install' => ' zypper in --non-interactive ', 'www-uid' => 'wwwrun', 'www-gid' => 'www', 'type' => 'zypper'],
+        'redhat' => ['cmd_check' => ' rpm -qa | grep ', 'cmd_install' => ' yum install ', 'www-uid' => 'www-data', 'www-gid' => 'www-data', 'type' => 'yum'],
+        'fedora' => ['cmd_check' => ' rpm -qa | grep ', 'cmd_install' => ' dnf install ', 'www-uid' => 'www-data', 'www-gid' => 'www-data', 'type' => 'dnf'],
+        'debian' => ['cmd_check' => ' dpkg --get-selections | grep -v deinstall | grep ', 'cmd_install' => ' apt-get install -y ', 'www-uid' => 'www-data', 'www-gid' => 'www-data', 'type' => 'apt'],
+    ];
 
     /**
      * @return int
@@ -164,11 +164,11 @@ class SystemHelper
      */
     public static function ps(string $find, $without = null)
     {
-        $return = array();
+        $return = [];
         $cmd = '(ps ax || ps w) | grep -ie "' . $find . '" | grep -v "grep"';
         if ($without !== null) {
             if (!is_array($without)) {
-                $without = array($without);
+                $without = [$without];
             }
             foreach ($without as $value) {
                 $cmd .= ' | grep -v "' . $value . '"';
@@ -178,13 +178,13 @@ class SystemHelper
         if (!is_array($results) || count($results) == 0) {
             return $return;
         }
-        $order = array('pid', 'tty', 'stat', 'time', 'command');
+        $order = ['pid', 'tty', 'stat', 'time', 'command'];
         foreach ($results as $result) {
             if (trim($result) == '') {
                 continue;
             }
             $explodes = explode(" ", $result);
-            $info = array();
+            $info = [];
             $i = 0;
             foreach ($explodes as $value) {
                 if (trim($value) == '') {
@@ -331,7 +331,7 @@ class SystemHelper
     public static function getMemInfo()
     {
         $data = explode("\n", file_get_contents("/proc/meminfo"));
-        $meminfo = array();
+        $meminfo = [];
         foreach ($data as $line) {
             $info = explode(":", $line);
             if (count($info) != 2) {
@@ -395,8 +395,9 @@ class SystemHelper
      */
     public static function stopService(string $serviceName)
     {
-        return exec(self::getCmdSudo() . ' service ' . $serviceName .' stop');
+        return exec(self::getCmdSudo() . ' service ' . $serviceName . ' stop');
     }
+
     /**
      * Start a service
      *
@@ -406,7 +407,12 @@ class SystemHelper
      */
     public static function startService(string $serviceName)
     {
-        return exec(self::getCmdSudo() . ' service ' . $serviceName .' start');
+        return exec(self::getCmdSudo() . ' service ' . $serviceName . ' start');
+    }
+
+    public static function getSystemInformations()
+    {
+        return shell_exec('uname -a');
     }
 
     /**

--- a/src/Helpers/TimeLineHelper.php
+++ b/src/Helpers/TimeLineHelper.php
@@ -62,11 +62,11 @@ class TimeLineHelper
     {
         $path = NEXTDOM_DATA . '/data/timeline.json';
         if (!file_exists($path)) {
-            $result = array();
+            $result = [];
         } else {
             \com_shell::execute(SystemHelper::getCmdSudo() . 'chmod 666 ' . $path . ' > /dev/null 2>&1;echo "$(tail -n ' . ConfigManager::byKey('timeline::maxevent') . ' ' . $path . ')" > ' . $path);
             $lines = explode("\n", trim(file_get_contents($path)));
-            $result = array();
+            $result = [];
             foreach ($lines as $line) {
                 $result[] = json_decode($line, true);
             }

--- a/src/Helpers/TranslateHelper.php
+++ b/src/Helpers/TranslateHelper.php
@@ -121,7 +121,7 @@ class TranslateHelper
         }
 
         $modify = false;
-        $replace = array();
+        $replace = [];
         preg_match_all("/{{(.*?)}}/s", $content, $matches);
         if ($oldTranslationMode) {
             foreach ($matches[1] as $text) {
@@ -138,7 +138,7 @@ class TranslateHelper
                     if (strpos($filename, '#') === false) {
                         $modify = true;
                         if (!isset($translate[$filename])) {
-                            $translate[$filename] = array();
+                            $translate[$filename] = [];
                         }
                         $translate[$filename][$text] = $text;
                     }
@@ -178,9 +178,9 @@ class TranslateHelper
     {
         // Test si les traductions ont été mises en cache
         if (!self::$translationLoaded) {
-            self::$translation = array(
+            self::$translation = [
                 self::getLanguage() => self::loadTranslation(),
-            );
+            ];
             self::$translationLoaded = true;
         }
         return self::$translation[self::getLanguage()];
@@ -228,7 +228,7 @@ class TranslateHelper
         $result = $defaultValue;
         // Lecture et mise en cache de la configuration
         if (self::$config === null) {
-            self::$config = ConfigManager::byKeys(array('language', 'generateTranslation'), 'core', array('language' => 'fr_FR'));
+            self::$config = ConfigManager::byKeys(['language', 'generateTranslation'], 'core', ['language' => 'fr_FR']);
         }
         // Recherche de l'information
         if (isset(self::$config[$informationKey])) {
@@ -313,7 +313,7 @@ class TranslateHelper
                 $plugin = substr($page, strpos($page, 'plugins/') + 8);
                 $plugin = substr($plugin, 0, strpos($plugin, '/'));
                 if (!isset($plugins[$plugin])) {
-                    $plugins[$plugin] = array();
+                    $plugins[$plugin] = [];
                 }
                 $plugins[$plugin][$page] = $translation;
             }

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -129,6 +129,19 @@ class Utils
     }
 
     /**
+     * Obtenir un entier passé en paramètre
+     *
+     * @param string $name Nom de la variable
+     * @param mixed $default Valeur par défaut
+     *
+     * @return mixed Valeur de la variable
+     */
+    public static function initInt(string $name, $default = 0): int
+    {
+        return intval(self::init($name, $default));
+    }
+
+    /**
      * Obtenir une variable passée en paramètre
      *
      * @param string $name Nom de la variable
@@ -158,9 +171,21 @@ class Utils
      *
      * @return mixed Valeur de la variable
      */
-    public static function initInt(string $name, $default = 0): int
+    public static function initStr(string $name, $default = ''): string
     {
-        return intval(self::init($name, $default));
+        return self::sanitizeString(self::init($name, $default));
+    }
+
+    /**
+     * Keep only characters, numbers, - _ characters
+     *
+     * @param $strToSanitize
+     *
+     * @return string Sanitized string
+     */
+    public static function sanitizeString($strToSanitize)
+    {
+        return preg_replace('/[^a-zA-Z0-9\-_]/', '', $strToSanitize);
     }
 
     /**
@@ -202,8 +227,9 @@ class Utils
      */
     public static function checkPath(string $path): bool
     {
+        $realpathToCheck = realpath($path);
         foreach ([NEXTDOM_ROOT, NEXTDOM_DATA, NEXTDOM_TMP, NEXTDOM_LOG] as $authorizedPath) {
-            if (strpos($path, $authorizedPath) === 0) {
+            if (strpos($realpathToCheck, $authorizedPath) === 0) {
                 return true;
             }
         }
@@ -338,7 +364,7 @@ class Utils
      */
     public static function cleanPath($path)
     {
-        $out = array();
+        $out = [];
         foreach (explode('/', $path) as $i => $fold) {
             if ($fold == '' || $fold == '.') {
                 continue;
@@ -428,7 +454,7 @@ class Utils
             }
         }
 
-        $paths = array();
+        $paths = [];
         $p = $begin + 1;
 
         // For each comma-separated subpattern.
@@ -458,7 +484,7 @@ class Utils
      */
     public static function removeCR($_string)
     {
-        return trim(str_replace(array("\n", "\r\n", "\r", "\n\r"), '', $_string));
+        return trim(str_replace(["\n", "\r\n", "\r", "\n\r"], '', $_string));
     }
 
     /**
@@ -607,16 +633,16 @@ class Utils
      */
     public static function minify($_buffer)
     {
-        $search = array(
+        $search = [
             '/\>[^\S ]+/s', // strip whitespaces after tags, except space
             '/[^\S ]+\</s', // strip whitespaces before tags, except space
             '/(\s)+/s', // shorten multiple whitespace sequences
-        );
-        $replace = array(
+        ];
+        $replace = [
             '>',
             '<',
             '\\1',
-        );
+        ];
         return preg_replace($search, $replace, $_buffer);
     }
 
@@ -627,7 +653,7 @@ class Utils
      */
     public static function sanitizeAccent($_message)
     {
-        $caracteres = array(
+        $caracteres = [
             'À' => 'a', 'Á' => 'a', 'Â' => 'a', 'Ä' => 'a', 'à' => 'a', 'á' => 'a', 'â' => 'a', 'ä' => 'a', '@' => 'a',
             'Ç' => 'c', 'ç' => 'c',
             'È' => 'e', 'É' => 'e', 'Ê' => 'e', 'Ë' => 'e', 'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e', '€' => 'e',
@@ -635,7 +661,7 @@ class Utils
             'Ò' => 'o', 'Ó' => 'o', 'Ô' => 'o', 'Ö' => 'o', 'ò' => 'o', 'ó' => 'o', 'ô' => 'o', 'ö' => 'o',
             'Ù' => 'u', 'Ú' => 'u', 'Û' => 'u', 'Ü' => 'u', 'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u', 'µ' => 'u',
             'Œ' => 'oe', 'œ' => 'oe',
-            '$' => 's');
+            '$' => 's'];
         return preg_replace('#[^A-Za-z0-9 \n\.\'=\*:]+\#\)\(#', '', strtr($_message, $caracteres));
     }
 
@@ -729,16 +755,16 @@ class Utils
      */
     public static function arg2array($_string): array
     {
-        $return = array();
+        $result = [];
         $re = '/[\/-]?(([a-zA-Z0-9áàâäãåçéèêëíìîïñóòôöõúùûüýÿæœ_#]+)(?:[=:]("[^"]+"|[^\s"]+))?)(?:\s+|$)/';
         preg_match_all($re, $_string, $matches, PREG_SET_ORDER, 0);
         foreach ($matches as $match) {
             if (count($match) != 4) {
                 continue;
             }
-            $return[$match[2]] = $match[3];
+            $result[$match[2]] = $match[3];
         }
-        return $return;
+        return $result;
     }
 
     /**
@@ -773,56 +799,7 @@ class Utils
             $g = hexdec(substr($hex, 2, 2));
             $b = hexdec(substr($hex, 4, 2));
         }
-        return array($r, $g, $b);
-    }
-
-    /**
-     * @param $_pathimg
-     * @return string|array
-     */
-    function getDominantColor($_pathimg, $_level = null, $_ignoreDarkColor = false)
-    {
-        $colors = array();
-        $i = imagecreatefromjpeg($_pathimg);
-        $imagesX = imagesx($i);
-        $imagesY = imagesy($i);
-        $ratio = $imagesX / $imagesY;
-        $size = 270;
-        $img = imagecreatetruecolor($size, $size / $ratio);
-        imagecopyresized($img, $i, 0, 0, 0, 0, $size, $size / $ratio, $imagesX, $imagesY);
-        $imagesX = $size;
-        $imagesY = $size / $ratio;
-        for ($x = 0; $x < $imagesX; $x++) {
-            for ($y = 0; $y < $imagesY; $y++) {
-                $rgb = imagecolorat($img, $x, $y);
-                if ($_ignoreDarkColor) {
-                    $sum = (($rgb >> 16) & 0xFF) + (($rgb >> 8) & 0xFF) + ($rgb & 0xFF);
-                    if ($sum < 10) {
-                        continue;
-                    }
-                }
-                if (!isset($colors[$rgb])) {
-                    $colors[$rgb] = array('value' => $rgb, 'nb' => 0);
-                }
-                $colors[$rgb]['nb']++;
-            }
-        }
-        usort($colors, function ($a, $b) {
-            return $b['nb'] - $a['nb'];
-        });
-
-        if ($_level == null) {
-            if ($colors[0]['value'] == 0) {
-                return '#' . substr("000000" . dechex($colors[1]['value']), -6);
-            }
-            return '#' . substr("000000" . dechex($colors[0]['value']), -6);
-        }
-        $return = array();
-        $colors = array_slice($colors, 0, $_level);
-        foreach ($colors as $color) {
-            $return[] = '#' . substr("000000" . dechex($color['value']), -6);
-        }
-        return $return;
+        return [$r, $g, $b];
     }
 
     /**
@@ -840,13 +817,13 @@ class Utils
      */
     public static function findCodeIcon($_icon): array
     {
-        $icon = trim(str_replace(array('fa ', 'icon ', '></i>', '<i', 'class="', '"'), '', trim($_icon)));
+        $icon = trim(str_replace(['fa ', 'icon ', '></i>', '<i', 'class="', '"'], '', trim($_icon)));
         $re = '/.' . $icon . ':.*\n.*content:.*"(.*?)";/m';
 
         $css = file_get_contents(NEXTDOM_ROOT . '/vendor/node_modules/font-awesome/css/font-awesome.css');
         preg_match($re, $css, $matches);
         if (isset($matches[1])) {
-            return array('icon' => trim($matches[1], '\\'), 'fontfamily' => 'FontAwesome');
+            return ['icon' => trim($matches[1], '\\'), 'fontfamily' => 'FontAwesome'];
         }
 
         foreach (FileSystemHelper::ls(NEXTDOM_ROOT . '/public/icon', '*') as $dir) {
@@ -854,7 +831,7 @@ class Utils
                 $css = file_get_contents(NEXTDOM_ROOT . '/public/icon/' . $dir . '/style.css');
                 preg_match($re, $css, $matches);
                 if (isset($matches[1])) {
-                    return array('icon' => trim($matches[1], '\\'), 'fontfamily' => trim($dir, '/'));
+                    return ['icon' => trim($matches[1], '\\'), 'fontfamily' => trim($dir, '/')];
                 }
             }
         }
@@ -872,7 +849,7 @@ class Utils
      * @param array $_display
      * @return null
      */
-    public static function addGraphLink($_from, $_from_type, $_to, $_to_type, &$_data, $_level, $_drill, $_display = array('dashvalue' => '5,3', 'lengthfactor' => 0.6))
+    public static function addGraphLink($_from, $_from_type, $_to, $_to_type, &$_data, $_level, $_drill, $_display = ['dashvalue' => '5,3', 'lengthfactor' => 0.6])
     {
         if (is_array($_to) && count($_to) == 0) {
             return null;
@@ -881,7 +858,7 @@ class Utils
             if (!is_object($_to)) {
                 return null;
             }
-            $_to = array($_to);
+            $_to = [$_to];
         }
         foreach ($_to as $to) {
             $to->getLinkData($_data, $_level, $_drill);
@@ -891,10 +868,10 @@ class Utils
             if (isset($_data['link'][$_from_type . $_from->getId() . '-' . $_to_type . $to->getId()])) {
                 continue;
             }
-            $_data['link'][$_to_type . $to->getId() . '-' . $_from_type . $_from->getId()] = array(
+            $_data['link'][$_to_type . $to->getId() . '-' . $_from_type . $_from->getId()] = [
                 'from' => $_to_type . $to->getId(),
                 'to' => $_from_type . $_from->getId(),
-            );
+            ];
             $_data['link'][$_to_type . $to->getId() . '-' . $_from_type . $_from->getId()] = array_merge($_data['link'][$_to_type . $to->getId() . '-' . $_from_type . $_from->getId()], $_display);
         }
         return $_data;
@@ -947,16 +924,15 @@ class Utils
      */
     public static function o2a($objectToConvert, $_noToArray = false)
     {
+        $result = [];
         if (is_array($objectToConvert)) {
-            $return = array();
             foreach ($objectToConvert as $subObject) {
-                $return[] = self::o2a($subObject);
+                $result[] = self::o2a($subObject);
             }
-            return $return;
+            return $result;
         }
-        $array = array();
         if (!is_object($objectToConvert)) {
-            return $array;
+            return $result;
         }
         if (!$_noToArray && method_exists($objectToConvert, 'toArray')) {
             return $objectToConvert->toArray();
@@ -977,10 +953,10 @@ class Utils
                     $value = $property->getValue($objectToConvert);
                     $property->setAccessible(false);
                 }
-                $array[$name] = ($value === null) ? null : Utils::isJson($value, $value);
+                $result[$name] = ($value === null) ? null : Utils::isJson($value, $value);
             }
         }
-        return $array;
+        return $result;
     }
 
     /**
@@ -997,11 +973,11 @@ class Utils
             if (!is_string($_string)) {
                 return $_default;
             }
-            $return = json_decode($_string, true, 512, JSON_BIGINT_AS_STRING);
-            if (!is_array($return)) {
+            $result = json_decode($_string, true, 512, JSON_BIGINT_AS_STRING);
+            if (!is_array($result)) {
                 return $_default;
             }
-            return $return;
+            return $result;
         }
         return ((is_string($_string) && is_array(json_decode($_string, true, 512, JSON_BIGINT_AS_STRING)))) ? true : false;
     }
@@ -1029,7 +1005,7 @@ class Utils
             $_dbList = $_class::all();
         }
 
-        $enableList = array();
+        $enableList = [];
         foreach ($_ajaxList as $ajaxObject) {
             $resultObject = $_class::byId($ajaxObject['id']);
             if (!is_object($resultObject)) {
@@ -1091,12 +1067,12 @@ class Utils
     {
         if ($_value === null && !is_array($_key)) {
             if (!is_array($_attr)) {
-                $_attr = Utils::isJson($_attr, array());
+                $_attr = Utils::isJson($_attr, []);
             }
             unset($_attr[$_key]);
         } else {
             if (!is_array($_attr)) {
-                $_attr = Utils::isJson($_attr, array());
+                $_attr = Utils::isJson($_attr, []);
             }
             if (is_array($_key)) {
                 $_attr = array_merge($_attr, $_key);
@@ -1121,25 +1097,25 @@ class Utils
             }
         } else {
             if ($_key == '') {
-                return self::isJson($_attr, array());
+                return self::isJson($_attr, []);
             }
             if ($_attr === '') {
                 if (is_array($_key)) {
                     foreach ($_key as $key) {
-                        $return[$key] = $_default;
+                        $result[$key] = $_default;
                     }
-                    return $return;
+                    return $result;
                 }
                 return $_default;
             }
             $_attr = json_decode($_attr, true);
         }
         if (is_array($_key)) {
-            $return = array();
+            $result = [];
             foreach ($_key as $key) {
-                $return[$key] = (isset($_attr[$key]) && $_attr[$key] !== '') ? $_attr[$key] : $_default;
+                $result[$key] = (isset($_attr[$key]) && $_attr[$key] !== '') ? $_attr[$key] : $_default;
             }
-            return $return;
+            return $result;
         }
         return (isset($_attr[$_key]) && $_attr[$_key] !== '') ? $_attr[$_key] : $_default;
     }
@@ -1172,7 +1148,7 @@ class Utils
      */
     public static function parseArgs($argv)
     {
-        $args = array();
+        $args = [];
         if (isset($argv)) {
             foreach ($argv as $c_arg) {
                 $parts = explode('=', $c_arg);
@@ -1302,5 +1278,54 @@ class Utils
         }
 
         return (substr($haystack, -$length) === $needle);
+    }
+
+    /**
+     * @param $_pathimg
+     * @return string|array
+     */
+    function getDominantColor($_pathimg, $_level = null, $_ignoreDarkColor = false)
+    {
+        $colors = [];
+        $i = imagecreatefromjpeg($_pathimg);
+        $imagesX = imagesx($i);
+        $imagesY = imagesy($i);
+        $ratio = $imagesX / $imagesY;
+        $size = 270;
+        $img = imagecreatetruecolor($size, $size / $ratio);
+        imagecopyresized($img, $i, 0, 0, 0, 0, $size, $size / $ratio, $imagesX, $imagesY);
+        $imagesX = $size;
+        $imagesY = $size / $ratio;
+        for ($x = 0; $x < $imagesX; $x++) {
+            for ($y = 0; $y < $imagesY; $y++) {
+                $rgb = imagecolorat($img, $x, $y);
+                if ($_ignoreDarkColor) {
+                    $sum = (($rgb >> 16) & 0xFF) + (($rgb >> 8) & 0xFF) + ($rgb & 0xFF);
+                    if ($sum < 10) {
+                        continue;
+                    }
+                }
+                if (!isset($colors[$rgb])) {
+                    $colors[$rgb] = ['value' => $rgb, 'nb' => 0];
+                }
+                $colors[$rgb]['nb']++;
+            }
+        }
+        usort($colors, function ($a, $b) {
+            return $b['nb'] - $a['nb'];
+        });
+
+        if ($_level == null) {
+            if ($colors[0]['value'] == 0) {
+                return '#' . substr("000000" . dechex($colors[1]['value']), -6);
+            }
+            return '#' . substr("000000" . dechex($colors[0]['value']), -6);
+        }
+        $result = [];
+        $colors = array_slice($colors, 0, $_level);
+        foreach ($colors as $color) {
+            $result[] = '#' . substr("000000" . dechex($color['value']), -6);
+        }
+        return $result;
     }
 }

--- a/src/Interfaces/BaseRepo.php
+++ b/src/Interfaces/BaseRepo.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace NextDom\Interfaces;
+
+
+interface BaseRepo
+{
+
+}

--- a/src/Managers/BackupManager.php
+++ b/src/Managers/BackupManager.php
@@ -19,6 +19,7 @@ namespace NextDom\Managers;
 
 use NextDom\Enums\ConfigKey;
 use NextDom\Enums\DateFormat;
+use NextDom\Enums\FoldersReferential;
 use NextDom\Enums\LogLevel;
 use NextDom\Enums\LogTarget;
 use NextDom\Enums\NextDomObj;
@@ -27,7 +28,6 @@ use NextDom\Helpers\ConsoleHelper;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\FileSystemHelper;
 use NextDom\Helpers\LogHelper;
-use NextDom\Enums\FoldersReferential;
 use NextDom\Helpers\MigrationHelper;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\SystemHelper;
@@ -75,7 +75,7 @@ class BackupManager
     {
         $backupDir = self::getBackupDirectory();
 
-        if(FileSystemHelper::getDirectoryFreeSpace($backupDir) < 400000000){
+        if (FileSystemHelper::getDirectoryFreeSpace($backupDir) < 400000000) {
             throw new CoreException('Not Enough space to create local backup');
         }
         self::$logLevel = ConfigManager::byKey(ConfigKey::LOG_LEVEL, 'core', LogLevel::ERROR);
@@ -118,7 +118,7 @@ class BackupManager
             $status = "error";
             ConsoleHelper::nok();
             ConsoleHelper::error($e);
-            LogHelper::add('backup', 'error', $e->getMessage());
+            LogHelper::addError(LogTarget::BACKUP, $e->getMessage());
         } finally {
             ConsoleHelper::step("starting NextDom (cron & scenario)");
             NextDomHelper::startSystem();
@@ -279,19 +279,19 @@ class BackupManager
         $tar->addFile($sqlPath, "DB_backup.sql");
 
         // Backup config and data folders
-        FileSystemHelper::mkdirIfNotExists(NEXTDOM_DATA.'/data/custom',0775,true);
-        $roots = [NEXTDOM_DATA.'/data/', NEXTDOM_DATA.'/config/'];
-        $pattern = NEXTDOM_DATA .'/';
+        FileSystemHelper::mkdirIfNotExists(NEXTDOM_DATA . '/data/custom', 0775, true);
+        $roots = [NEXTDOM_DATA . '/data/', NEXTDOM_DATA . '/config/'];
+        $pattern = NEXTDOM_DATA . '/';
         self::addPathToArchive($roots, $pattern, $tar, $logFile);
 
         // Backup plugins folder
-        $roots = [NEXTDOM_ROOT.'/plugins/'];
-        $pattern = NEXTDOM_ROOT .'/';
+        $roots = [NEXTDOM_ROOT . '/plugins/'];
+        $pattern = NEXTDOM_ROOT . '/';
         self::addPathToArchive($roots, $pattern, $tar, $logFile);
 
         $dir = new \RecursiveDirectoryIterator(NEXTDOM_ROOT, \FilesystemIterator::SKIP_DOTS);
         // Flatten the recursive iterator, folders come before their files
-        $it  = new \RecursiveIteratorIterator($dir, \RecursiveIteratorIterator::SELF_FIRST);
+        $it = new \RecursiveIteratorIterator($dir, \RecursiveIteratorIterator::SELF_FIRST);
         // Maximum depth is 1 level deeper than the base folder
         $it->setMaxDepth(0);
 
@@ -300,16 +300,44 @@ class BackupManager
         foreach ($it as $fileInfo) {
             if (($fileInfo->isDir() || $fileInfo->isFile()) && !in_array($fileInfo->getFilename(), FoldersReferential::NEXTDOMFOLDERS)
                 && !in_array($fileInfo->getFilename(), FoldersReferential::NEXTDOMFILES)
-                && !is_link( $fileInfo->getFilename())) {
+                && !is_link($fileInfo->getFilename())) {
                 $tar->addFile($fileInfo->getPathname(), $fileInfo->getFilename());
                 if ($fileInfo->isDir()) {
-                    $roots = [NEXTDOM_ROOT.'/'.$fileInfo->getFilename()];
+                    $roots = [NEXTDOM_ROOT . '/' . $fileInfo->getFilename()];
                     self::addPathToArchive($roots, $pattern, $tar, $logFile);
                 }
             }
         }
 
         $tar->close();
+    }
+
+    /**
+     * @param array $roots
+     * @param string $pattern
+     * @param Tar $tar
+     * @param string logFile
+     */
+    private static function addPathToArchive($roots, $pattern, $tar, $logFile)
+    {
+        foreach ($roots as $c_root) {
+            $path = $c_root;
+            $dirIter = new RecursiveDirectoryIterator($path);
+            $riIter = new RecursiveIteratorIterator($dirIter);
+            ConsoleHelper::stepLine('Add files of ' . $c_root . ' to archive');
+            // iterate on files recursively found
+            foreach ($riIter as $c_entry) {
+                if (false === $c_entry->isFile()) {
+                    continue;
+                }
+                $message = 'Add folder to archive : ' . $c_entry->getPathname();
+                if (self::$logLevel == LogLevel::DEBUG && $logFile === LogTarget::BACKUP) {
+                    LogHelper::addDebug($logFile, $message);
+                }
+                $dest = str_replace($pattern, "", $c_entry->getPathname());
+                $tar->addFile($c_entry->getPathname(), $dest);
+            }
+        }
     }
 
     /**
@@ -366,13 +394,15 @@ class BackupManager
         }
 
         // 2.
-        $files = array_map(function ($c_file) {
+        $array_map = [];
+        foreach ($entries as $key => $c_file) {
             $stat = stat($c_file);
             if (false === $stat) {
                 throw new CoreException("unable to stat file " . $c_file);
             }
-            return array("file" => $c_file, "mtime" => $stat[9], "size" => $stat[7]);
-        }, $entries);
+            $array_map[$key] = ["file" => $c_file, "mtime" => $stat[9], "size" => $stat[7]];
+        }
+        $files = $array_map;
 
         if ($order == "newest") {
             usort($files, function ($x, $y) {
@@ -477,7 +507,7 @@ class BackupManager
             self::restoreJeedomConfig($tmpDir);
             ConsoleHelper::ok();
             ConsoleHelper::step("restoring custom data...\n");
-            self::restoreCustomData($tmpDir,LogTarget::RESTORE);
+            self::restoreCustomData($tmpDir, LogTarget::RESTORE);
             ConsoleHelper::ok();
             ConsoleHelper::step("migrating data...");
             MigrationHelper::migrate(LogTarget::RESTORE);
@@ -551,19 +581,78 @@ class BackupManager
      */
     private static function extractArchive($file)
     {
-        $excludeDirs = array("AlternativeMarketForJeedom", "musicast");
+        $excludeDirs = ["AlternativeMarketForJeedom", "musicast"];
         $exclude = sprintf("/^(%s)$/", join("|", $excludeDirs));
         $tmpDir = sprintf("%s-restore-%s", NEXTDOM_TMP, date('Y-m-d-H:i:s'));
         if (false === mkdir($tmpDir, 0775, true)) {
             throw new CoreException("unable to create tmp directory " . $tmpDir);
         }
-        if(FileSystemHelper::getDirectoryFreeSpace($tmpDir) < 400000000){
+        if (FileSystemHelper::getDirectoryFreeSpace($tmpDir) < 400000000) {
             throw new CoreException('Not enough space to extract archive');
         }
         $tar = new Tar();
         $tar->open($file);
         $tar->extract($tmpDir, "", $exclude);
         return $tmpDir;
+    }
+
+    /**
+     * Restore plugins from backup archive
+     *
+     * @param string $tmpDir extracted backup root directory
+     * @throws CoreException
+     */
+    private static function restorePlugins($tmpDir)
+    {
+        $pluginDirs = glob(sprintf("%s/plugins/*", $tmpDir), GLOB_ONLYDIR);
+        $pluginRoot = sprintf("%s/plugins", NEXTDOM_ROOT);
+
+        FileSystemHelper::rrmdir($pluginRoot);
+        FileSystemHelper::mkdirIfNotExists($pluginRoot, 0775, true);
+        foreach ($pluginDirs as $c_dir) {
+            if (false === FileSystemHelper::mv($c_dir, $pluginRoot)) {
+                // should probably fail, keeping behavior prior to install/restore.php refactoring
+            }
+        }
+        self::restorePublicPerms($pluginRoot);
+
+        $plugins = PluginManager::listPlugin(true);
+        foreach ($plugins as $c_plugin) {
+            // call plugin restore hook, if any
+            $pluginID = $c_plugin->getId();
+            if (method_exists($pluginID, 'restore')) {
+                $pluginID::restore();
+            }
+            // reset plugin dependencies
+            $cache = CacheManager::byKey('dependancy' . $c_plugin->getId());
+            $cache->remove();
+            CacheManager::set('dependancy' . $c_plugin->getId(), "nok");
+        }
+    }
+
+    /**
+     * Restore www-data owner and 775 permissions on directory
+     *
+     * @param $folderRoot
+     * @throws CoreException on permission error
+     */
+    private static function restorePublicPerms($folderRoot)
+    {
+        $status = SystemHelper::vsystem("%s chown %s:%s -R %s",
+            SystemHelper::getCmdSudo(),
+            SystemHelper::getWWWUid(),
+            SystemHelper::getWWWGid(),
+            $folderRoot);
+        if (0 != $status) {
+            throw new CoreException("unable to restore filesystem owner on " . $folderRoot);
+        }
+
+        SystemHelper::vsystem("%s chmod 775 -R %s",
+            SystemHelper::getCmdSudo(),
+            $folderRoot);
+        if (0 != $status) {
+            throw new CoreException("unable to restore filesystem rights" . $folderRoot);
+        }
     }
 
     /**
@@ -621,18 +710,6 @@ class BackupManager
     }
 
     /**
-     * Loads migrate script into mysql database
-     *
-     * @throws CoreException from RestoreManager::loadSQLFromFile
-     */
-    private static function loadSQLMigrateScript()
-    {
-        $migrateFile = sprintf("%s/install/migrate/migrate_0_0_0.sql", NEXTDOM_ROOT);
-
-        self::loadSQLFromFile($migrateFile);
-    }
-
-    /**
      * Import common config if not already exists
      *
      * @param string $tmpDir extracted backup root directory
@@ -653,7 +730,6 @@ class BackupManager
         }
     }
 
-
     /**
      * Restore custom data from backup archive
      *
@@ -666,7 +742,7 @@ class BackupManager
 
         foreach ($rootCustomDataDirs as $c_dir) {
             $name = basename($c_dir);
-            if(!in_array($name, FoldersReferential::NEXTDOMFOLDERS)
+            if (!in_array($name, FoldersReferential::NEXTDOMFOLDERS)
                 && !in_array($name, FoldersReferential::NEXTDOMFILES)
                 && !in_array($name, FoldersReferential::JEEDOMFOLDERS)
                 && !in_array($name, FoldersReferential::JEEDOMFILES)) {
@@ -679,7 +755,7 @@ class BackupManager
                 if (true === FileSystemHelper::mv($c_dir, sprintf("%s/%s", NEXTDOM_ROOT, $name))) {
                     self::restorePublicPerms(NEXTDOM_ROOT);
                 }
-                if($logFile != LogTarget::MIGRATION) {
+                if ($logFile != LogTarget::MIGRATION) {
                     ConsoleHelper::ok();
                 }
             }
@@ -690,11 +766,11 @@ class BackupManager
         $customDataRoot = sprintf("%s/data", NEXTDOM_DATA);
 
         FileSystemHelper::rrmdir($customDataRoot . "/");
-        FileSystemHelper::mkdirIfNotExists($customDataRoot,0775,true);
+        FileSystemHelper::mkdirIfNotExists($customDataRoot, 0775, true);
         foreach ($customDataDirs as $c_dir) {
             $name = basename($c_dir);
-            $message ='Restoring folder :'.$name;
-            if($logFile == LogTarget::MIGRATION) {
+            $message = 'Restoring folder :' . $name;
+            if ($logFile == LogTarget::MIGRATION) {
                 LogHelper::addInfo($logFile, $message, '');
             } else {
                 ConsoleHelper::process($message);
@@ -702,7 +778,7 @@ class BackupManager
             if (true === FileSystemHelper::mv($c_dir, sprintf("%s/%s", $customDataRoot, $name))) {
                 self::restorePublicPerms($customDataRoot);
             }
-            if($logFile != LogTarget::MIGRATION) {
+            if ($logFile != LogTarget::MIGRATION) {
                 ConsoleHelper::ok();
             }
         }
@@ -710,10 +786,10 @@ class BackupManager
         $customPlanDirs = glob(sprintf("%s/core/img/*", $tmpDir), GLOB_ONLYDIR);
         $customPlanRoot = sprintf("%s/data/custom/plans", NEXTDOM_DATA);
 
-        FileSystemHelper::mkdirIfNotExists($customPlanRoot,0775,true);
+        FileSystemHelper::mkdirIfNotExists($customPlanRoot, 0775, true);
         foreach ($customPlanDirs as $c_dir) {
             $name = basename($c_dir);
-            if(Utils::startsWith($name,NextDomObj::PLAN)) {
+            if (Utils::startsWith($name, NextDomObj::PLAN)) {
                 $message = 'Restoring folder :' . $name;
                 if ($logFile == LogTarget::MIGRATION) {
                     LogHelper::addInfo($logFile, $message, '');
@@ -732,70 +808,27 @@ class BackupManager
 
     }
 
-    /**
-     * Restore plugins from backup archive
-     *
-     * @param string $tmpDir extracted backup root directory
-     * @throws CoreException
-     */
-    private static function restorePlugins($tmpDir)
-    {
-        $pluginDirs = glob(sprintf("%s/plugins/*", $tmpDir), GLOB_ONLYDIR);
-        $pluginRoot = sprintf("%s/plugins", NEXTDOM_ROOT);
-
-        FileSystemHelper::rrmdir($pluginRoot);
-        FileSystemHelper::mkdirIfNotExists($pluginRoot,0775,true);
-        foreach ($pluginDirs as $c_dir) {
-            if (false === FileSystemHelper::mv($c_dir, $pluginRoot)) {
-                // should probably fail, keeping behavior prior to install/restore.php refactoring
-            }
-        }
-        self::restorePublicPerms($pluginRoot);
-
-        $plugins = PluginManager::listPlugin(true);
-        foreach ($plugins as $c_plugin) {
-            // call plugin restore hook, if any
-            $pluginID = $c_plugin->getId();
-            if (method_exists($pluginID, 'restore')) {
-                $pluginID::restore();
-            }
-            // reset plugin dependencies
-            $cache = CacheManager::byKey('dependancy' . $c_plugin->getId());
-            $cache->remove();
-            CacheManager::set('dependancy' . $c_plugin->getId(), "nok");
-        }
-    }
-
-    /**
-     * Restore www-data owner and 775 permissions on directory
-     *
-     * @param $folderRoot
-     * @throws CoreException on permission error
-     */
-    private static function restorePublicPerms($folderRoot)
-    {
-        $status = SystemHelper::vsystem("%s chown %s:%s -R %s",
-            SystemHelper::getCmdSudo(),
-            SystemHelper::getWWWUid(),
-            SystemHelper::getWWWGid(),
-            $folderRoot);
-        if (0 != $status) {
-            throw new CoreException("unable to restore filesystem owner on ".$folderRoot);
-        }
-
-        SystemHelper::vsystem("%s chmod 775 -R %s",
-            SystemHelper::getCmdSudo(),
-            $folderRoot);
-        if (0 != $status) {
-            throw new CoreException("unable to restore filesystem rights".$folderRoot);
-        }
-    }
-
     private static function updateConfig()
     {
         ConfigManager::save('hardware_name', '');
         $cache = CacheManager::byKey('nextdom::isCapable::sudo');
         $cache->remove();
+    }
+
+    /**
+     * Init default values
+     *
+     * @throws \Exception
+     */
+    private static function initValues()
+    {
+        ConfigManager::save('nextdom::firstUse', 0);
+    }
+
+    private static function clearCache()
+    {
+        CacheManager::flush();
+        exec('sh ' . NEXTDOM_ROOT . '/scripts/clear_cache.sh');
     }
 
     /**
@@ -834,44 +867,14 @@ class BackupManager
     }
 
     /**
-     * @param array $roots
-     * @param string $pattern
-     * @param Tar $tar
-     * @param string logFile
-     */
-    private static function addPathToArchive($roots, $pattern, $tar, $logFile)
-    {
-        foreach ($roots as $c_root) {
-            $path = $c_root;
-            $dirIter = new RecursiveDirectoryIterator($path);
-            $riIter = new RecursiveIteratorIterator($dirIter);
-            ConsoleHelper::stepLine('Add files of ' . $c_root .' to archive');
-            // iterate on files recursively found
-            foreach ($riIter as $c_entry) {
-                if (false === $c_entry->isFile()) {
-                    continue;
-                }
-                $message ='Add folder to archive : '.$c_entry->getPathname();
-                if(self::$logLevel == LogLevel::DEBUG && $logFile === LogTarget::BACKUP) {
-                    LogHelper::addDebug($logFile, $message);
-                }
-                $dest = str_replace($pattern, "", $c_entry->getPathname());
-                $tar->addFile($c_entry->getPathname(), $dest);
-            }
-        }
-    }
-
-    private static function clearCache() {
-        CacheManager::flush();
-        exec('sh ' . NEXTDOM_ROOT . '/scripts/clear_cache.sh');
-    }
-
-    /**
-     * Init default values
+     * Loads migrate script into mysql database
      *
-     * @throws \Exception
+     * @throws CoreException from RestoreManager::loadSQLFromFile
      */
-    private static function initValues() {
-        ConfigManager::save('nextdom::firstUse', 0);
+    private static function loadSQLMigrateScript()
+    {
+        $migrateFile = sprintf("%s/install/migrate/migrate_0_0_0.sql", NEXTDOM_ROOT);
+
+        self::loadSQLFromFile($migrateFile);
     }
 }

--- a/src/Managers/CacheManager.php
+++ b/src/Managers/CacheManager.php
@@ -34,6 +34,7 @@
 
 namespace NextDom\Managers;
 
+use NextDom\Enums\DateFormat;
 use NextDom\Helpers\FileSystemHelper;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\SystemHelper;
@@ -103,7 +104,7 @@ class CacheManager
         }
         if ($details) {
             $re = '/s:\d*:(.*?);s:\d*:"(.*?)";s/';
-            $result = array();
+            $result = [];
             foreach (FileSystemHelper::ls(self::getFolder()) as $folder) {
                 foreach (FileSystemHelper::ls(self::getFolder() . '/' . $folder) as $file) {
                     $path = self::getFolder() . '/' . $folder . '/' . $file;
@@ -225,7 +226,7 @@ class CacheManager
      */
     public static function search(): array
     {
-        return array();
+        return [];
     }
 
     /**
@@ -323,7 +324,7 @@ class CacheManager
             return;
         }
         $re = '/s:\d*:(.*?);s:\d*:"(.*?)";s/';
-        $result = array();
+        $result = [];
         foreach (FileSystemHelper::ls(self::getFolder()) as $folder) {
             foreach (FileSystemHelper::ls(self::getFolder() . '/' . $folder) as $file) {
                 $path = self::getFolder() . '/' . $folder . '/' . $file;
@@ -339,7 +340,7 @@ class CacheManager
                 $result[] = $matches[2][0];
             }
         }
-        $cleanCache = array(
+        $cleanCache = [
             'cmdCacheAttr' => 'cmd',
             'cmd' => 'cmd',
             'eqLogicCacheAttr' => 'eqLogic',
@@ -347,7 +348,7 @@ class CacheManager
             'scenarioCacheAttr' => 'scenario',
             'cronCacheAttr' => 'cron',
             'cron' => 'cron',
-        );
+        ];
         foreach ($result as $key) {
             $matches = null;
             if (strpos($key, '::lastCommunication') !== false) {
@@ -474,7 +475,7 @@ class CacheManager
         if (!is_object($cache)) {
             $cache = new Cache();
             $cache->setKey($key)
-                ->setDatetime(date('Y-m-d H:i:s'));
+                ->setDatetime(date(DateFormat::FULL));
         }
         return $cache;
     }

--- a/src/Managers/ConsistencyManager.php
+++ b/src/Managers/ConsistencyManager.php
@@ -43,19 +43,19 @@ use NextDom\Model\Entity\Cron;
  */
 class ConsistencyManager
 {
-    private static $defaultSummary = array(
-        'security' => array('key' => 'security', 'name' => 'Alerte', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-alerte2"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false),
-        'motion' => array('key' => 'motion', 'name' => 'Mouvement', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-mouvement"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false),
-        'door' => array('key' => 'door', 'name' => 'Porte', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-porte-ouverte"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false),
-        'windows' => array('key' => 'windows', 'name' => 'Fenêtre', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-fenetre-ouverte"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false),
-        'shutter' => array('key' => 'shutter', 'name' => 'Volet', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-volet-ouvert"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false),
-        'light' => array('key' => 'light', 'name' => 'Lumière', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-lumiere-on"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false),
-        'outlet' => array('key' => 'outlet', 'name' => 'Prise', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-prise"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false),
-        'temperature' => array('key' => 'temperature', 'name' => 'Température', 'calcul' => 'avg', 'icon' => '<i class="icon divers-thermometer31"></i>', 'unit' => '°C', 'allowDisplayZero' => true),
-        'humidity' => array('key' => 'humidity', 'name' => 'Humidité', 'calcul' => 'avg', 'icon' => '<i class="fa fa-tint"></i>', 'unit' => '%', 'allowDisplayZero' => true),
-        'luminosity' => array('key' => 'luminosity', 'name' => 'Luminosité', 'calcul' => 'avg', 'icon' => '<i class="icon meteo-soleil"></i>', 'unit' => 'lx', 'allowDisplayZero' => false),
-        'power' => array('key' => 'power', 'name' => 'Puissance', 'calcul' => 'sum', 'icon' => '<i class="fa fa-bolt"></i>', 'unit' => 'W', 'allowDisplayZero' => false),
-    );
+    private static $defaultSummary = [
+        'security' => ['key' => 'security', 'name' => 'Alerte', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-alerte2"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false],
+        'motion' => ['key' => 'motion', 'name' => 'Mouvement', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-mouvement"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false],
+        'door' => ['key' => 'door', 'name' => 'Porte', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-porte-ouverte"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false],
+        'windows' => ['key' => 'windows', 'name' => 'Fenêtre', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-fenetre-ouverte"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false],
+        'shutter' => ['key' => 'shutter', 'name' => 'Volet', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-volet-ouvert"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false],
+        'light' => ['key' => 'light', 'name' => 'Lumière', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-lumiere-on"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false],
+        'outlet' => ['key' => 'outlet', 'name' => 'Prise', 'calcul' => 'sum', 'icon' => '<i class="icon nextdom-prise"></i>', 'unit' => '', 'count' => 'binary', 'allowDisplayZero' => false],
+        'temperature' => ['key' => 'temperature', 'name' => 'Température', 'calcul' => 'avg', 'icon' => '<i class="icon divers-thermometer31"></i>', 'unit' => '°C', 'allowDisplayZero' => true],
+        'humidity' => ['key' => 'humidity', 'name' => 'Humidité', 'calcul' => 'avg', 'icon' => '<i class="fa fa-tint"></i>', 'unit' => '%', 'allowDisplayZero' => true],
+        'luminosity' => ['key' => 'luminosity', 'name' => 'Luminosité', 'calcul' => 'avg', 'icon' => '<i class="icon meteo-soleil"></i>', 'unit' => 'lx', 'allowDisplayZero' => false],
+        'power' => ['key' => 'power', 'name' => 'Puissance', 'calcul' => 'sum', 'icon' => '<i class="fa fa-bolt"></i>', 'unit' => 'W', 'allowDisplayZero' => false],
+    ];
 
     /**
      * Start consistency check of the system
@@ -150,103 +150,103 @@ class ConsistencyManager
      */
     public static function getDefaultCrons()
     {
-        return array(
-            "nextdom" => array(
-                "backup" => array(
+        return [
+            "nextdom" => [
+                "backup" => [
                     "schedule" => mt_rand(10, 59) . ' 0' . mt_rand(0, 7) . ' * * *',
                     "timeout" => 60,
                     "enabled" => 1
-                ),
-                "cronDaily" => array(
+                ],
+                "cronDaily" => [
                     "schedule" => "00 00 * * * *",
                     "timeout" => 240,
                     "enabled" => 1
-                ),
-                "cronHourly" => array(
+                ],
+                "cronHourly" => [
                     "schedule" => "00 * * * * *",
                     "timeout" => 60,
                     "enabled" => 1
-                ),
-                "cron10" => array(
+                ],
+                "cron10" => [
                     "schedule" => "*/10 * * * * *",
                     "timeout" => 10
-                ),
-                "cron5" => array(
+                ],
+                "cron5" => [
                     "schedule" => "*/5 * * * * *",
                     "timeout" => 5
-                ),
-                "cron" => array(
+                ],
+                "cron" => [
                     "schedule" => "* * * * * *",
                     "timeout" => 2
-                ),
-            ),
-            "plugin" => array(
-                "cronDaily" => array(
+                ],
+            ],
+            "plugin" => [
+                "cronDaily" => [
                     "schedule" => "00 00 * * * *",
                     "timeout" => 240,
                     "enabled" => 1
-                ),
-                "cronHourly" => array(
+                ],
+                "cronHourly" => [
                     "schedule" => "00 * * * * *",
                     "timeout" => 60,
                     "enabled" => 1
-                ),
-                "cron" => array(
+                ],
+                "cron" => [
                     "schedule" => "* * * * * *",
                     "timeout" => 2
-                ),
-                "cron5" => array(
+                ],
+                "cron5" => [
                     "schedule" => "*/5 * * * * *",
                     "timeout" => 5,
                     "enabled" => 1
-                ),
-                "cron10" => array(
+                ],
+                "cron10" => [
                     "schedule" => "*/10 * * * * *",
                     "timeout" => 10
-                ),
-                "cron15" => array(
+                ],
+                "cron15" => [
                     "schedule" => "*/15 * * * * *",
                     "timeout" => 15
-                ),
-                "cron30" => array(
+                ],
+                "cron30" => [
                     "schedule" => "*/15 * * * * *",
                     "timeout" => 30
-                ),
-                "checkDeamon" => array(
+                ],
+                "checkDeamon" => [
                     "schedule" => "*/5 * * * * *",
                     "timeout" => 5
-                ),
-                "heartbeat" => array(
+                ],
+                "heartbeat" => [
                     "schedule" => "*/5 * * * * *",
                     "timeout" => 10,
                     "enabled" => 1
-                ),
-            ),
-            "scenario" => array(
-                "check" => array(
+                ],
+            ],
+            "scenario" => [
+                "check" => [
                     "schedule" => "* * * * * *",
                     "timeout" => 30,
                     "enabled" => 1
-                ),
-                "control" => array(
+                ],
+                "control" => [
                     "schedule" => "* * * * * *",
                     "timeout" => 30,
                     "enabled" => 1
-                ),
-            ),
-            "cache" => array(
-                "persist" => array(
+                ],
+            ],
+            "cache" => [
+                "persist" => [
                     "schedule" => "*/30 * * * * *",
                     "timeout" => 30
-                ),
-            ),
-            "history" => array(
-                "archive" => array(
+                ],
+            ],
+            "history" => [
+                "archive" => [
                     "schedule" => "00 5 * * * *",
                     "timeout" => 240
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     private static function cleanWidgetCache()

--- a/src/Managers/CronManager.php
+++ b/src/Managers/CronManager.php
@@ -60,9 +60,9 @@ class CronManager
      */
     public static function byId($cronId)
     {
-        $value = array(
+        $value = [
             'id' => $cronId,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE id = :id';
@@ -81,10 +81,10 @@ class CronManager
      */
     public static function byClassAndFunction($className, $functionName, $options = '')
     {
-        $value = array(
+        $value = [
             'class' => $className,
             'function' => $functionName,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE class = :class
@@ -109,10 +109,10 @@ class CronManager
      */
     public static function searchClassAndFunction($className, $functionName, $options = '')
     {
-        $value = array(
+        $value = [
             'class' => $className,
             'function' => $functionName,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE class = :class
@@ -166,7 +166,7 @@ class CronManager
      */
     public static function nbCronRun()
     {
-        return count(SystemHelper::ps('start_cron.php', array('grep', 'sudo', 'shell=/bin/bash - ', '/bin/bash -c ', posix_getppid(), getmypid())));
+        return count(SystemHelper::ps('start_cron.php', ['grep', 'sudo', 'shell=/bin/bash - ', '/bin/bash -c ', posix_getppid(), getmypid()]));
     }
 
     /**

--- a/src/Managers/DataStoreManager.php
+++ b/src/Managers/DataStoreManager.php
@@ -56,9 +56,9 @@ class DataStoreManager
      */
     public static function byId($id)
     {
-        $values = array(
+        $values = [
             'id' => $id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE id=:id';
@@ -79,11 +79,11 @@ class DataStoreManager
      */
     public static function byTypeLinkIdKey($dataType, $linkId, $key)
     {
-        $values = array(
+        $values = [
             'type' => $dataType,
             'link_id' => $linkId,
             'key' => $key,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE `type` = :type
@@ -123,9 +123,9 @@ class DataStoreManager
      */
     public static function byTypeLinkId($dataType, $linkId = '')
     {
-        $values = array(
+        $values = [
             'type' => $dataType,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE type=:type';

--- a/src/Managers/DevicesManager.php
+++ b/src/Managers/DevicesManager.php
@@ -58,17 +58,17 @@ class DevicesManager
     {
         $cache = CacheManager::byKey('nextdom::usbMapping');
         if (!Utils::isJson($cache->getValue()) || $name == '') {
-            $usbMapping = array();
+            $usbMapping = [];
             foreach (FileSystemHelper::ls('/dev/', 'ttyUSB*') as $usb) {
                 $vendor = '';
                 $model = '';
                 $devsList = shell_exec('/sbin/udevadm info --name=/dev/' . $usb . ' --query=all');
                 foreach (explode("\n", $devsList) as $line) {
                     if (strpos($line, 'E: ID_MODEL=') !== false) {
-                        $model = trim(str_replace(array('E: ID_MODEL=', '"'), '', $line));
+                        $model = trim(str_replace(['E: ID_MODEL=', '"'], '', $line));
                     }
                     if (strpos($line, 'E: ID_VENDOR=') !== false) {
-                        $vendor = trim(str_replace(array('E: ID_VENDOR=', '"'), '', $line));
+                        $vendor = trim(str_replace(['E: ID_VENDOR=', '"'], '', $line));
                     }
                 }
                 if ($vendor == '' && $model == '') {
@@ -140,7 +140,7 @@ class DevicesManager
     {
         $cache = CacheManager::byKey('nextdom::bluetoothMapping');
         if (!Utils::isJson($cache->getValue()) || $name == '') {
-            $bluetoothMapping = array();
+            $bluetoothMapping = [];
             foreach (explode("\n", shell_exec('hcitool dev')) as $line) {
                 if (strpos($line, 'hci') === false || trim($line) == '') {
                     continue;

--- a/src/Managers/EqLogicManager.php
+++ b/src/Managers/EqLogicManager.php
@@ -59,9 +59,9 @@ class EqLogicManager
      */
     public static function byEqRealId($eqRealId)
     {
-        $values = array(
+        $values = [
             'eqReal_id' => $eqRealId,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE eqReal_id = :eqReal_id';
@@ -96,8 +96,7 @@ class EqLogicManager
                     return $target;
                 }
             }
-        }
-        catch (CoreException $e) {
+        } catch (CoreException $e) {
             MessageManager::add('core', $e->getMessage());
             return null;
         }
@@ -121,7 +120,7 @@ class EqLogicManager
      */
     public static function byObjectId($objectId, $onlyEnable = true, $onlyVisible = false, $eqTypeName = null, $logicalId = null, $orderByName = false)
     {
-        $values = array();
+        $values = [];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . ' ';
         if ($objectId === null) {
@@ -191,9 +190,9 @@ class EqLogicManager
      */
     public static function byType($eqTypeName, $onlyEnable = false)
     {
-        $values = array(
+        $values = [
             'eqType_name' => $eqTypeName,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME, 'el') . '
                 FROM ' . self::DB_CLASS_NAME . '  el
                 LEFT JOIN object ob ON el.object_id = ob.id
@@ -214,10 +213,10 @@ class EqLogicManager
      */
     public static function byCategory($category)
     {
-        $values = array(
+        $values = [
             'category' => '%"' . $category . '":1%',
             'category2' => '%"' . $category . '":"1"%',
-        );
+        ];
 
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
@@ -237,10 +236,10 @@ class EqLogicManager
      */
     public static function byTypeAndSearhConfiguration($eqTypeName, $configuration)
     {
-        $values = array(
+        $values = [
             'eqType_name' => $eqTypeName,
             'configuration' => '%' . $configuration . '%',
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE eqType_name = :eqType_name
@@ -260,16 +259,16 @@ class EqLogicManager
     public static function searchConfiguration($configuration, $type = null)
     {
         if (!is_array($configuration)) {
-            $values = array(
+            $values = [
                 'configuration' => '%' . $configuration . '%',
-            );
+            ];
             $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                     FROM ' . self::DB_CLASS_NAME . '
                     WHERE configuration LIKE :configuration';
         } else {
-            $values = array(
+            $values = [
                 'configuration' => '%' . $configuration[0] . '%',
-            );
+            ];
             $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                     FROM ' . self::DB_CLASS_NAME . '
                     WHERE configuration LIKE :configuration';
@@ -298,10 +297,10 @@ class EqLogicManager
     public static function listByTypeAndCmdType($eqTypeName, $typeCmd, $subTypeCmd = '')
     {
         if ($subTypeCmd == '') {
-            $values = array(
+            $values = [
                 'eqType_name' => $eqTypeName,
                 'typeCmd' => $typeCmd,
-            );
+            ];
             $sql = 'SELECT DISTINCT(el.id),el.name
                     FROM ' . self::DB_CLASS_NAME . '  el
                     INNER JOIN cmd c ON c.eqLogic_id = el.id
@@ -310,11 +309,11 @@ class EqLogicManager
                     ORDER BY name';
             return DBHelper::getAll($sql, $values);
         } else {
-            $values = array(
+            $values = [
                 'eqType_name' => $eqTypeName,
                 'typeCmd' => $typeCmd,
                 'subTypeCmd' => $subTypeCmd,
-            );
+            ];
             $sql = 'SELECT DISTINCT(el.id),el.name
                     FROM ' . self::DB_CLASS_NAME . '  el
                     INNER JOIN cmd c ON c.eqLogic_id = el.id
@@ -337,7 +336,7 @@ class EqLogicManager
      */
     public static function listByObjectAndCmdType($objectId, $typeCmd, $subTypeCmd = '')
     {
-        $values = array();
+        $values = [];
         $sql = 'SELECT DISTINCT(el.id), el.name
                 FROM ' . self::DB_CLASS_NAME . '  el
                 INNER JOIN cmd c ON c.eqLogic_id=el.id
@@ -402,10 +401,10 @@ class EqLogicManager
                             foreach ($cmds as $id) {
                                 $cmd = CmdManager::byId(str_replace('#', '', $id));
                                 if (is_object($cmd)) {
-                                    $cmd->execCmd(array(
+                                    $cmd->execCmd([
                                         'title' => __('[' . ConfigManager::byKey('name', 'core', 'NEXTDOM') . '] ') . $message,
                                         'message' => ConfigManager::byKey('name', 'core', 'NEXTDOM') . ' : ' . $message,
-                                    ));
+                                    ]);
                                 }
                             }
                         }
@@ -432,9 +431,9 @@ class EqLogicManager
      */
     public static function byTimeout($timeout = 0, $onlyEnable = false)
     {
-        $values = array(
+        $values = [
             'timeout' => $timeout,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE timeout >= :timeout';
@@ -503,9 +502,9 @@ class EqLogicManager
         if ($id == '') {
             return null;
         }
-        $values = array(
+        $values = [
             'id' => $id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE id = :id';
@@ -550,9 +549,9 @@ class EqLogicManager
      * @param array $options
      * @return array
      */
-    public static function generateHtmlTable($nbLine, $nbColumn, $options = array())
+    public static function generateHtmlTable($nbLine, $nbColumn, $options = [])
     {
-        $return = array('html' => '', 'replace' => array());
+        $return = ['html' => '', 'replace' => []];
         if (!isset($options['styletd'])) {
             $options['styletd'] = '';
         }
@@ -598,13 +597,13 @@ class EqLogicManager
      */
     public static function getAllTags()
     {
-        $values = array();
+        $values = [];
         $sql = 'SELECT tags
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE tags IS NOT NULL
         	    AND tags!=""';
         $results = DBHelper::getAll($sql, $values);
-        $return = array();
+        $return = [];
         foreach ($results as $result) {
             $tags = explode(',', $result['tags']);
             foreach ($tags as $tag) {
@@ -621,9 +620,9 @@ class EqLogicManager
      */
     public static function byString($_string)
     {
-        $eqLogic = self::byId(str_replace(array('#','eqLogic'), '', self::fromHumanReadable($_string)));
+        $eqLogic = self::byId(str_replace(['#', 'eqLogic'], '', self::fromHumanReadable($_string)));
         if (!is_object($eqLogic)) {
-            throw new \Exception(__('L\'équipement n\'a pas pu être trouvé : ') . $_string . __(' => ') . self::fromHumanReadable($_string));
+            throw new CoreException(__('L\'équipement n\'a pas pu être trouvé : ') . $_string . __(' => ') . self::fromHumanReadable($_string));
         }
         return $eqLogic;
     }
@@ -703,10 +702,10 @@ class EqLogicManager
                     WHERE name=:eqLogic_name
                     AND object_id IS NULL';
         } else {
-            $values = array(
+            $values = [
                 'eqLogic_name' => $eqLogicName,
                 'object_name' => $objectName,
-            );
+            ];
             $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME, 'el') . '
                     FROM ' . self::DB_CLASS_NAME . '  el
                     INNER JOIN object ob ON el.object_id=ob.id

--- a/src/Managers/EqRealManager.php
+++ b/src/Managers/EqRealManager.php
@@ -55,16 +55,16 @@ class EqRealManager
      */
     public static function byLogicalId($_logicalId, $_cat)
     {
-        $values = array(
+        $values = [
             'logicalId' => $_logicalId,
             'cat' => $_cat,
-        );
+        ];
         $sql = 'SELECT id
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE logicalId = :logicalId
                   AND cat= : cat';
         $results = DBHelper::getAll($sql, $values);
-        $return = array();
+        $return = [];
         foreach ($results as $result) {
             $return[] = self::byId($result['id']);
         }
@@ -79,9 +79,9 @@ class EqRealManager
      */
     public static function byId($_id)
     {
-        $values = array(
+        $values = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE id = :id';
@@ -99,9 +99,9 @@ class EqRealManager
         if (get_called_class() != self::CLASS_NAME) {
             return get_called_class();
         }
-        $values = array(
+        $values = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT plugin, isEnable
                 FROM `eqLogic`
                 WHERE eqReal_id = :id';

--- a/src/Managers/EventManager.php
+++ b/src/Managers/EventManager.php
@@ -70,7 +70,7 @@ class EventManager
             if (!is_array($value)) {
                 $value = [];
             }
-            $value[] = array('datetime' => Utils::getMicrotime(), 'name' => $eventName, 'option' => $options);
+            $value[] = ['datetime' => Utils::getMicrotime(), 'name' => $eventName, 'option' => $options];
             CacheManager::set('event', json_encode(self::cleanEvent($value)));
             flock($fd, LOCK_UN);
         }
@@ -102,7 +102,7 @@ class EventManager
         $find = [];
         $currentTime = strtotime(DateFormat::NOW) + 300;
         foreach (array_values($events) as $key => $event) {
-            if($event['datetime'] > $currentTime){
+            if ($event['datetime'] > $currentTime) {
                 unset($events[$key]);
                 continue;
             }
@@ -114,7 +114,7 @@ class EventManager
                 $id = $event['name'] . '::' . $event['option']['scenario_id'];
             } elseif ($event['name'] == 'jeeObject::summary::update') {
                 $id = $event['name'] . '::' . $event['option']['object_id'];
-                if(is_array($event['option']['keys']) && count($event['option']['keys']) > 0) {
+                if (is_array($event['option']['keys']) && count($event['option']['keys']) > 0) {
                     foreach ($event['option']['keys'] as $optionKey => $value) {
                         $id .= $optionKey;
                     }
@@ -150,7 +150,7 @@ class EventManager
             }
             $value = [];
             foreach ($values as $option) {
-                $value[] = array('datetime' => Utils::getMicrotime(), 'name' => $eventName, 'option' => $option);
+                $value[] = ['datetime' => Utils::getMicrotime(), 'name' => $eventName, 'option' => $option];
             }
             CacheManager::set('event', json_encode(self::cleanEvent(array_merge($value_src, $value))));
             flock($fd, LOCK_UN);
@@ -214,8 +214,8 @@ class EventManager
         if ($_filter == null) {
             return $_data;
         }
-        $filters = ($_filter !== null) ? CacheManager::byKey($_filter . '::event')->getValue(array()) : array();
-        $return = array('datetime' => $_data['datetime'], 'result' => array());
+        $filters = ($_filter !== null) ? CacheManager::byKey($_filter . '::event')->getValue([]) : [];
+        $return = ['datetime' => $_data['datetime'], 'result' => []];
         foreach ($_data['result'] as $value) {
             if ($_filter !== null && isset($_filter::$_listenEvents) && !in_array($value['name'], $_filter::$_listenEvents)) {
                 continue;
@@ -239,11 +239,11 @@ class EventManager
      */
     protected static function changesSince($_datetime)
     {
-        $return = array('datetime' => $_datetime, 'result' => array());
+        $return = ['datetime' => $_datetime, 'result' => []];
         $cache = CacheManager::byKey('event');
         $events = json_decode($cache->getValue('[]'), true);
         if (!is_array($events)) {
-            $events = array();
+            $events = [];
         }
         $values = array_reverse($events);
         if (count($values) > 0) {

--- a/src/Managers/HistoryManager.php
+++ b/src/Managers/HistoryManager.php
@@ -34,6 +34,8 @@
 
 namespace NextDom\Managers;
 
+use NextDom\Enums\CmdSubType;
+use NextDom\Enums\CmdType;
 use NextDom\Enums\DateFormat;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
@@ -58,39 +60,39 @@ class HistoryManager
      */
     public static function copyHistoryToCmd($_source_id, $_target_id)
     {
-        $source_cmd = CmdManager::byId(str_replace('#', '', $_source_id));
-        if (!is_object($source_cmd)) {
+        $sourceCmd = CmdManager::byId(str_replace('#', '', $_source_id));
+        if (!is_object($sourceCmd)) {
             throw new CoreException(__('La commande source n\'existe pas :') . ' ' . $_source_id);
         }
-        if ($source_cmd->getIsHistorized() != 1) {
+        if ($sourceCmd->getIsHistorized() != 1) {
             throw new CoreException(__('La commande source n\'est pas historisée'));
         }
-        if ($source_cmd->getType() != 'info') {
+        if ($sourceCmd->isType(CmdType::INFO)) {
             throw new CoreException(__('La commande source n\'est pas de type info'));
         }
-        $target_cmd = CmdManager::byId(str_replace('#', '', $_target_id));
-        if (!is_object($target_cmd)) {
+        $targetCmd = CmdManager::byId(str_replace('#', '', $_target_id));
+        if (!is_object($targetCmd)) {
             throw new CoreException(__('La commande cible n\'existe pas :') . ' ' . $_target_id);
         }
-        if ($target_cmd->getType() != 'info') {
+        if ($targetCmd->isType(CmdType::INFO)) {
             throw new CoreException(__('La commande cible n\'est pas de type info'));
         }
-        if ($target_cmd->getSubType() != $source_cmd->getSubType()) {
+        if ($targetCmd->getSubType() != $sourceCmd->getSubType()) {
             throw new CoreException(__('Le sous-type de la commande cible n\'est pas le même que celui de la commande source'));
         }
-        if ($target_cmd->getIsHistorized() != 1) {
-            $target_cmd->setIsHistorized(1);
-            $target_cmd->save();
+        if ($targetCmd->getIsHistorized() != 1) {
+            $targetCmd->setIsHistorized(1);
+            $targetCmd->save();
         }
-        $values = array(
-            'source_id' => $source_cmd->getId(),
-        );
+        $values = [
+            'source_id' => $sourceCmd->getId(),
+        ];
         $sql = 'REPLACE INTO ' . self::DB_CLASS_NAME . ' (`cmd_id`,`datetime`,`value`)
-                SELECT ' . $target_cmd->getId() . ',`datetime`,`value` FROM ' . self::DB_CLASS_NAME . ' WHERE cmd_id=:source_id';
+                SELECT ' . $targetCmd->getId() . ',`datetime`,`value` FROM ' . self::DB_CLASS_NAME . ' WHERE cmd_id=:source_id';
         DBHelper::exec($sql, $values);
 
         $sql = 'REPLACE INTO `historyArch` (`cmd_id`,`datetime`,`value`)
-                SELECT ' . $target_cmd->getId() . ',`datetime`,`value` FROM `historyArch` WHERE cmd_id=:source_id';
+                SELECT ' . $targetCmd->getId() . ',`datetime`,`value` FROM `historyArch` WHERE cmd_id=:source_id';
         DBHelper::exec($sql, $values);
     }
 
@@ -108,11 +110,11 @@ class HistoryManager
         if ($_endTime == null) {
             $_endTime = $_startTime;
         }
-        $values = array(
+        $values = [
             'cmd_id' => $_cmd_id,
             'startTime' => $_startTime,
             'endTime' => $_endTime,
-        );
+        ];
         if ($_oldValue != null) {
             $values['oldValue'] = $_oldValue;
         }
@@ -173,33 +175,33 @@ class HistoryManager
         if ($archiveDatetime === false) {
             $archiveDatetime = date(DateFormat::FULL, strtotime('- 1 hours'));
         }
-        $values = array(
+        $values = [
             'archiveDatetime' => $archiveDatetime,
-        );
+        ];
         $sql = 'SELECT DISTINCT(cmd_id)
         FROM history
         WHERE `datetime`<:archiveDatetime';
         $list_sensors = DBHelper::getAll($sql, $values);
         foreach ($list_sensors as $sensors) {
             $cmd = CmdManager::byId($sensors['cmd_id']);
-            if (!is_object($cmd) || $cmd->getType() != 'info' || $cmd->getIsHistorized() != 1) {
+            if (!is_object($cmd) || !$cmd->isType(CmdType::INFO) || $cmd->getIsHistorized() != 1) {
                 continue;
             }
             if ($cmd->getConfiguration('historyPurge', '') != '') {
                 $purgeTime = date(DateFormat::FULL, strtotime($cmd->getConfiguration('historyPurge', '')));
                 if ($purgeTime !== false) {
-                    $values = array(
+                    $values = [
                         'cmd_id' => $cmd->getId(),
                         'datetime' => $purgeTime,
-                    );
+                    ];
                     $sql = 'DELETE FROM historyArch WHERE cmd_id=:cmd_id AND `datetime` < :datetime';
                     DBHelper::exec($sql, $values);
                 }
             }
             if (!$NEXTDOM_INTERNAL_CONFIG['cmd']['type']['info']['subtype'][$cmd->getSubType()]['isHistorized']['canBeSmooth'] || $cmd->getConfiguration('historizeMode', 'avg') == 'none') {
-                $values = array(
+                $values = [
                     'cmd_id' => $cmd->getId(),
-                );
+                ];
                 $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                     FROM history
                     WHERE cmd_id=:cmd_id ORDER BY `datetime` ASC';
@@ -219,9 +221,9 @@ class HistoryManager
                 $history[0]->save();
                 $history[0]->setTableName('history');
                 $history[0]->remove();
-                $values = array(
+                $values = [
                     'cmd_id' => $cmd->getId(),
-                );
+                ];
                 $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                     FROM historyArch
                     WHERE cmd_id=:cmd_id ORDER BY datetime ASC';
@@ -235,10 +237,10 @@ class HistoryManager
                 }
                 continue;
             }
-            $values = array(
+            $values = [
                 'cmd_id' => $sensors['cmd_id'],
                 'archiveDatetime' => $archiveDatetime,
-            );
+            ];
             $sql = 'SELECT MIN(`datetime`) as oldest
                     FROM history
                     WHERE `datetime`<:archiveDatetime
@@ -248,11 +250,11 @@ class HistoryManager
             $mode = $cmd->getConfiguration('historizeMode', 'avg');
 
             while ($oldest['oldest'] !== null) {
-                $values = array(
+                $values = [
                     'cmd_id' => $sensors['cmd_id'],
                     'oldest' => $oldest['oldest'],
                     'archivePackage' => '-' . $archivePackage,
-                );
+                ];
 
                 $sql = 'SELECT ' . $mode . '(CAST(value AS DECIMAL(12,2))) as value,
                         FROM_UNIXTIME(AVG(UNIX_TIMESTAMP(`datetime`))) as datetime
@@ -268,20 +270,20 @@ class HistoryManager
                 $history->setTableName('historyArch');
                 $history->save();
 
-                $values = array(
+                $values = [
                     'cmd_id' => $sensors['cmd_id'],
                     'oldest' => $oldest['oldest'],
                     'archivePackage' => '-' . $archivePackage,
-                );
+                ];
                 $sql = 'DELETE FROM history
                         WHERE addtime(`datetime`,:archivePackage)<:oldest
                         AND cmd_id=:cmd_id';
                 DBHelper::exec($sql, $values);
 
-                $values = array(
+                $values = [
                     'cmd_id' => $sensors['cmd_id'],
                     'archiveDatetime' => $archiveDatetime,
-                );
+                ];
                 $sql = 'SELECT MIN(`datetime`) as oldest
                         FROM history
                         WHERE `datetime`<:archiveDatetime
@@ -300,9 +302,9 @@ class HistoryManager
      */
     public static function removes($_cmd_id, $_startTime = null, $_endTime = null)
     {
-        $values = array(
+        $values = [
             'cmd_id' => $_cmd_id,
-        );
+        ];
         if ($_startTime !== null) {
             $values['startTime'] = $_startTime;
         }
@@ -346,9 +348,9 @@ class HistoryManager
      */
     public static function getPlurality($_cmd_id, $_startTime = null, $_endTime = null, $_period = 'day', $_offset = 0)
     {
-        $values = array(
+        $values = [
             'cmd_id' => $_cmd_id,
-        );
+        ];
         if ($_startTime !== null) {
             $values['startTime'] = $_startTime;
         }
@@ -464,9 +466,9 @@ class HistoryManager
      */
     public static function all($_cmd_id, $_startTime = null, $_endTime = null)
     {
-        $values = array(
+        $values = [
             'cmd_id' => $_cmd_id,
-        );
+        ];
         if ($_startTime !== null) {
             $values['startTime'] = $_startTime;
         }
@@ -510,11 +512,11 @@ class HistoryManager
      */
     public static function getStatistics($_cmd_id, $_startTime, $_endTime)
     {
-        $values = array(
+        $values = [
             'cmd_id' => $_cmd_id,
             'startTime' => $_startTime,
             'endTime' => $_endTime,
-        );
+        ];
         $sql = 'SELECT AVG(CAST(value AS DECIMAL(12,2))) as avg, MIN(CAST(value AS DECIMAL(12,2))) as min, MAX(CAST(value AS DECIMAL(12,2))) as max, SUM(CAST(value AS DECIMAL(12,2))) as sum, COUNT(CAST(value AS DECIMAL(12,2))) as count, STD(CAST(value AS DECIMAL(12,2))) as std, VARIANCE(CAST(value AS DECIMAL(12,2))) as variance
         FROM (
             SELECT *
@@ -531,13 +533,13 @@ class HistoryManager
         ) as dt';
         $result = DBHelper::getOne($sql, $values);
         if (!is_array($result)) {
-            $result = array();
+            $result = [];
         }
-        $values = array(
+        $values = [
             'cmd_id' => $_cmd_id,
             'startTime' => $_startTime,
             'endTime' => $_endTime,
-        );
+        ];
         $sql = 'SELECT value as `last`
         FROM (
             SELECT *
@@ -556,7 +558,7 @@ class HistoryManager
         LIMIT 1';
         $result2 = DBHelper::getOne($sql, $values);
         if (!is_array($result2)) {
-            $result2 = array();
+            $result2 = [];
         }
         $return = array_merge($result, $result2);
         foreach ($return as $key => &$value) {
@@ -576,7 +578,7 @@ class HistoryManager
      */
     public static function getTendance($_cmd_id, $_startTime, $_endTime)
     {
-        $values = array();
+        $values = [];
         foreach (self::all($_cmd_id, $_startTime, $_endTime) as $history) {
             $values[] = $history->getValue();
         }
@@ -644,7 +646,7 @@ class HistoryManager
     {
         $cmd = CmdManager::byId($_cmd_id);
         if (!is_object($cmd)) {
-            throw new \Exception(__('Commande introuvable : ') . $_cmd_id);
+            throw new CoreException(__('Commande introuvable : ') . $_cmd_id);
         }
         if ($cmd->getIsHistorized() != 1) {
             return -2;
@@ -803,7 +805,7 @@ class HistoryManager
         if ($_value === null) {
             $_value = $cmd->execCmd();
         }
-        if ($cmd->getSubType() != 'string') {
+        if (!$cmd->isSubType(CmdSubType::STRING)) {
             $_value = str_replace(',', '.', $_value);
             $_decimal = strlen(substr(strrchr($_value, "."), 1));
             $_condition = ' ROUND(CAST(value AS DECIMAL(12,2)),' . $_decimal . ') = ' . $_value;
@@ -811,9 +813,9 @@ class HistoryManager
             $_condition = ' value = ' . $_value;
         }
 
-        $values = array(
+        $values = [
             'cmd_id' => $_cmd_id,
-        );
+        ];
         $sql = 'SELECT count(*) as changes
                 FROM (SELECT t1.*
                 FROM (
@@ -852,9 +854,9 @@ class HistoryManager
      */
     public static function emptyHistory($_cmd_id, $_date = '')
     {
-        $values = array(
+        $values = [
             'cmd_id' => $_cmd_id,
-        );
+        ];
         if ($_date != '') {
             $values['date'] = $_date;
         }
@@ -881,8 +883,8 @@ class HistoryManager
     public static function getHistoryFromCalcul($_strcalcul, $_dateStart = null, $_dateEnd = null, $_noCalcul = false)
     {
         $now = strtotime('now');
-        $value = array();
-        $cmd_histories = array();
+        $value = [];
+        $cmd_histories = [];
         preg_match_all("/#([0-9]*)#/", $_strcalcul, $matches);
         if (count($matches[1]) > 0) {
             foreach ($matches[1] as $cmd_id) {
@@ -895,7 +897,7 @@ class HistoryManager
                         $histories_cmd_count = count($histories_cmd);
                         for ($i = 0; $i < $histories_cmd_count; $i++) {
                             if (!isset($cmd_histories[$histories_cmd[$i]->getDatetime()])) {
-                                $cmd_histories[$histories_cmd[$i]->getDatetime()] = array();
+                                $cmd_histories[$histories_cmd[$i]->getDatetime()] = [];
                             }
                             $cmd_histories[$histories_cmd[$i]->getDatetime()]['#' . $cmd_id . '#'] = $histories_cmd[$i]->getValue();
 

--- a/src/Managers/InteractDefManager.php
+++ b/src/Managers/InteractDefManager.php
@@ -57,9 +57,9 @@ class InteractDefManager
      */
     public static function byId($_id)
     {
-        $values = array(
+        $values = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE id = :id';
@@ -73,7 +73,7 @@ class InteractDefManager
      */
     public static function listGroup($_group = null)
     {
-        $values = array();
+        $values = [];
         $sql = 'SELECT DISTINCT(`group`)
                 FROM ' . self::DB_CLASS_NAME;
         if ($_group !== null) {
@@ -90,7 +90,7 @@ class InteractDefManager
      */
     public static function generateTextVariant($_text)
     {
-        $return = array();
+        $return = [];
         preg_match_all("/(\[.*?\])/", $_text, $words);
         if (count($words[1]) == 0) {
             $return[] = $_text;
@@ -117,9 +117,9 @@ class InteractDefManager
      */
     public static function searchByQuery($_query)
     {
-        $values = array(
+        $values = [
             'query' => '%' . $_query . '%',
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE query LIKE :query';
@@ -140,7 +140,7 @@ class InteractDefManager
      */
     public static function all($_group = '')
     {
-        $values = array();
+        $values = [];
         if ($_group === '') {
             $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                     FROM ' . self::DB_CLASS_NAME . '
@@ -169,7 +169,7 @@ class InteractDefManager
     {
         $_def = self::sanitizeQuery(trim($_def));
         $_query = self::sanitizeQuery(trim($_query));
-        $options = array();
+        $options = [];
         $regexp = preg_quote(strtolower($_def));
         preg_match_all("/#(.*?)#/", $_def, $tags);
         if (count($tags[1]) > 0) {
@@ -200,7 +200,7 @@ class InteractDefManager
      */
     public static function sanitizeQuery($_query)
     {
-        $_query = str_replace(array("\'"), array("'"), $_query);
+        $_query = str_replace(["\'"], ["'"], $_query);
         $_query = preg_replace('/\s+/', ' ', $_query);
         $_query = ucfirst(strtolower($_query));
         $_query = strtolower(Utils::sanitizeAccent($_query));
@@ -213,14 +213,14 @@ class InteractDefManager
      */
     public static function deadCmd()
     {
-        $return = array();
+        $return = [];
         foreach (self::all() as $interact) {
             if (is_string($interact->getActions('cmd')) && $interact->getActions('cmd') != '') {
                 preg_match_all("/#([0-9]*)#/", $interact->getActions('cmd'), $matches);
                 foreach ($matches[1] as $cmd_id) {
                     if (is_numeric($cmd_id)) {
                         if (!CmdManager::byId(str_replace('#', '', $cmd_id))) {
-                            $return[] = array('detail' => 'Interaction ' . $interact->getName() . ' du groupe ' . $interact->getGroup(), 'help' => 'Action', 'who' => '#' . $cmd_id . '#');
+                            $return[] = ['detail' => 'Interaction ' . $interact->getName() . ' du groupe ' . $interact->getGroup(), 'help' => 'Action', 'who' => '#' . $cmd_id . '#'];
                         }
                     }
                 }
@@ -230,7 +230,7 @@ class InteractDefManager
                 foreach ($matches[1] as $cmd_id) {
                     if (is_numeric($cmd_id)) {
                         if (!CmdManager::byId(str_replace('#', '', $cmd_id))) {
-                            $return[] = array('detail' => 'Interaction ' . $interact->getName() . ' du groupe ' . $interact->getGroup(), 'help' => 'Réponse', 'who' => '#' . $cmd_id . '#');
+                            $return[] = ['detail' => 'Interaction ' . $interact->getName() . ' du groupe ' . $interact->getGroup(), 'help' => 'Réponse', 'who' => '#' . $cmd_id . '#'];
                         }
                     }
                 }
@@ -245,7 +245,7 @@ class InteractDefManager
      */
     public static function cleanInteract()
     {
-        $list_id = array();
+        $list_id = [];
         foreach (self::all() as $interactDef) {
             $list_id[$interactDef->getId()] = $interactDef->getId();
         }
@@ -263,7 +263,7 @@ class InteractDefManager
      */
     public static function searchByUse($searchPattern)
     {
-        $return = array();
+        $return = [];
         $interactDefs = self::searchByActionsOrReply($searchPattern);
         $interactQueries = InteractQueryManager::searchActions($searchPattern);
         foreach ($interactQueries as $interactQuery) {
@@ -285,17 +285,17 @@ class InteractDefManager
     private static function searchByActionsOrReply($searchPattern)
     {
         if (!is_array($searchPattern)) {
-            $values = array(
+            $values = [
                 'search' => '%' . $searchPattern . '%',
-            );
+            ];
             $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                     FROM ' . self::DB_CLASS_NAME . '
                     WHERE actions LIKE :search
                         OR reply LIKE :search';
         } else {
-            $values = array(
+            $values = [
                 'search' => '%' . $searchPattern[0] . '%',
-            );
+            ];
             $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                     FROM ' . self::DB_CLASS_NAME . '
                     WHERE actions LIKE :search
@@ -317,7 +317,7 @@ class InteractDefManager
      */
     public static function generateSynonymeVariante($_text, $_synonymes, $_deep = 0)
     {
-        $return = array();
+        $return = [];
         if (count($_synonymes) == 0) {
             return $return;
         }

--- a/src/Managers/InteractQueryManager.php
+++ b/src/Managers/InteractQueryManager.php
@@ -34,6 +34,12 @@
 
 namespace NextDom\Managers;
 
+use NextDom\Enums\CmdSubType;
+use NextDom\Enums\CmdType;
+use NextDom\Enums\Common;
+use NextDom\Enums\ConfigKey;
+use NextDom\Enums\LogTarget;
+use NextDom\Enums\NextDomObj;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\LogHelper;
 use NextDom\Helpers\NextDomHelper;
@@ -56,28 +62,6 @@ class InteractQueryManager
     const DB_CLASS_NAME = '`interactQuery`';
 
     /**
-     * @param $_query
-     * @param null $_interactDef_id
-     * @return array|mixed|null
-     * @throws \NextDom\Exceptions\CoreException
-     * @throws \ReflectionException
-     */
-    public static function byQuery($_query, $_interactDef_id = null)
-    {
-        $values = array(
-            'query' => $_query,
-        );
-        $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
-                FROM ' . self::DB_CLASS_NAME . '
-                WHERE query=:query';
-        if ($_interactDef_id !== null) {
-            $values['interactDef_id'] = $_interactDef_id;
-            $sql .= ' AND interactDef_id=:interactDef_id';
-        }
-        return DBHelper::getOneObject($sql, $values, self::CLASS_NAME);
-    }
-
-    /**
      * @param $_interactDef_id
      * @return array|mixed|null
      * @throws \NextDom\Exceptions\CoreException
@@ -85,9 +69,9 @@ class InteractQueryManager
      */
     public static function byInteractDefId($_interactDef_id)
     {
-        $values = array(
+        $values = [
             'interactDef_id' => $_interactDef_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE interactDef_id=:interactDef_id
@@ -103,16 +87,16 @@ class InteractQueryManager
     public static function searchActions($_action)
     {
         if (!is_array($_action)) {
-            $values = array(
+            $values = [
                 'actions' => '%' . $_action . '%',
-            );
+            ];
             $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                     FROM ' . self::DB_CLASS_NAME . '
                     WHERE actions LIKE :actions';
         } else {
-            $values = array(
+            $values = [
                 'actions' => '%' . $_action[0] . '%',
-            );
+            ];
             $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                     FROM ' . self::DB_CLASS_NAME . '
                     WHERE actions LIKE :actions';
@@ -131,9 +115,9 @@ class InteractQueryManager
      */
     public static function removeByInteractDefId($_interactDef_id)
     {
-        $values = array(
+        $values = [
             'interactDef_id' => $_interactDef_id,
-        );
+        ];
         $sql = 'DELETE FROM ' . self::DB_CLASS_NAME . '
                 WHERE interactDef_id = :interactDef_id';
         return DBHelper::getAllObjects($sql, $values, self::CLASS_NAME);
@@ -156,7 +140,7 @@ class InteractQueryManager
      */
     public static function warnMeExecute($_options)
     {
-        $warnMeCmd = (isset($_options['reply_cmd'])) ? $_options['reply_cmd'] : ConfigManager::byKey('interact::warnme::defaultreturncmd');
+        $warnMeCmd = (isset($_options[Common::REPLY_CMD])) ? $_options[Common::REPLY_CMD] : ConfigManager::byKey('interact::warnme::defaultreturncmd');
         if (!isset($_options['test']) || $_options['test'] == '' || $warnMeCmd == '') {
             ListenerManager::byId($_options['listener_id'])->remove();
             return;
@@ -168,10 +152,10 @@ class InteractQueryManager
             if (!is_object($cmd)) {
                 return;
             }
-            $cmd->execCmd(array(
+            $cmd->execCmd([
                 'title' => __('Alerte : ') . str_replace('#value#', $_options['name'], $_options['test']) . __(' valeur : ') . $_options['value'],
                 'message' => __('Alerte : ') . str_replace('#value#', $_options['name'], $_options['test']) . __(' valeur : ') . $_options['value'],
-            ));
+            ]);
         }
     }
 
@@ -182,10 +166,10 @@ class InteractQueryManager
      * @throws \NextDom\Exceptions\CoreException
      * @throws \ReflectionException
      */
-    public static function tryToReply($_query, $_parameters = array())
+    public static function tryToReply($_query, $_parameters = [])
     {
         if (trim($_query) == '') {
-            return array('reply' => '');
+            return ['reply' => ''];
         }
         $_parameters['identifier'] = '';
         if (isset($_parameters['plugin'])) {
@@ -193,28 +177,28 @@ class InteractQueryManager
         } else {
             $_parameters['identifier'] = 'unknown';
         }
-        if (isset($_parameters['profile'])) {
-            $_parameters['identifier'] .= '::' . $_parameters['profile'];
+        if (isset($_parameters[Common::PROFILE])) {
+            $_parameters['identifier'] .= '::' . $_parameters[Common::PROFILE];
         }
         $_parameters['dictation'] = $_query;
-        if (isset($_parameters['profile'])) {
-            $_parameters['profile'] = strtolower($_parameters['profile']);
+        if (isset($_parameters[Common::PROFILE])) {
+            $_parameters[Common::PROFILE] = strtolower($_parameters[Common::PROFILE]);
         }
         $reply = '';
         $words = str_word_count($_query, 1);
         $startContextual = explode(';', ConfigManager::byKey('interact::contextual::startpriority'));
         if (is_array($startContextual) && count($startContextual) > 0 && ConfigManager::byKey('interact::contextual::enable') == 1 && isset($words[0]) && in_array(strtolower($words[0]), $startContextual)) {
             $reply = self::contextualReply($_query, $_parameters);
-            LogHelper::add('interact', 'debug', 'Je cherche interaction contextuel (prioritaire) : ' . print_r($reply, true));
+            LogHelper::addDebug(LogTarget::INTERACT, 'Je cherche interaction contextuel (prioritaire) : ' . print_r($reply, true));
         }
         $startWarnMe = explode(';', ConfigManager::byKey('interact::warnme::start'));
         if (is_array($startWarnMe) && count($startWarnMe) > 0 && ConfigManager::byKey('interact::warnme::enable') == 1 && Utils::strContainsOneOf(strtolower(Utils::sanitizeAccent($_query)), $startWarnMe)) {
             $reply = self::warnMe($_query, $_parameters);
-            LogHelper::add('interact', 'debug', 'Je cherche interaction "previens-moi" : ' . print_r($reply, true));
+            LogHelper::addDebug(LogTarget::INTERACT, 'Je cherche interaction "previens-moi" : ' . print_r($reply, true));
         }
         if (ConfigManager::byKey('interact::contextual::splitword') != '') {
             $splitWords = explode(';', ConfigManager::byKey('interact::contextual::splitword'));
-            $queries = array();
+            $queries = [];
             foreach ($splitWords as $split) {
                 if (in_array($split, $words)) {
                     $queries = array_merge($queries, explode(' ' . $split . ' ', $_query));
@@ -232,10 +216,8 @@ class InteractQueryManager
                                     $reply[$key] = $value;
                                     continue;
                                 }
-                                if (is_string($value)) {
-                                    if ($reply[$key] != $value) {
-                                        $reply[$key] .= "\n" . $value;
-                                    }
+                                if (is_string($value) && $reply[$key] != $value) {
+                                    $reply[$key] .= "\n" . $value;
                                 }
                                 if (is_array($value)) {
                                     $reply[$key] = array_merge($reply[$key], $value);
@@ -252,34 +234,34 @@ class InteractQueryManager
         if ($reply == '') {
             $reply = self::pluginReply($_query, $_parameters);
             if ($reply !== null) {
-                LogHelper::add('interact', 'info', 'J\'ai reçu : ' . $_query . '. Un plugin a répondu : ' . print_r($reply, true));
+                LogHelper::addInfo(LogTarget::INTERACT, 'J\'ai reçu : ' . $_query . '. Un plugin a répondu : ' . print_r($reply, true));
                 return $reply;
             }
             $interactQuery = self::recognize($_query);
             if (is_object($interactQuery)) {
                 $reply = $interactQuery->executeAndReply($_parameters);
-                $cmds = $interactQuery->getActions('cmd');
-                if (isset($cmds[0]) && isset($cmds[0]['cmd'])) {
-                    self::addLastInteract(str_replace('#', '', $cmds[0]['cmd']), $_parameters['identifier']);
+                $cmds = $interactQuery->getActions(NextDomObj::CMD);
+                if (isset($cmds[0]) && isset($cmds[0][NextDomObj::CMD])) {
+                    self::addLastInteract(str_replace('#', '', $cmds[0][NextDomObj::CMD]), $_parameters['identifier']);
                 }
-                LogHelper::add('interact', 'info', 'J\'ai reçu : ' . $_query . ". J'ai compris : " . $interactQuery->getQuery() . ". J'ai répondu : " . $reply);
-                return array('reply' => ucfirst($reply));
+                LogHelper::addInfo(LogTarget::INTERACT, 'J\'ai reçu : ' . $_query . ". J'ai compris : " . $interactQuery->getQuery() . ". J'ai répondu : " . $reply);
+                return ['reply' => ucfirst($reply)];
             }
         }
         if ($reply == '' && ConfigManager::byKey('interact::autoreply::enable') == 1) {
             $reply = self::autoInteract($_query, $_parameters);
-            LogHelper::add('interact', 'debug', 'Je cherche dans les interactions automatiques, résultat : ' . $reply);
+            LogHelper::addDebug(LogTarget::INTERACT, 'Je cherche dans les interactions automatiques, résultat : ' . $reply);
         }
         if ($reply == '' && ConfigManager::byKey('interact::noResponseIfEmpty', 'core', 0) == 0 && (!isset($_parameters['emptyReply']) || $_parameters['emptyReply'] == 0)) {
             $reply = self::dontUnderstand($_parameters);
-            LogHelper::add('interact', 'info', 'J\'ai reçu : ' . $_query . ". Je n'ai rien compris. J'ai répondu : " . $reply);
+            LogHelper::addInfo(LogTarget::INTERACT, 'J\'ai reçu : ' . $_query . ". Je n'ai rien compris. J'ai répondu : " . $reply);
         }
         if (!is_array($reply)) {
-            $reply = array('reply' => ucfirst($reply));
+            $reply = ['reply' => ucfirst($reply)];
         }
-        LogHelper::add('interact', 'info', 'J\'ai reçu : ' . $_query . ". Je réponds : " . print_r($reply, true));
-        if (isset($_parameters['reply_cmd']) && is_object($_parameters['reply_cmd']) && isset($_parameters['force_reply_cmd'])) {
-            $_parameters['reply_cmd']->execCmd(array('message' => $reply['reply']));
+        LogHelper::addInfo(LogTarget::INTERACT, 'J\'ai reçu : ' . $_query . ". Je réponds : " . print_r($reply, true));
+        if (isset($_parameters[Common::REPLY_CMD]) && is_object($_parameters[Common::REPLY_CMD]) && isset($_parameters['force_reply_cmd'])) {
+            $_parameters[Common::REPLY_CMD]->execCmd(['message' => $reply['reply']]);
             return true;
         }
         return $reply;
@@ -292,7 +274,7 @@ class InteractQueryManager
      * @return array|null|string
      * @throws \Exception
      */
-    public static function contextualReply($_query, $_parameters = array(), $_lastCmd = null)
+    public static function contextualReply($_query, $_parameters = [], $_lastCmd = null)
     {
         $return = '';
         if (!isset($_parameters['identifier'])) {
@@ -307,38 +289,38 @@ class InteractQueryManager
         } else {
             $lastCmd = $_lastCmd;
         }
-        $current = array();
-        $current['cmd'] = CmdManager::byId($lastCmd);
-        if (is_object($current['cmd'])) {
-            $current['eqLogic'] = $current['cmd']->getEqLogicId();
-            if (!is_object($current['eqLogic'])) {
+        $current = [];
+        $current[NextDomObj::CMD] = CmdManager::byId($lastCmd);
+        if (is_object($current[NextDomObj::CMD])) {
+            $current[NextDomObj::EQLOGIC] = $current[NextDomObj::CMD]->getEqLogicId();
+            if (!is_object($current[NextDomObj::EQLOGIC])) {
                 return $return;
             }
-            $current['object'] = $current['eqLogic']->getObject();
-            $humanName = $current['cmd']->getHumanName();
+            $current[NextDomObj::OBJECT] = $current[NextDomObj::EQLOGIC]->getObject();
+            $humanName = $current[NextDomObj::CMD]->getHumanName();
         } else {
             $humanName = strtolower(Utils::sanitizeAccent($lastCmd));
-            $current = self::findInQuery('object', $humanName);
-            $current = array_merge($current, self::findInQuery('summary', $current['query'], $current));
+            $current = self::findInQuery(NextDomObj::OBJECT, $humanName);
+            $current = array_merge($current, self::findInQuery(Common::SUMMARY, $current[Common::QUERY], $current));
         }
 
-        $data = self::findInQuery('object', $_query);
-        $data = array_merge($data, self::findInQuery('eqLogic', $data['query'], $data));
-        $data = array_merge($data, self::findInQuery('cmd', $data['query'], $data));
-        if (isset($data['object']) && is_object($current['object'])) {
-            $humanName = self::replaceForContextual($current['object']->getName(), $data['object']->getName(), $humanName);
+        $data = self::findInQuery(NextDomObj::OBJECT, $_query);
+        $data = array_merge($data, self::findInQuery(NextDomObj::EQLOGIC, $data[Common::QUERY], $data));
+        $data = array_merge($data, self::findInQuery(NextDomObj::CMD, $data[Common::QUERY], $data));
+        if (isset($data[NextDomObj::OBJECT]) && is_object($current[NextDomObj::OBJECT])) {
+            $humanName = self::replaceForContextual($current[NextDomObj::OBJECT]->getName(), $data[NextDomObj::OBJECT]->getName(), $humanName);
         }
-        if (isset($data['cmd']) && is_object($current['cmd'])) {
-            $humanName = self::replaceForContextual($current['cmd']->getName(), $data['cmd']->getName(), $humanName);
+        if (isset($data[NextDomObj::CMD]) && is_object($current[NextDomObj::CMD])) {
+            $humanName = self::replaceForContextual($current[NextDomObj::CMD]->getName(), $data[NextDomObj::CMD]->getName(), $humanName);
         }
-        if (isset($data['eqLogic']) && is_object($current['eqLogic'])) {
-            $humanName = self::replaceForContextual($current['eqLogic']->getName(), $data['eqLogic']->getName(), $humanName);
+        if (isset($data[NextDomObj::EQLOGIC]) && is_object($current[NextDomObj::EQLOGIC])) {
+            $humanName = self::replaceForContextual($current[NextDomObj::EQLOGIC]->getName(), $data[NextDomObj::EQLOGIC]->getName(), $humanName);
         }
         $reply = self::pluginReply($humanName, $_parameters);
         if ($reply !== null) {
             return $reply;
         }
-        $return = self::autoInteract(str_replace(array('][', '[', ']'), array(' ', '', ''), $humanName), $_parameters);
+        $return = self::autoInteract(str_replace(['][', '[', ']'], [' ', '', ''], $humanName), $_parameters);
         if ($return == '' && $_lastCmd === null) {
             $last = CacheManager::byKey('interact::lastCmd2::' . $_parameters['identifier']);
             if ($last->getValue() != '') {
@@ -357,24 +339,24 @@ class InteractQueryManager
      */
     public static function findInQuery($_type, $_query, $_data = null)
     {
-        $return = array();
-        $return['query'] = strtolower(Utils::sanitizeAccent($_query));
+        $return = [];
+        $return[Common::QUERY] = strtolower(Utils::sanitizeAccent($_query));
         $return[$_type] = null;
-        $synonyms = self::getQuerySynonym($return['query'], $_type);
-        if ($_type == 'object') {
+        $synonyms = self::getQuerySynonym($return[Common::QUERY], $_type);
+        if ($_type == NextDomObj::OBJECT) {
             $jeeObjects = JeeObjectManager::all();
-        } elseif ($_type == 'eqLogic') {
-            if ($_data !== null && is_object($_data['object'])) {
-                $jeeObjects = $_data['object']->getEqLogic();
+        } elseif ($_type == NextDomObj::EQLOGIC) {
+            if ($_data !== null && is_object($_data[NextDomObj::OBJECT])) {
+                $jeeObjects = $_data[NextDomObj::OBJECT]->getEqLogic();
             } else {
                 $jeeObjects = EqLogicManager::all(true);
             }
-        } elseif ($_type == 'cmd') {
-            if ($_data !== null && is_object($_data['eqLogic'])) {
-                $jeeObjects = $_data['eqLogic']->getCmd();
-            } elseif ($_data !== null && is_object($_data['object'])) {
-                $jeeObjects = array();
-                foreach ($_data['object']->getEqLogic() as $eqLogic) {
+        } elseif ($_type == NextDomObj::CMD) {
+            if ($_data !== null && is_object($_data[NextDomObj::EQLOGIC])) {
+                $jeeObjects = $_data[NextDomObj::EQLOGIC]->getCmd();
+            } elseif ($_data !== null && is_object($_data[NextDomObj::OBJECT])) {
+                $jeeObjects = [];
+                foreach ($_data[NextDomObj::OBJECT]->getEqLogic() as $eqLogic) {
                     if ($eqLogic->getIsEnable() == 0) {
                         continue;
                     }
@@ -385,26 +367,26 @@ class InteractQueryManager
             } else {
                 $jeeObjects = CmdManager::all();
             }
-        } elseif ($_type == 'summary') {
-            foreach (ConfigManager::byKey('object:summary') as $key => $value) {
-                if (count($synonyms) > 0 && in_array(strtolower($value['name']), $synonyms)) {
-                    $return[$_type] = $value;
+        } elseif ($_type == Common::SUMMARY) {
+            foreach (ConfigManager::byKey(ConfigKey::OBJECT_SUMMARY) as $summary) {
+                if (count($synonyms) > 0 && in_array(strtolower($summary['name']), $synonyms)) {
+                    $return[$_type] = $summary;
                     break;
                 }
-                if (self::autoInteractWordFind($return['query'], $value['name'])) {
-                    $return[$_type] = $value;
-                    $return['query'] = str_replace(strtolower(Utils::sanitizeAccent($value['name'])), '', $return['query']);
+                if (self::autoInteractWordFind($return[Common::QUERY], $summary['name'])) {
+                    $return[$_type] = $summary;
+                    $return[Common::QUERY] = str_replace(strtolower(Utils::sanitizeAccent($summary['name'])), '', $return[Common::QUERY]);
                     break;
                 }
             }
             if (count($synonyms) > 0) {
-                foreach ($synonyms as $value) {
-                    $return['query'] = str_replace(strtolower(Utils::sanitizeAccent($value)), '', $return['query']);
+                foreach ($synonyms as $summary) {
+                    $return[Common::QUERY] = str_replace(strtolower(Utils::sanitizeAccent($summary)), '', $return[Common::QUERY]);
                 }
             }
             return $return;
         }
-        usort($jeeObjects, array("interactQuery", "cmp_objectName"));
+        usort($jeeObjects, ["interactQuery", "cmp_objectName"]);
         foreach ($jeeObjects as $jeeObject) {
             if ($jeeObject->getConfiguration('interact::auto::disable', 0) == 1) {
                 continue;
@@ -413,18 +395,16 @@ class InteractQueryManager
                 $return[$_type] = $jeeObject;
                 break;
             }
-            if (self::autoInteractWordFind($return['query'], $jeeObject->getName())) {
+            if (self::autoInteractWordFind($return[Common::QUERY], $jeeObject->getName())) {
                 $return[$_type] = $jeeObject;
                 break;
             }
         }
-        if ($_type != 'eqLogic') {
-            if (is_object($return[$_type])) {
-                $return['query'] = str_replace(strtolower(Utils::sanitizeAccent($return[$_type]->getName())), '', $return['query']);
-                if (count($synonyms) > 0) {
-                    foreach ($synonyms as $value) {
-                        $return['query'] = str_replace(strtolower(Utils::sanitizeAccent($value)), '', $return['query']);
-                    }
+        if ($_type != NextDomObj::EQLOGIC && is_object($return[$_type])) {
+            $return[Common::QUERY] = str_replace(strtolower(Utils::sanitizeAccent($return[$_type]->getName())), '', $return[Common::QUERY]);
+            if (count($synonyms) > 0) {
+                foreach ($synonyms as $summary) {
+                    $return[Common::QUERY] = str_replace(strtolower(Utils::sanitizeAccent($summary)), '', $return[Common::QUERY]);
                 }
             }
         }
@@ -439,7 +419,7 @@ class InteractQueryManager
      */
     public static function getQuerySynonym($_query, $_for)
     {
-        $return = array();
+        $return = [];
         $base_synonyms = explode(';', ConfigManager::byKey('interact::autoreply::' . $_for . '::synonym'));
         if (count($base_synonyms) == 0) {
             return $return;
@@ -488,26 +468,26 @@ class InteractQueryManager
      * @return array|null
      * @throws \Exception
      */
-    public static function pluginReply($_query, $_parameters = array())
+    public static function pluginReply($_query, $_parameters = [])
     {
         try {
             foreach (PluginManager::listPlugin(true) as $plugin) {
                 if (ConfigManager::byKey('functionality::interact::enable', $plugin->getId(), 1) == 0) {
                     continue;
                 }
-                if (method_exists($plugin->getId(), 'interact')) {
+                if (method_exists($plugin->getId(), NextDomObj::INTERACT)) {
                     $plugin_id = $plugin->getId();
                     $reply = $plugin_id::interact($_query, $_parameters);
                     if ($reply !== null || is_array($reply)) {
                         $reply['reply'] = '[' . $plugin_id . '] ' . $reply['reply'];
                         self::addLastInteract($_query, $_parameters['identifier']);
-                        LogHelper::add('interact', 'debug', 'Le plugin ' . $plugin_id . ' a répondu');
+                        LogHelper::addDebug(LogTarget::INTERACT, 'Le plugin ' . $plugin_id . ' a répondu');
                         return $reply;
                     }
                 }
             }
         } catch (\Exception $e) {
-            return array('reply' => __('Erreur : ') . $e->getMessage());
+            return ['reply' => __('Erreur : ') . $e->getMessage()];
         }
         return null;
     }
@@ -532,87 +512,86 @@ class InteractQueryManager
      * @return string
      * @throws \Exception
      */
-    public static function autoInteract($_query, $_parameters = array())
+    public static function autoInteract($_query, $_parameters = [])
     {
-        global $NEXTDOM_INTERNAL_CONFIG;
         if (!isset($_parameters['identifier'])) {
             $_parameters['identifier'] = '';
         }
-        $data = self::findInQuery('object', $_query);
-        $data['cmd_parameters'] = array();
+        $data = self::findInQuery(NextDomObj::OBJECT, $_query);
+        $data[Common::CMD_PARAMETERS] = [];
         /** @var EqLogic[] $data */
-        $data = array_merge($data, self::findInQuery('eqLogic', $data['query'], $data));
-        $data = array_merge($data, self::findInQuery('cmd', $data['query'], $data));
-        if (isset($data['eqLogic']) && is_object($data['eqLogic']) && (!isset($data['cmd']) || !is_object($data['cmd']))) {
-            foreach ($data['eqLogic']->getCmd('action') as $cmd) {
-                if ($cmd->getSubtype() == 'slider') {
+        $data = array_merge($data, self::findInQuery(NextDomObj::EQLOGIC, $data[Common::QUERY], $data));
+        $data = array_merge($data, self::findInQuery(NextDomObj::CMD, $data[Common::QUERY], $data));
+        if (isset($data[NextDomObj::EQLOGIC]) && is_object($data[NextDomObj::EQLOGIC]) && (!isset($data[NextDomObj::CMD]) || !is_object($data[NextDomObj::CMD]))) {
+            foreach ($data[NextDomObj::EQLOGIC]->getCmd(CmdType::ACTION) as $cmd) {
+                if ($cmd->isSubType(CmdSubType::SLIDER)) {
                     break;
                 }
             }
             if (is_object($cmd)) {
-                if (preg_match_all('/' . ConfigManager::byKey('interact::autoreply::cmd::slider::max') . '/i', $data['query'])) {
-                    $data['cmd'] = $cmd;
-                    $data['cmd_parameters']['slider'] = $cmd->getConfiguration('maxValue', 100);
+                if (preg_match_all('/' . ConfigManager::byKey('interact::autoreply::cmd::slider::max') . '/i', $data[Common::QUERY])) {
+                    $data[NextDomObj::CMD] = $cmd;
+                    $data[Common::CMD_PARAMETERS][CmdSubType::SLIDER] = $cmd->getConfiguration('maxValue', 100);
                 }
-                if (preg_match_all('/' . ConfigManager::byKey('interact::autoreply::cmd::slider::min') . '/i', $data['query'])) {
-                    $data['cmd'] = $cmd;
-                    $data['cmd_parameters']['slider'] = $cmd->getConfiguration('minValue', 0);
+                if (preg_match_all('/' . ConfigManager::byKey('interact::autoreply::cmd::slider::min') . '/i', $data[Common::QUERY])) {
+                    $data[NextDomObj::CMD] = $cmd;
+                    $data[Common::CMD_PARAMETERS][CmdSubType::SLIDER] = $cmd->getConfiguration('minValue', 0);
                 }
             }
         }
-        if (!isset($data['cmd']) || !is_object($data['cmd'])) {
-            $data = array_merge($data, self::findInQuery('summary', $data['query'], $data));
-            LogHelper::add('interact', 'debug', print_r($data, true));
-            if (!isset($data['summary'])) {
+        if (!isset($data[NextDomObj::CMD]) || !is_object($data[NextDomObj::CMD])) {
+            $data = array_merge($data, self::findInQuery(Common::SUMMARY, $data[Common::QUERY], $data));
+            LogHelper::addDebug(LogTarget::INTERACT, print_r($data, true));
+            if (!isset($data[Common::SUMMARY])) {
                 return '';
             }
-            $return = $data['summary']['name'];
+            $return = $data[Common::SUMMARY][Common::NAME];
             $value = '';
-            if (is_object($data['object'])) {
-                $return .= ' ' . $data['object']->getName();
-                $value = $data['object']->getSummary($data['summary']['key']);
+            if (is_object($data[NextDomObj::OBJECT])) {
+                $return .= ' ' . $data[NextDomObj::OBJECT]->getName();
+                $value = $data[NextDomObj::OBJECT]->getSummary($data[Common::SUMMARY][Common::KEY]);
             }
             if (trim($value) === '') {
-                $value = JeeObjectManager::getGlobalSummary($data['summary']['key']);
+                $value = JeeObjectManager::getGlobalSummary($data[Common::SUMMARY][Common::KEY]);
             }
             if (trim($value) === '') {
                 return '';
             }
             self::addLastInteract($_query, $_parameters['identifier']);
-            return $return . ' ' . $value . ' ' . $data['summary']['unit'];
+            return $return . ' ' . $value . ' ' . $data[Common::SUMMARY]['unit'];
         }
-        self::addLastInteract($data['cmd']->getId(), $_parameters['identifier']);
-        if ($data['cmd']->getType() == 'info') {
-            return trim($data['cmd']->getHumanName() . ' ' . $data['cmd']->execCmd() . ' ' . $data['cmd']->getUnite());
+        self::addLastInteract($data[NextDomObj::CMD]->getId(), $_parameters['identifier']);
+        if ($data[NextDomObj::CMD]->isType(CmdType::INFO)) {
+            return trim($data[NextDomObj::CMD]->getHumanName() . ' ' . $data[NextDomObj::CMD]->execCmd() . ' ' . $data[NextDomObj::CMD]->getUnite());
         } else {
-            if ($data['cmd']->getSubtype() == 'slider') {
-                preg_match_all('/(\d+)/', strtolower(Utils::sanitizeAccent($data['query'])), $matches);
+            if ($data[NextDomObj::CMD]->getSubtype() == CmdSubType::SLIDER) {
+                preg_match_all('/(\d+)/', strtolower(Utils::sanitizeAccent($data[Common::QUERY])), $matches);
                 if (isset($matches[0]) && isset($matches[0][0])) {
-                    $data['cmd_parameters']['slider'] = $matches[0][0];
+                    $data[Common::CMD_PARAMETERS][CmdSubType::SLIDER] = $matches[0][0];
                 }
             }
-            if ($data['cmd']->getSubtype() == 'color') {
+            if ($data[NextDomObj::CMD]->getSubtype() == CmdSubType::COLOR) {
                 $colors = array_change_key_case(ConfigManager::byKey('convertColor'));
                 foreach ($colors as $name => $value) {
-                    if (strpos($data['query'], $name) !== false) {
-                        $data['cmd_parameters']['color'] = $value;
+                    if (strpos($data[Common::QUERY], $name) !== false) {
+                        $data[Common::CMD_PARAMETERS]['color'] = $value;
                         break;
                     }
                 }
             }
-            $data['cmd']->execCmd($data['cmd_parameters']);
+            $data[NextDomObj::CMD]->execCmd($data[Common::CMD_PARAMETERS]);
             $return = __('C\'est fait') . ' (';
-            $eqLogic = $data['cmd']->getEqLogic();
+            $eqLogic = $data[NextDomObj::CMD]->getEqLogic();
             if (is_object($eqLogic)) {
                 $linkedObject = $eqLogic->getObject();
                 if (is_object($linkedObject)) {
                     $return .= $linkedObject->getName();
                 }
-                $return .= ' ' . $data['cmd']->getEqLogic()->getName();
+                $return .= ' ' . $data[NextDomObj::CMD]->getEqLogic()->getName();
             }
-            $return .= ' ' . $data['cmd']->getName();
-            if (isset($data['cmd_parameters']['slider'])) {
-                $return .= ' => ' . $data['cmd_parameters']['slider'] . '%';
+            $return .= ' ' . $data[NextDomObj::CMD]->getName();
+            if (isset($data[Common::CMD_PARAMETERS][CmdSubType::SLIDER])) {
+                $return .= ' => ' . $data[Common::CMD_PARAMETERS][CmdSubType::SLIDER] . '%';
             }
             return $return . ')';
         }
@@ -625,12 +604,12 @@ class InteractQueryManager
      * @throws \NextDom\Exceptions\CoreException
      * @throws \ReflectionException
      */
-    public static function warnMe($_query, $_parameters = array())
+    public static function warnMe($_query, $_parameters = [])
     {
         global $NEXTDOM_INTERNAL_CONFIG;
         $operator = null;
         $operand = null;
-        foreach ($NEXTDOM_INTERNAL_CONFIG['interact']['test'] as $key => $value) {
+        foreach ($NEXTDOM_INTERNAL_CONFIG[NextDomObj::INTERACT]['test'] as $key => $value) {
             if (Utils::strContainsOneOf(strtolower(Utils::sanitizeAccent($_query)), $value)) {
                 $operator .= $key;
                 break;
@@ -644,29 +623,29 @@ class InteractQueryManager
             return null;
         }
         $test = '#value# ' . $operator . ' ' . $operand;
-        $options = array('test' => $test);
-        if (is_object($_parameters['reply_cmd'])) {
-            $options['reply_cmd'] = $_parameters['reply_cmd']->getId();
+        $options = ['test' => $test];
+        if (is_object($_parameters[Common::REPLY_CMD])) {
+            $options[Common::REPLY_CMD] = $_parameters[Common::REPLY_CMD]->getId();
         }
         $listener = new Listener();
-        $listener->setClass('interactQuery');
+        $listener->setClass(NextDomObj::INTERACT_QUERY);
         $listener->setFunction('warnMeExecute');
-        $data = self::findInQuery('object', $_query);
-        $data = array_merge($data, self::findInQuery('eqLogic', $data['query'], $data));
-        $data = array_merge($data, self::findInQuery('cmd', $data['query'], $data));
-        if (!isset($data['cmd']) || !is_object($data['cmd'])) {
+        $data = self::findInQuery(NextDomObj::OBJECT, $_query);
+        $data = array_merge($data, self::findInQuery(NextDomObj::EQLOGIC, $data[Common::QUERY], $data));
+        $data = array_merge($data, self::findInQuery(NextDomObj::CMD, $data[Common::QUERY], $data));
+        if (!isset($data[NextDomObj::CMD]) || !is_object($data[NextDomObj::CMD])) {
             return null;
         } else {
-            if ($data['cmd']->getType() == 'action') {
+            if ($data[NextDomObj::CMD]->isType(CmdType::ACTION)) {
                 return null;
             }
-            $options['type'] = 'cmd';
-            $options['cmd_id'] = $data['cmd']->getId();
-            $options['name'] = $data['cmd']->getHumanName();
-            $listener->addEvent($data['cmd']->getId());
+            $options['type'] = NextDomObj::CMD;
+            $options['cmd_id'] = $data[NextDomObj::CMD]->getId();
+            $options['name'] = $data[NextDomObj::CMD]->getHumanName();
+            $listener->addEvent($data[NextDomObj::CMD]->getId());
             $listener->setOption($options);
             $listener->save(true);
-            return array('reply' => __('C\'est noté : ') . str_replace('#value#', $data['cmd']->getHumanName(), $test));
+            return ['reply' => __('C\'est noté : ') . str_replace('#value#', $data[NextDomObj::CMD]->getHumanName(), $test)];
         }
     }
 
@@ -682,40 +661,27 @@ class InteractQueryManager
         if (trim($_query) == '') {
             return null;
         }
-        $values = array(
-            'query' => $_query,
-        );
-        $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
-                FROM ' . self::DB_CLASS_NAME . '
-                WHERE LOWER(query)=LOWER(:query)';
-        $query = DBHelper::getOneObject($sql, $values, self::CLASS_NAME);
+        $query = self::byQuery($_query, null, false);
         if (is_object($query)) {
-            $interactDef = $query->getInteractDef();
-            if ($interactDef->getOptions('mustcontain') != '' && !preg_match($interactDef->getOptions('mustcontain'), $_query)) {
-                LogHelper::add('interact', 'debug', __('Correspondance trouvée : ') . $query->getQuery() . __(' mais ne contient pas : ') . InteractDefManager::sanitizeQuery($interactDef->getOptions('mustcontain')));
-                return null;
+            if (self::searchCorrespondence($_query, $query)) {
+                LogHelper::addDebug(LogTarget::INTERACT, 'Je prends : ' . $query->getQuery());
+                return $query;
             }
-            LogHelper::add('interact', 'debug', 'Je prends : ' . $query->getQuery());
-            return $query;
+            return null;
         }
 
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . ', MATCH query AGAINST (:query IN NATURAL LANGUAGE MODE) as score
                 FROM ' . self::DB_CLASS_NAME . '
                 GROUP BY id
                 HAVING score > 1';
-        $queries = DBHelper::getAllObjects($sql, $values, self::CLASS_NAME);
+        $queries = DBHelper::getAllObjects($sql, [Common::QUERY => $_query], self::CLASS_NAME);
         if (count($queries) == 0) {
-            $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
-                    FROM ' . self::DB_CLASS_NAME . '
-                    WHERE query=:query';
-            $query = DBHelper::getOneObject($sql, $values, self::CLASS_NAME);
+            $query = self::byQuery($_query);
             if (is_object($query)) {
-                $interactDef = $query->getInteractDef();
-                if ($interactDef->getOptions('mustcontain') != '' && !preg_match($interactDef->getOptions('mustcontain'), $_query)) {
-                    LogHelper::add('interact', 'debug', __('Correspondance trouvée : ') . $query->getQuery() . __(' mais ne contient pas : ') . InteractDefManager::sanitizeQuery($interactDef->getOptions('mustcontain')));
-                    return null;
+                if (self::searchCorrespondence($_query, $query)) {
+                    return $queries;
                 }
-                return $queries;
+                return null;
             }
             $queries = self::all();
         }
@@ -732,7 +698,7 @@ class InteractQueryManager
                 $input = str_replace(array_keys($tags), $tags, $input);
             }
             $lev = levenshtein($input, $_query);
-            LogHelper::add('interact', 'debug', 'Je compare : ' . $_query . ' avec ' . $input . ' => ' . $lev);
+            LogHelper::addDebug(LogTarget::INTERACT, 'Je compare : ' . $_query . ' avec ' . $input . ' => ' . $lev);
             if (trim($_query) == trim($input)) {
                 $shortest = 0;
                 $closest = $query;
@@ -749,14 +715,14 @@ class InteractQueryManager
             }
         }
         if ($shortest < 0) {
-            LogHelper::add('interact', 'debug', __('Aucune correspondance trouvée'));
+            LogHelper::addDebug(LogTarget::INTERACT, __('Aucune correspondance trouvée'));
             return null;
         }
-        $weigh = array(
+        $weigh = [
             1 => ConfigManager::byKey('interact::weigh1'),
             2 => ConfigManager::byKey('interact::weigh2'),
             3 => ConfigManager::byKey('interact::weigh3'),
-            4 => ConfigManager::byKey('interact::weigh4'));
+            4 => ConfigManager::byKey('interact::weigh4')];
 
         foreach (str_word_count($_query, 1) as $word) {
             if (isset($weigh[strlen($word)])) {
@@ -765,29 +731,72 @@ class InteractQueryManager
             }
         }
         if (str_word_count($_query) == 1 && ConfigManager::byKey('interact::confidence1') > 0 && $shortest > ConfigManager::byKey('interact::confidence1')) {
-            LogHelper::add('interact', 'debug', __('Correspondance trop éloigné : ') . $shortest);
+            LogHelper::addDebug(LogTarget::INTERACT, __('Correspondance trop éloigné : ') . $shortest);
             return null;
         } else if (str_word_count($_query) == 2 && ConfigManager::byKey('interact::confidence2') > 0 && $shortest > ConfigManager::byKey('interact::confidence2')) {
-            LogHelper::add('interact', 'debug', __('Correspondance trop éloigné : ') . $shortest);
+            LogHelper::addDebug(LogTarget::INTERACT, __('Correspondance trop éloigné : ') . $shortest);
             return null;
         } else if (str_word_count($_query) == 3 && ConfigManager::byKey('interact::confidence3') > 0 && $shortest > ConfigManager::byKey('interact::confidence3')) {
-            LogHelper::add('interact', 'debug', __('Correspondance trop éloigné : ') . $shortest);
+            LogHelper::addDebug(LogTarget::INTERACT, __('Correspondance trop éloigné : ') . $shortest);
             return null;
         } else if (str_word_count($_query) > 3 && ConfigManager::byKey('interact::confidence') > 0 && $shortest > ConfigManager::byKey('interact::confidence')) {
-            LogHelper::add('interact', 'debug', __('Correspondance trop éloigné : ') . $shortest);
+            LogHelper::addDebug(LogTarget::INTERACT, __('Correspondance trop éloigné : ') . $shortest);
             return null;
         }
         if (!is_object($closest)) {
-            LogHelper::add('interact', 'debug', __('Aucune phrase trouvée'));
+            LogHelper::addDebug(LogTarget::INTERACT, __('Aucune phrase trouvée'));
             return null;
         }
         $interactDef = $closest->getInteractDef();
         if ($interactDef->getOptions('mustcontain') != '' && !preg_match($interactDef->getOptions('mustcontain'), $_query)) {
-            LogHelper::add('interact', 'debug', __('Correspondance trouvée : ') . $closest->getQuery() . __(' mais ne contient pas : ') . InteractDefManager::sanitizeQuery($interactDef->getOptions('mustcontain')));
+            LogHelper::addDebug(LogTarget::INTERACT, __('Correspondance trouvée : ') . $closest->getQuery() . __(' mais ne contient pas : ') . InteractDefManager::sanitizeQuery($interactDef->getOptions('mustcontain')));
             return null;
         }
-        LogHelper::add('interact', 'debug', __('J\'ai une correspondance  : ') . $closest->getQuery() . __(' avec ') . $shortest);
+        LogHelper::addDebug(LogTarget::INTERACT, __('J\'ai une correspondance  : ') . $closest->getQuery() . __(' avec ') . $shortest);
         return $closest;
+    }
+
+    /**
+     * @param $_query
+     * @param null $_interactDef_id
+     * @param bool $caseSensitive Set to false for insensitive case comparaison
+     * @return InteractQuery
+     * @throws \NextDom\Exceptions\CoreException
+     * @throws \ReflectionException
+     */
+    public static function byQuery($_query, $_interactDef_id = null, $caseSensitive = true)
+    {
+        $values = [
+            Common::QUERY => $_query,
+        ];
+        $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
+                FROM ' . self::DB_CLASS_NAME;
+        if ($caseSensitive) {
+            $sql .= ' WHERE query=:query';
+        } else {
+            $sql .= ' WHERE LOWER(query)=LOWER(:query)';
+        }
+        if ($_interactDef_id !== null) {
+            $values['interactDef_id'] = $_interactDef_id;
+            $sql .= ' AND interactDef_id=:interactDef_id';
+        }
+        return DBHelper::getOneObject($sql, $values, self::CLASS_NAME);
+    }
+
+    /**
+     * @param string $baseQuery
+     * @param InteractQuery $interactQuery
+     * @return bool
+     * @throws \Exception
+     */
+    private static function searchCorrespondence($baseQuery, $interactQuery)
+    {
+        $interactDef = $interactQuery->getInteractDef();
+        if ($interactDef->getOptions('mustcontain') != '' && !preg_match($interactDef->getOptions('mustcontain'), $baseQuery)) {
+            LogHelper::addDebug(LogTarget::INTERACT, __('Correspondance trouvée : ') . $interactQuery->getQuery() . __(' mais ne contient pas : ') . InteractDefManager::sanitizeQuery($interactDef->getOptions('mustcontain')));
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -809,15 +818,15 @@ class InteractQueryManager
      */
     public static function dontUnderstand($_parameters)
     {
-        $notUnderstood = array(
+        $notUnderstood = [
             __('Désolé je n\'ai pas compris'),
             __('Désolé je n\'ai pas compris la demande'),
             __('Désolé je ne comprends pas la demande'),
             __('Je ne comprends pas'),
-        );
-        if (isset($_parameters['profile'])) {
-            $notUnderstood[] = __('Désolé ') . $_parameters['profile'] . __(' je n\'ai pas compris');
-            $notUnderstood[] = __('Désolé ') . $_parameters['profile'] . __(' je n\'ai pas compris ta demande');
+        ];
+        if (isset($_parameters[Common::PROFILE])) {
+            $notUnderstood[] = __('Désolé ') . $_parameters[Common::PROFILE] . __(' je n\'ai pas compris');
+            $notUnderstood[] = __('Désolé ') . $_parameters[Common::PROFILE] . __(' je n\'ai pas compris ta demande');
         }
         $random = rand(0, count($notUnderstood) - 1);
         return $notUnderstood[$random];
@@ -832,8 +841,8 @@ class InteractQueryManager
     {
         global $PROFILE;
         $PROFILE = '';
-        if (isset($_parameters['profile'])) {
-            $PROFILE = $_parameters['profile'];
+        if (isset($_parameters[Common::PROFILE])) {
+            $PROFILE = $_parameters[Common::PROFILE];
         }
         require_once NEXTDOM_DATA . '/config/bot.config.php';
         global $BRAINREPLY;
@@ -863,12 +872,12 @@ class InteractQueryManager
      */
     public static function replyOk()
     {
-        $reply = array(
+        $reply = [
             __('C\'est fait'),
             __('Ok'),
             __('Voila, c\'est fait'),
             __('Bien compris'),
-        );
+        ];
         $random = rand(0, count($reply) - 1);
         return $reply[$random];
     }
@@ -896,9 +905,9 @@ class InteractQueryManager
      */
     public static function byId($_id)
     {
-        $values = array(
+        $values = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE id=:id';

--- a/src/Managers/JeeObjectManager.php
+++ b/src/Managers/JeeObjectManager.php
@@ -33,6 +33,12 @@
 
 namespace NextDom\Managers;
 
+use NextDom\Enums\CmdSubType;
+use NextDom\Enums\CmdType;
+use NextDom\Enums\Common;
+use NextDom\Enums\ConfigKey;
+use NextDom\Enums\NextDomObj;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Utils;
@@ -50,26 +56,6 @@ class JeeObjectManager
     const CLASS_NAME = JeeObject::class;
 
     /**
-     * Get an object by with his id.
-     *
-     * @param int $id Identifiant de l'objet
-     * @return JeeObject|null
-     *
-     * @throws \Exception
-     */
-    public static function byId($id)
-    {
-        if ($id == '' || $id == -1) {
-            return null;
-        }
-        $values = ['id' => $id];
-        $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
-                FROM ' . self::DB_CLASS_NAME . '
-                WHERE id = :id';
-        return DBHelper::getOneObject($sql, $values, self::CLASS_NAME);
-    }
-
-    /**
      * Get an object by with his name.
      *
      * @param string $name
@@ -78,9 +64,9 @@ class JeeObjectManager
      */
     public static function byName($name)
     {
-        $values = array(
+        $values = [
             'name' => $name,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE name=:name';
@@ -99,7 +85,7 @@ class JeeObjectManager
      */
     public static function buildTree($nodeObject = null, $visible = true)
     {
-        $result = array();
+        $result = [];
         if (!is_object($nodeObject)) {
             $objectsList = self::getRootObjects(true, $visible);
         } else {
@@ -112,18 +98,6 @@ class JeeObjectManager
             }
         }
         return $result;
-    }
-
-    public static function getDefaultUserRoom(User $user)
-    {
-        $rootRoomId = $user->getOptions('defaultDashboardObject');
-        if (empty($rootRoomId)) {
-            $defaultRoom = self::getRootObjects();
-        }
-        else {
-            $defaultRoom = self::byId($rootRoomId);
-        }
-        return $defaultRoom;
     }
 
     /**
@@ -153,6 +127,37 @@ class JeeObjectManager
         return DBHelper::Prepare($sql, [], $fetchType, \PDO::FETCH_CLASS, self::CLASS_NAME);
     }
 
+    public static function getDefaultUserRoom(User $user)
+    {
+        $rootRoomId = $user->getOptions('defaultDashboardObject');
+        if (empty($rootRoomId)) {
+            $defaultRoom = self::getRootObjects();
+        } else {
+            $defaultRoom = self::byId($rootRoomId);
+        }
+        return $defaultRoom;
+    }
+
+    /**
+     * Get an object by with his id.
+     *
+     * @param int $id Identifiant de l'objet
+     * @return JeeObject|null
+     *
+     * @throws \Exception
+     */
+    public static function byId($id)
+    {
+        if ($id == '' || $id == -1) {
+            return null;
+        }
+        $values = ['id' => $id];
+        $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
+                FROM ' . self::DB_CLASS_NAME . '
+                WHERE id = :id';
+        return DBHelper::getOneObject($sql, $values, self::CLASS_NAME);
+    }
+
     /**
      * TODO: ???
      *
@@ -166,23 +171,23 @@ class JeeObjectManager
      *
      * @throws \Exception
      */
-    public static function fullData($restrict = array())
+    public static function fullData($restrict = [])
     {
-        $result = array();
+        $result = [];
         foreach (self::all(true) as $jeeObject) {
-            if (!isset($restrict['object']) || !is_array($restrict['object']) || isset($restrict['object'][$jeeObject->getId()])) {
+            if (!isset($restrict[NextDomObj::OBJECT]) || !is_array($restrict[NextDomObj::OBJECT]) || isset($restrict[NextDomObj::OBJECT][$jeeObject->getId()])) {
                 $object_return = Utils::o2a($jeeObject);
-                $object_return['eqLogics'] = array();
+                $object_return['eqLogics'] = [];
                 $objectGetEqLogic = $jeeObject->getEqLogic(true, true);
                 foreach ($objectGetEqLogic as $eqLogic) {
-                    if (!isset($restrict['eqLogic']) || !is_array($restrict['eqLogic']) || isset($restrict['eqLogic'][$eqLogic->getId()])) {
+                    if (!isset($restrict[NextDomObj::EQLOGIC]) || !is_array($restrict[NextDomObj::EQLOGIC]) || isset($restrict[NextDomObj::EQLOGIC][$eqLogic->getId()])) {
                         $eqLogic_return = Utils::o2a($eqLogic);
                         $eqLogic_return['cmds'] = [];
                         $eqLogicGetCmd = $eqLogic->getCmd();
                         foreach ($eqLogicGetCmd as $cmd) {
-                            if (!isset($restrict['cmd']) || !is_array($restrict['cmd']) || isset($restrict['cmd'][$cmd->getId()])) {
+                            if (!isset($restrict[NextDomObj::CMD]) || !is_array($restrict[NextDomObj::CMD]) || isset($restrict[NextDomObj::CMD][$cmd->getId()])) {
                                 $cmd_return = Utils::o2a($cmd);
-                                if ($cmd->getType() == 'info') {
+                                if ($cmd->isType(CmdType::INFO)) {
                                     $cmd_return['state'] = $cmd->execCmd();
                                 }
                                 $eqLogic_return['cmds'][] = $cmd_return;
@@ -225,12 +230,12 @@ class JeeObjectManager
      */
     public static function deadCmd()
     {
-        $result = array();
+        $result = [];
         foreach (self::all() as $jeeObject) {
-            foreach ($jeeObject->getConfiguration('summary', []) as $key => $summary) {
+            foreach ($jeeObject->getConfiguration(Common::SUMMARY, []) as $key => $summary) {
                 foreach ($summary as $cmdInfo) {
                     if (!CmdManager::byId(str_replace('#', '', $cmdInfo['cmd']))) {
-                        $result[] = array('detail' => 'Résumé ' . $jeeObject->getName(), 'help' => ConfigManager::byKey('object:summary')[$key]['name'], 'who' => $cmdInfo['cmd']);
+                        $result[] = ['detail' => 'Résumé ' . $jeeObject->getName(), 'help' => ConfigManager::byKey(ConfigKey::OBJECT_SUMMARY)[$key]['name'], 'who' => $cmdInfo['cmd']];
                     }
                 }
             }
@@ -250,22 +255,22 @@ class JeeObjectManager
         if (count($jeeObjects) == 0) {
             return;
         }
-        $toRefreshCmd = array();
-        $global = array();
+        $toRefreshCmd = [];
+        $global = [];
         foreach ($jeeObjects as $jeeObject) {
-            $summaries = $jeeObject->getConfiguration('summary');
+            $summaries = $jeeObject->getConfiguration(Common::SUMMARY);
             if (!is_array($summaries)) {
                 continue;
             }
-            $event = array('object_id' => $jeeObject->getId(), 'keys' => array());
+            $event = [Common::OBJECT_ID => $jeeObject->getId(), Common::KEYS => []];
             foreach ($summaries as $key => $summary) {
                 foreach ($summary as $cmd_info) {
                     preg_match_all("/#([0-9]*)#/", $cmd_info['cmd'], $matches);
                     foreach ($matches[1] as $cmd_id) {
                         if ($cmd_id == $cmdId) {
                             $value = $jeeObject->getSummary($key);
-                            $event['keys'][$key] = array('value' => $value);
-                            $toRefreshCmd[] = array('key' => $key, 'object' => $jeeObject, 'value' => $value);
+                            $event['keys'][$key] = ['value' => $value];
+                            $toRefreshCmd[] = ['key' => $key, 'object' => $jeeObject, 'value' => $value];
                             if ($jeeObject->getConfiguration('summary::global::' . $key, 0) == 1) {
                                 $global[$key] = 1;
                             }
@@ -289,7 +294,7 @@ class JeeObjectManager
                         $jeeObject->save();
                         continue;
                     }
-                    $cmd = $virtual->getCmd('info', $value['key']);
+                    $cmd = $virtual->getCmd(CmdType::INFO, $value['key']);
                     if (!is_object($cmd)) {
                         continue;
                     }
@@ -302,19 +307,19 @@ class JeeObjectManager
         if (count($global) > 0) {
             CacheManager::set('globalSummaryHtmldesktop', '');
             CacheManager::set('globalSummaryHtmlmobile', '');
-            $event = array('object_id' => 'global', 'keys' => array());
+            $event = [Common::OBJECT_ID => 'global', Common::KEYS => []];
             foreach ($global as $key => $value) {
                 try {
                     $result = JeeObjectManager::getGlobalSummary($key);
                     if ($result === null) {
                         continue;
                     }
-                    $event['keys'][$key] = array('value' => $result);
+                    $event['keys'][$key] = ['value' => $result];
                     $virtual = EqLogicManager::byLogicalId('summaryglobal', 'virtual');
                     if (!is_object($virtual)) {
                         continue;
                     }
-                    $cmd = $virtual->getCmd('info', $key);
+                    $cmd = $virtual->getCmd(CmdType::INFO, $key);
                     if (!is_object($cmd)) {
                         continue;
                     }
@@ -338,9 +343,9 @@ class JeeObjectManager
      */
     public static function searchConfiguration(string $search)
     {
-        $values = array(
+        $values = [
             'configuration' => '%' . $search . '%',
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE `configuration` LIKE :configuration';
@@ -359,9 +364,9 @@ class JeeObjectManager
         if ($key == '') {
             return null;
         }
-        $def = ConfigManager::byKey('object:summary');
+        $def = ConfigManager::byKey(ConfigKey::OBJECT_SUMMARY);
         $jeeObjects = self::all();
-        $value = array();
+        $value = [];
         foreach ($jeeObjects as $jeeObject) {
             if ($jeeObject->getConfiguration('summary::global::' . $key, 0) == 0) {
                 continue;
@@ -397,8 +402,8 @@ class JeeObjectManager
             return $cache->getValue();
         }
         $jeeObjects = self::all();
-        $def = ConfigManager::byKey('object:summary');
-        $values = array();
+        $def = ConfigManager::byKey(ConfigKey::OBJECT_SUMMARY);
+        $values = [];
         $return = '<span class="objectSummaryglobal" data-version="' . $version . '">';
         foreach ($def as $key => $value) {
             foreach ($jeeObjects as $jeeObject) {
@@ -406,7 +411,7 @@ class JeeObjectManager
                     continue;
                 }
                 if (!isset($values[$key])) {
-                    $values[$key] = array();
+                    $values[$key] = [];
                 }
                 $result = $jeeObject->getSummary($key, true);
                 if ($result === null || !is_array($result)) {
@@ -453,7 +458,7 @@ class JeeObjectManager
         if ($key == '') {
             return;
         }
-        $def = ConfigManager::byKey('object:summary');
+        $def = ConfigManager::byKey(ConfigKey::OBJECT_SUMMARY);
         if (!isset($def[$key])) {
             return;
         }
@@ -489,10 +494,10 @@ class JeeObjectManager
             $plugin->setIsEnable(1);
         }
         if (!is_object($plugin)) {
-            throw new \Exception(__('Le plugin virtuel doit être installé'));
+            throw new CoreException(__('Le plugin virtuel doit être installé'));
         }
         if (!$plugin->isActive()) {
-            throw new \Exception(__('Le plugin virtuel doit être actif'));
+            throw new CoreException(__('Le plugin virtuel doit être actif'));
         }
 
         $virtual = EqLogicManager::byLogicalId('summaryglobal', 'virtual');
@@ -507,7 +512,7 @@ class JeeObjectManager
         $virtual->setLogicalId('summaryglobal');
         $virtual->setEqType_name('virtual');
         $virtual->save();
-        $cmd = $virtual->getCmd('info', $key);
+        $cmd = $virtual->getCmd(CmdType::INFO, $key);
         if (!is_object($cmd)) {
             /** @noinspection PhpUndefinedClassInspection */
             $cmd = new \virtualCmd();
@@ -516,24 +521,24 @@ class JeeObjectManager
         }
         $cmd->setEqLogic_id($virtual->getId());
         $cmd->setLogicalId($key);
-        $cmd->setType('info');
+        $cmd->setType(CmdType::INFO);
         if ($def[$key]['calcul'] == 'text') {
-            $cmd->setSubtype('string');
+            $cmd->setSubtype(CmdSubType::STRING);
         } else {
-            $cmd->setSubtype('numeric');
+            $cmd->setSubtype(CmdSubType::NUMERIC);
         }
         $cmd->setUnite($def[$key]['unit']);
         $cmd->save();
 
         foreach (self::all() as $jeeObject) {
-            $summaries = $jeeObject->getConfiguration('summary');
+            $summaries = $jeeObject->getConfiguration(Common::SUMMARY);
             if (!is_array($summaries)) {
                 continue;
             }
             if (!isset($summaries[$key]) || !is_array($summaries[$key]) || count($summaries[$key]) == 0) {
                 continue;
             }
-            $virtual = EqLogicManager::byLogicalId('summary' . $jeeObject->getId(), 'virtual');
+            $virtual = EqLogicManager::byLogicalId(Common::SUMMARY . $jeeObject->getId(), 'virtual');
             if (!is_object($virtual)) {
                 /** @noinspection PhpUndefinedClassInspection */
                 $virtual = new \virtual();
@@ -542,13 +547,13 @@ class JeeObjectManager
                 $virtual->setIsEnable(1);
             }
             $virtual->setIsEnable(1);
-            $virtual->setLogicalId('summary' . $jeeObject->getId());
+            $virtual->setLogicalId(Common::SUMMARY . $jeeObject->getId());
             $virtual->setEqType_name('virtual');
             $virtual->setObject_id($jeeObject->getId());
             $virtual->save();
             $jeeObject->setConfiguration('summary_virtual_id', $virtual->getId());
             $jeeObject->save();
-            $cmd = $virtual->getCmd('info', $key);
+            $cmd = $virtual->getCmd(CmdType::INFO, $key);
             if (!is_object($cmd)) {
                 /** @noinspection PhpUndefinedClassInspection */
                 $cmd = new \virtualCmd();
@@ -557,11 +562,11 @@ class JeeObjectManager
             }
             $cmd->setEqLogic_id($virtual->getId());
             $cmd->setLogicalId($key);
-            $cmd->setType('info');
+            $cmd->setType(CmdType::INFO);
             if ($def[$key]['calcul'] == 'text') {
-                $cmd->setSubtype('string');
+                $cmd->setSubtype(CmdSubType::STRING);
             } else {
-                $cmd->setSubtype('numeric');
+                $cmd->setSubtype(CmdSubType::NUMERIC);
             }
             $cmd->setUnite($def[$key]['unit']);
             $cmd->save();

--- a/src/Managers/ListenerManager.php
+++ b/src/Managers/ListenerManager.php
@@ -70,9 +70,9 @@ class ListenerManager
      */
     public static function byId($_id)
     {
-        $value = array(
+        $value = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE id=:id';
@@ -87,9 +87,9 @@ class ListenerManager
      */
     public static function byClass($_class)
     {
-        $value = array(
+        $value = [
             'class' => $_class,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE class=:class';
@@ -106,10 +106,10 @@ class ListenerManager
      */
     public static function byClassAndFunction($_class, $_function, $_option = '')
     {
-        $value = array(
+        $value = [
             'class' => $_class,
             'function' => $_function,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE class=:class
@@ -132,11 +132,11 @@ class ListenerManager
      */
     public static function searchClassFunctionOption($_class, $_function, $_option = '')
     {
-        $value = array(
+        $value = [
             'class' => $_class,
             'function' => $_function,
             'option' => '%' . $_option . '%',
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE class=:class
@@ -155,11 +155,11 @@ class ListenerManager
      */
     public static function byClassFunctionAndEvent($_class, $_function, $_event)
     {
-        $value = array(
+        $value = [
             'class' => $_class,
             'function' => $_function,
             'event' => $_event,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE class=:class
@@ -177,11 +177,11 @@ class ListenerManager
      */
     public static function removeByClassFunctionAndEvent($_class, $_function, $_event, $_option = '')
     {
-        $value = array(
+        $value = [
             'class' => $_class,
             'function' => $_function,
             'event' => $_event,
-        );
+        ];
         $sql = 'DELETE FROM ' . self::DB_CLASS_NAME . '
         WHERE class=:class
         AND function=:function
@@ -218,13 +218,13 @@ class ListenerManager
     public static function searchEvent($_event)
     {
         if (strpos($_event, '#') !== false) {
-            $value = array(
+            $value = [
                 'event' => '%' . $_event . '%',
-            );
+            ];
         } else {
-            $value = array(
+            $value = [
                 'event' => '%#' . $_event . '#%',
-            );
+            ];
         }
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '

--- a/src/Managers/MessageManager.php
+++ b/src/Managers/MessageManager.php
@@ -34,6 +34,7 @@
 
 namespace NextDom\Managers;
 
+use NextDom\Enums\DateFormat;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\Utils;
 use NextDom\Model\Entity\Message;
@@ -65,7 +66,7 @@ class MessageManager
             ->setPlugin(Utils::secureXSS($_type))
             ->setMessage(Utils::secureXSS($_message))
             ->setAction(Utils::secureXSS($_action))
-            ->setDate(date('Y-m-d H:i:s'))
+            ->setDate(date(DateFormat::FULL_DAY))
             ->setLogicalId(Utils::secureXSS($_logicalId));
         $message->save($_writeMessage);
     }
@@ -79,7 +80,7 @@ class MessageManager
      */
     public static function removeAll($_plugin = '', $_logicalId = '', $_search = false)
     {
-        $values = array();
+        $values = [];
         $sql = 'DELETE FROM ' . self::DB_CLASS_NAME;
         if ($_plugin != '') {
             $values['plugin'] = $_plugin;
@@ -119,9 +120,9 @@ class MessageManager
      */
     public static function byId($_id)
     {
-        $values = array(
+        $values = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE id=:id';
@@ -136,10 +137,10 @@ class MessageManager
      */
     public static function byPluginLogicalId($_plugin, $_logicalId)
     {
-        $values = array(
+        $values = [
             'logicalId' => $_logicalId,
             'plugin' => $_plugin,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE logicalId=:logicalId
@@ -155,9 +156,9 @@ class MessageManager
      */
     public static function byPlugin($_plugin)
     {
-        $values = array(
+        $values = [
             'plugin' => $_plugin,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE plugin=:plugin
@@ -195,11 +196,12 @@ class MessageManager
      * @param $logicialId
      * @return mixed
      */
-    public static function removeByPluginLogicalId($pluginId, $logicialId) {
-        $values = array(
+    public static function removeByPluginLogicalId($pluginId, $logicialId)
+    {
+        $values = [
             'logicalId' => $logicialId,
             'plugin' => $pluginId,
-        );
+        ];
         $sql = 'DELETE FROM message
                 WHERE logicalId=:logicalId
                 AND plugin=:plugin';

--- a/src/Managers/Plan3dHeaderManager.php
+++ b/src/Managers/Plan3dHeaderManager.php
@@ -53,9 +53,9 @@ class Plan3dHeaderManager
      */
     public static function byId($_id)
     {
-        $values = array(
+        $values = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE id=:id';
@@ -84,7 +84,7 @@ class Plan3dHeaderManager
      */
     public static function searchByUse($_type, $_id)
     {
-        $return = array();
+        $return = [];
         $search = '#' . str_replace('cmd', '', $_type . $_id) . '#';
         $plan3ds = array_merge(Plan3dManager::byLinkTypeLinkId($_type, $_id), Plan3dManager::searchByConfiguration($search, 'eqLogic'));
         foreach ($plan3ds as $plan3d) {

--- a/src/Managers/Plan3dManager.php
+++ b/src/Managers/Plan3dManager.php
@@ -53,9 +53,9 @@ class Plan3dManager
      */
     public static function byId($_id)
     {
-        $values = array(
+        $values = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE id=:id';
@@ -69,9 +69,9 @@ class Plan3dManager
      */
     public static function byPlan3dHeaderId($_plan3dHeader_id)
     {
-        $values = array(
+        $values = [
             'plan3dHeader_id' => $_plan3dHeader_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE plan3dHeader_id=:plan3dHeader_id';
@@ -87,10 +87,10 @@ class Plan3dManager
      */
     public static function byLinkTypeLinkId($_link_type, $_link_id)
     {
-        $values = array(
+        $values = [
             'link_type' => $_link_type,
             'link_id' => $_link_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE link_type=:link_type
@@ -107,10 +107,10 @@ class Plan3dManager
      */
     public static function byName3dHeaderId($_name, $_plan3dHeader_id)
     {
-        $values = array(
+        $values = [
             'name' => $_name,
             'plan3dHeader_id' => $_plan3dHeader_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE name=:name
@@ -128,11 +128,11 @@ class Plan3dManager
      */
     public static function byLinkTypeLinkId3dHeaderId($_link_type, $_link_id, $_plan3dHeader_id)
     {
-        $values = array(
+        $values = [
             'link_type' => $_link_type,
             'link_id' => $_link_id,
             'plan3dHeader_id' => $_plan3dHeader_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE link_type=:link_type
@@ -150,11 +150,11 @@ class Plan3dManager
      */
     public static function removeByLinkTypeLinkId3dHeaderId($_link_type, $_link_id, $_plan3dHeader_id)
     {
-        $values = array(
+        $values = [
             'link_type' => $_link_type,
             'link_id' => $_link_id,
             'plan3dHeader_id' => $_plan3dHeader_id,
-        );
+        ];
         $sql = 'DELETE FROM ' . self::DB_CLASS_NAME . '
         WHERE link_type=:link_type
         AND link_id=:link_id
@@ -182,9 +182,9 @@ class Plan3dManager
      */
     public static function searchByDisplay($_search)
     {
-        $value = array(
+        $value = [
             'search' => '%' . $_search . '%',
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE display LIKE :search';
@@ -200,10 +200,10 @@ class Plan3dManager
      */
     public static function searchByConfiguration($_search, $_not = '')
     {
-        $value = array(
+        $value = [
             'search' => '%' . $_search . '%',
             'not' => $_not,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE configuration LIKE :search

--- a/src/Managers/PlanHeaderManager.php
+++ b/src/Managers/PlanHeaderManager.php
@@ -52,9 +52,9 @@ class PlanHeaderManager
      */
     public static function byId($_id)
     {
-        $values = array(
+        $values = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE id=:id';
@@ -82,7 +82,7 @@ class PlanHeaderManager
      */
     public static function searchByUse($_type, $_id)
     {
-        $return = array();
+        $return = [];
         $search = '#' . str_replace('cmd', '', $_type . $_id) . '#';
         $plans = array_merge(PlanManager::byLinkTypeLinkId($_type, $_id), PlanManager::searchByConfiguration($search, 'eqLogic'));
         foreach ($plans as $plan) {

--- a/src/Managers/PlanManager.php
+++ b/src/Managers/PlanManager.php
@@ -59,9 +59,9 @@ class PlanManager
      */
     public static function byId($_id)
     {
-        $values = array(
+        $values = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE id = :id';
@@ -76,9 +76,9 @@ class PlanManager
      */
     public static function byPlanHeaderId($_planHeader_id)
     {
-        $values = array(
+        $values = [
             'planHeader_id' => $_planHeader_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE planHeader_id = :planHeader_id';
@@ -94,10 +94,10 @@ class PlanManager
      */
     public static function byLinkTypeLinkId($_link_type, $_link_id)
     {
-        $values = array(
+        $values = [
             'link_type' => $_link_type,
             'link_id' => $_link_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE link_type = :link_type
@@ -115,11 +115,11 @@ class PlanManager
      */
     public static function byLinkTypeLinkIdPlanHedaerId($_link_type, $_link_id, $_planHeader_id)
     {
-        $values = array(
+        $values = [
             'link_type' => $_link_type,
             'link_id' => $_link_id,
             'planHeader_id' => $_planHeader_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE link_type = :link_type
@@ -137,11 +137,11 @@ class PlanManager
      */
     public static function removeByLinkTypeLinkIdPlanHedaerId($_link_type, $_link_id, $_planHeader_id)
     {
-        $values = array(
+        $values = [
             'link_type' => $_link_type,
             'link_id' => $_link_id,
             'planHeader_id' => $_planHeader_id,
-        );
+        ];
         $sql = 'DELETE FROM ' . self::DB_CLASS_NAME . '
         WHERE link_type = :link_type
         AND link_id = :link_id
@@ -169,9 +169,9 @@ class PlanManager
      */
     public static function searchByDisplay($_search)
     {
-        $value = array(
+        $value = [
             'search' => '%' . $_search . '%',
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE display LIKE :search';
@@ -187,10 +187,10 @@ class PlanManager
      */
     public static function searchByConfiguration($_search, $_not = '')
     {
-        $value = array(
+        $value = [
             'search' => '%' . $_search . '%',
             'not' => $_not,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE configuration LIKE :search

--- a/src/Managers/PluginManager.php
+++ b/src/Managers/PluginManager.php
@@ -34,10 +34,13 @@
 namespace NextDom\Managers;
 
 use NextDom\Enums\DaemonState;
+use NextDom\Enums\DateFormat;
 use NextDom\Enums\PluginManagerCron;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\FileSystemHelper;
 use NextDom\Helpers\LogHelper;
+use NextDom\Helpers\Utils;
 use NextDom\Model\Entity\Plugin;
 
 /**
@@ -46,7 +49,7 @@ use NextDom\Model\Entity\Plugin;
  */
 class PluginManager
 {
-    private static $cache = array();
+    private static $cache = [];
     private static $enabledPlugins = null;
 
     /**
@@ -72,7 +75,7 @@ class PluginManager
      */
     public static function listPlugin(bool $activatedOnly = false, bool $orderByCategory = false, bool $nameOnly = false): array
     {
-        $listPlugin = array();
+        $listPlugin = [];
         if ($activatedOnly) {
             $sql = "SELECT plugin
                     FROM `config`
@@ -108,7 +111,7 @@ class PluginManager
                 }
             }
         }
-        $returnValue = array();
+        $returnValue = [];
         if ($orderByCategory) {
             if (count($listPlugin) > 0) {
                 foreach ($listPlugin as $plugin) {
@@ -117,7 +120,7 @@ class PluginManager
                         $category = __('Autre');
                     }
                     if (!isset($returnValue[$category])) {
-                        $returnValue[$category] = array();
+                        $returnValue[$category] = [];
                     }
                     $returnValue[$category][] = $plugin;
                 }
@@ -138,32 +141,39 @@ class PluginManager
     /**
      * Get a plugin from his username
      *
-     * @param string $id Identifiant du plugin
+     * @param string $pluginId Plugin Id or path to info.json
      *
      * @return mixed|Plugin Plugin
      *
      * @throws \Exception
      */
-    public static function byId($id)
+    public static function byId($pluginId)
     {
         global $NEXTDOM_INTERNAL_CONFIG;
-        if (is_string($id) && isset(self::$cache[$id])) {
-            return self::$cache[$id];
+        $pluginInfoFilePath = '';
+
+        // Check plugin data in cache
+        if (is_string($pluginId) && isset(self::$cache[$pluginId])) {
+            return self::$cache[$pluginId];
         }
-        if (!file_exists($id) || strpos($id, '/') === false) {
-            $id = self::getPathById($id);
+        if (!file_exists($pluginId) || strpos($pluginId, '/') === false) {
+            $pluginInfoFilePath = self::getPathById($pluginId);
+        } else {
+            // Info.json passed directly
+            $pluginInfoFilePath = realpath((string)$pluginId);
         }
-        if (!file_exists($id)) {
-            self::forceDisablePlugin($id);
-            throw new \Exception('Plugin introuvable : ' . $id);
+
+        if (!Utils::checkPath($pluginInfoFilePath) || !file_exists($pluginInfoFilePath)) {
+            self::forceDisablePlugin($pluginId);
+            throw new CoreException(__('Plugin introuvable : ') . $pluginId);
         }
-        $data = json_decode(file_get_contents($id), true);
-        if (!is_array($data)) {
-            self::forceDisablePlugin($id);
-            throw new \Exception('Plugin introuvable (json invalide) : ' . $id . ' => ' . print_r($data, true));
+        $pluginData = json_decode(file_get_contents($pluginInfoFilePath), true);
+        if (!is_array($pluginData)) {
+            self::forceDisablePlugin($pluginId);
+            throw new CoreException(__('Plugin introuvable (json invalide) : ') . $pluginInfoFilePath . ' => ' . print_r($pluginData, true));
         }
         $plugin = new Plugin();
-        $plugin->initPluginFromData($data);
+        $plugin->initPluginFromData($pluginData);
         self::$cache[$plugin->getId()] = $plugin;
         if (!isset($NEXTDOM_INTERNAL_CONFIG['plugin']['category'][$plugin->getCategory()])) {
             foreach ($NEXTDOM_INTERNAL_CONFIG['plugin']['category'] as $key => $value) {
@@ -187,7 +197,7 @@ class PluginManager
      */
     public static function getPathById(string $id): string
     {
-        return NEXTDOM_ROOT . '/plugins/' . $id . '/plugin_info/info.json';
+        return realpath(NEXTDOM_ROOT . '/plugins/' . $id . '/plugin_info/info.json');
     }
 
     /**
@@ -197,12 +207,12 @@ class PluginManager
     public static function forceDisablePlugin($_id)
     {
         ConfigManager::save('active', 0, $_id);
-        $values = array(
+        $values = [
             'eqType_name' => $_id,
-        );
+        ];
         $sql = 'UPDATE eqLogic
-                SET isEnable=0
-                WHERE eqType_name=:eqType_name';
+                SET isEnable = 0
+                WHERE eqType_name = :eqType_name';
         DBHelper::exec($sql, $values);
     }
 
@@ -236,7 +246,7 @@ class PluginManager
                 }
                 $ok = false;
                 foreach ($eqLogics as $eqLogic) {
-                    if ($eqLogic->getStatus('lastCommunication', date('Y-m-d H:i:s')) > date('Y-m-d H:i:s', strtotime('-' . $heartbeat . ' minutes' . date('Y-m-d H:i:s')))) {
+                    if ($eqLogic->getStatus('lastCommunication', date(DateFormat::FULL)) > date(DateFormat::FULL, strtotime('-' . $heartbeat . ' minutes' . date(DateFormat::FULL)))) {
                         $ok = true;
                         break;
                     }
@@ -275,7 +285,7 @@ class PluginManager
     private static function startCronTask(string $cronType = '')
     {
         $cache = CacheManager::byKey('plugin::' . $cronType . '::inprogress');
-        if(is_array($cache->getValue(0))){
+        if (is_array($cache->getValue(0))) {
             CacheManager::set('plugin::' . $cronType . '::inprogress', -1);
             $cache = CacheManager::byKey('plugin::' . $cronType . '::inprogress');
         }
@@ -289,9 +299,9 @@ class PluginManager
                     $pluginId = $plugin->getId();
                     CacheManager::set('plugin::' . $cronType . '::last', $pluginId);
                     //try {
-                        $pluginId::$cronType();
+                    $pluginId::$cronType();
                     //} catch (\Throwable $e) {
-//                        LogHelper::add($pluginId, 'error', __('Erreur sur la fonction cron du plugin : ') . $e->getMessage());
+//                        LogHelper::addError($pluginId, __('Erreur sur la fonction cron du plugin : ') . $e->getMessage());
                     //}
                 }
             }
@@ -373,7 +383,7 @@ class PluginManager
                 try {
                     $pluginId::start();
                 } catch (\Throwable $e) {
-                    LogHelper::add($pluginId, 'error', __('Erreur sur la fonction start du plugin : ') . $e->getMessage());
+                    LogHelper::addError($pluginId, __('Erreur sur la fonction start du plugin : ') . $e->getMessage());
                 }
             }
         }
@@ -393,7 +403,7 @@ class PluginManager
                 try {
                     $pluginId::stop();
                 } catch (\Throwable $e) {
-                    LogHelper::add($pluginId, 'error', __('Erreur sur la fonction stop du plugin : ') . $e->getMessage());
+                    LogHelper::addError($pluginId, __('Erreur sur la fonction stop du plugin : ') . $e->getMessage());
                 }
             }
         }
@@ -422,7 +432,7 @@ class PluginManager
                     shell_exec('rm ' . $dependancy_info['progress_file']);
                 }
                 ConfigManager::save('deamonAutoMode', 0, $plugin->getId());
-                LogHelper::add($plugin->getId(), 'error', __('Attention : l\'installation des dépendances a dépassé le temps maximum autorisé : ') . $plugin->getMaxDependancyInstallTime() . 'min');
+                LogHelper::addError($plugin->getId(), __('Attention : l\'installation des dépendances a dépassé le temps maximum autorisé : ') . $plugin->getMaxDependancyInstallTime() . 'min');
             }
             try {
                 $plugin->deamon_start(false, true);

--- a/src/Managers/ScenarioElementManager.php
+++ b/src/Managers/ScenarioElementManager.php
@@ -33,6 +33,7 @@
 
 namespace NextDom\Managers;
 
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\Utils;
 use NextDom\Model\Entity\ScenarioElement;
@@ -65,13 +66,13 @@ class ScenarioElementManager
             $elementDb = new ScenarioElement();
         }
         if (!isset($elementDb) || !is_object($elementDb)) {
-            throw new \Exception(__('Elément inconnu. Vérifiez l\'ID : ') . $ajaxElement['id']);
+            throw new CoreException(__('Elément inconnu. Vérifiez l\'ID : ') . $ajaxElement['id']);
         }
         Utils::a2o($elementDb, $ajaxElement);
         $elementDb->save();
         $subElementOrder = 0;
         $subElementList = $elementDb->getSubElement();
-        $enabledSubElement = array();
+        $enabledSubElement = [];
         foreach ($ajaxElement['subElements'] as $ajaxSubElement) {
             if (isset($ajaxSubElement['id']) && $ajaxSubElement['id'] != '') {
                 $subElementDb = ScenarioSubElementManager::byId($ajaxSubElement['id']);
@@ -79,7 +80,7 @@ class ScenarioElementManager
                 $subElementDb = new ScenarioSubElement();
             }
             if (!isset($subElementDb) || !is_object($subElementDb)) {
-                throw new \Exception(__('Elément inconnu. Vérifiez l\'ID : ') . $ajaxSubElement['id']);
+                throw new CoreException(__('Elément inconnu. Vérifiez l\'ID : ') . $ajaxSubElement['id']);
             }
             Utils::a2o($subElementDb, $ajaxSubElement);
             $subElementDb->setScenarioElement_id($elementDb->getId());
@@ -90,7 +91,7 @@ class ScenarioElementManager
 
             $expressionsList = $subElementDb->getExpression();
             $expressionOrder = 0;
-            $enabledExpression = array();
+            $enabledExpression = [];
             foreach ($ajaxSubElement['expressions'] as &$expression_ajax) {
                 if (isset($expression_ajax['scenarioSubElement_id']) && $expression_ajax['scenarioSubElement_id'] != $subElementDb->getId() && isset($expression_ajax['id']) && $expression_ajax['id'] != '') {
                     $expression_ajax['id'] = '';
@@ -101,7 +102,7 @@ class ScenarioElementManager
                     $expression_db = new ScenarioExpression();
                 }
                 if (!isset($expression_db) || !is_object($expression_db)) {
-                    throw new \Exception(__('Expression inconnue. Vérifiez l\'ID : ') . $expression_ajax['id']);
+                    throw new CoreException(__('Expression inconnue. Vérifiez l\'ID : ') . $expression_ajax['id']);
                 }
                 $expression_db->emptyOptions();
                 Utils::a2o($expression_db, $expression_ajax);
@@ -137,9 +138,9 @@ class ScenarioElementManager
      */
     public static function byId($id)
     {
-        $values = array(
+        $values = [
             'id' => $id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE id = :id';

--- a/src/Managers/ScenarioExpressionManager.php
+++ b/src/Managers/ScenarioExpressionManager.php
@@ -33,6 +33,7 @@
 
 namespace NextDom\Managers;
 
+use NextDom\Enums\CmdType;
 use NextDom\Enums\DateFormat;
 use NextDom\Enums\ScenarioState;
 use NextDom\Helpers\DateHelper;
@@ -168,7 +169,7 @@ class ScenarioExpressionManager
         $replace = [
             '#uid#' => 'exp' . mt_rand()
         ];
-        $result = array('html' => '');
+        $result = ['html' => ''];
         $cmd = CmdManager::byId(str_replace('#', '', CmdManager::humanReadableToCmd($expression)));
         if (is_object($cmd)) {
             $result['html'] = trim($cmd->toHtml('scenario', $options));
@@ -306,7 +307,7 @@ class ScenarioExpressionManager
                 }
             }
         }
-        $replace2 = array();
+        $replace2 = [];
         if (!is_string($_expression)) {
             return $_expression;
         }
@@ -382,7 +383,7 @@ class ScenarioExpressionManager
      */
     public static function getRequestTags($expression)
     {
-        $return = array();
+        $return = [];
         preg_match_all("/#([a-zA-Z0-9]*)#/", $expression, $matches);
         if (count($matches) == 0) {
             return $return;
@@ -520,7 +521,7 @@ class ScenarioExpressionManager
      */
     public static function scenario(string $scenarioExpression)
     {
-        $id = str_replace(array('scenario', '#'), '', trim($scenarioExpression));
+        $id = str_replace(['scenario', '#'], '', trim($scenarioExpression));
         $scenario = ScenarioManager::byId($id);
         if (!is_object($scenario)) {
             return -2;
@@ -548,7 +549,7 @@ class ScenarioExpressionManager
      */
     public static function eqEnable($eqLogicId)
     {
-        $id = str_replace(array('eqLogic', '#'), '', trim($eqLogicId));
+        $id = str_replace(['eqLogic', '#'], '', trim($eqLogicId));
         $eqLogic = EqLogicManager::byId($id);
         if (!is_object($eqLogic)) {
             return -2;
@@ -570,7 +571,7 @@ class ScenarioExpressionManager
     {
         $args = func_get_args();
         if (count($args) > 2 || strpos($period, '#') !== false || is_numeric($period)) {
-            $values = array();
+            $values = [];
             foreach ($args as $arg) {
                 if (is_numeric($arg)) {
                     $values[] = $arg;
@@ -695,7 +696,7 @@ class ScenarioExpressionManager
     {
         $args = func_get_args();
         if (count($args) > 2 || strpos($period, '#') !== false || is_numeric($period)) {
-            $values = array();
+            $values = [];
             foreach ($args as $arg) {
                 if (is_numeric($arg)) {
                     $values[] = $arg;
@@ -797,7 +798,7 @@ class ScenarioExpressionManager
     {
         $args = func_get_args();
         if (count($args) > 2 || strpos($period, '#') !== false || is_numeric($period)) {
-            $values = array();
+            $values = [];
             foreach ($args as $arg) {
                 if (is_numeric($arg)) {
                     $values[] = $arg;
@@ -871,7 +872,7 @@ class ScenarioExpressionManager
     public static function median()
     {
         $args = func_get_args();
-        $values = array();
+        $values = [];
         foreach ($args as $arg) {
             if (is_numeric($arg)) {
                 $values[] = $arg;
@@ -1284,7 +1285,7 @@ class ScenarioExpressionManager
      */
     public static function lastScenarioExecution($scenarioId)
     {
-        $scenario = ScenarioManager::byId(str_replace(array('#scenario', '#'), '', $scenarioId));
+        $scenario = ScenarioManager::byId(str_replace(['#scenario', '#'], '', $scenarioId));
         if (!is_object($scenario)) {
             return 0;
         }
@@ -1305,7 +1306,7 @@ class ScenarioExpressionManager
         if (!is_object($cmdObj)) {
             return -1;
         }
-        if ($cmdObj->getType() != 'info') {
+        if (!$cmdObj->isType(CmdType::INFO)) {
             return -2;
         }
         $cmdObj->execCmd();
@@ -1350,7 +1351,7 @@ class ScenarioExpressionManager
      */
     public static function lastCommunication($_eqLogic_id, $_format = DateFormat::FULL)
     {
-        $eqLogic = EqLogicManager::byId(trim(str_replace(array('#', '#eqLogic', 'eqLogic'), '', EqLogicManager::fromHumanReadable('#' . str_replace('#', '', $_eqLogic_id) . '#'))));
+        $eqLogic = EqLogicManager::byId(trim(str_replace(['#', '#eqLogic', 'eqLogic'], '', EqLogicManager::fromHumanReadable('#' . str_replace('#', '', $_eqLogic_id) . '#'))));
         if (!is_object($eqLogic)) {
             return -1;
         }

--- a/src/Managers/ScenarioSubElementManager.php
+++ b/src/Managers/ScenarioSubElementManager.php
@@ -56,7 +56,7 @@ class ScenarioSubElementManager
      */
     public static function byId($id)
     {
-        $values = array('id' => $id);
+        $values = ['id' => $id];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE id = :id';
@@ -75,9 +75,9 @@ class ScenarioSubElementManager
      */
     public static function byScenarioElementId($scenarioElementId, $filterByType = '')
     {
-        $values = array(
+        $values = [
             'scenarioElement_id' => $scenarioElementId,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
                 FROM ' . self::DB_CLASS_NAME . '
                 WHERE scenarioElement_id=:scenarioElement_id ';

--- a/src/Managers/ViewDataManager.php
+++ b/src/Managers/ViewDataManager.php
@@ -66,9 +66,9 @@ class ViewDataManager
      */
     public static function byId($_id)
     {
-        $value = array(
+        $value = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE id=:id';
@@ -83,9 +83,9 @@ class ViewDataManager
      */
     public static function byViewZoneId($_viewZone_id)
     {
-        $value = array(
+        $value = [
             'viewZone_id' => $_viewZone_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE viewZone_id=:viewZone_id
@@ -100,9 +100,9 @@ class ViewDataManager
      */
     public static function searchByConfiguration($_search)
     {
-        $value = array(
+        $value = [
             'search' => '%' . $_search . '%',
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE configuration LIKE :search';
@@ -132,10 +132,10 @@ class ViewDataManager
      */
     public static function byTypeLinkId($_type, $_link_id)
     {
-        $value = array(
+        $value = [
             'type' => $_type,
             'link_id' => $_link_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE type=:type

--- a/src/Managers/ViewManager.php
+++ b/src/Managers/ViewManager.php
@@ -64,9 +64,9 @@ class ViewManager
      */
     public static function byId($_id)
     {
-        $value = array(
+        $value = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE id = :id';
@@ -81,7 +81,7 @@ class ViewManager
      */
     public static function searchByUse($_type, $_id)
     {
-        $return = array();
+        $return = [];
         $viewDatas = ViewDataManager::byTypeLinkId($_type, $_id);
         $search = '#' . str_replace('cmd', '', $_type . $_id) . '#';
         $viewDatas = array_merge($viewDatas, ViewDataManager::searchByConfiguration($search));

--- a/src/Managers/ViewZoneManager.php
+++ b/src/Managers/ViewZoneManager.php
@@ -65,9 +65,9 @@ class ViewZoneManager
      */
     public static function byId($_id)
     {
-        $value = array(
+        $value = [
             'id' => $_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE id=:id';
@@ -82,9 +82,9 @@ class ViewZoneManager
      */
     public static function byView($_view_id)
     {
-        $value = array(
+        $value = [
             'view_id' => $_view_id,
-        );
+        ];
         $sql = 'SELECT ' . DBHelper::buildField(self::CLASS_NAME) . '
         FROM ' . self::DB_CLASS_NAME . '
         WHERE view_id=:view_id';
@@ -98,9 +98,9 @@ class ViewZoneManager
      */
     public static function removeByViewId($_view_id)
     {
-        $value = array(
+        $value = [
             'view_id' => $_view_id,
-        );
+        ];
         $sql = 'DELETE FROM ' . self::DB_CLASS_NAME . '
                 WHERE view_id = :view_id';
         return DBHelper::getOne($sql, $value);

--- a/src/Market/DownloadManager.php
+++ b/src/Market/DownloadManager.php
@@ -122,7 +122,7 @@ class DownloadManager
                 $url = $url . '?' . $toAdd;
             }
         }
-        LogHelper::add('AlternativeMarketForJeedom', 'debug', 'Download ' . $url);
+        LogHelper::addDebug('AlternativeMarketForJeedom', 'Download ' . $url);
         return self::downloadContentWithCurl($url, $binary);
     }
 

--- a/src/Market/GitManager.php
+++ b/src/Market/GitManager.php
@@ -19,6 +19,7 @@
 
 namespace NextDom\Market;
 
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DataStorage;
 
 /**
@@ -69,9 +70,9 @@ class GitManager
         $jsonList = $this->downloadRepositoriesList();
         if ($jsonList !== false) {
             $jsonAnswer = json_decode($jsonList, true);
-            $dataToStore = array();
+            $dataToStore = [];
             foreach ($jsonAnswer as $repository) {
-                $data = array();
+                $data = [];
                 $data['name'] = $repository['name'];
                 $data['full_name'] = $repository['full_name'];
                 $data['description'] = $repository['description'];
@@ -104,10 +105,10 @@ class GitManager
             $content = DownloadManager::downloadContent($this->githubApiDomain . '/rate_limit');
             $gitHubLimitData = json_decode($content, true);
             $refreshDate = date('H:i', $gitHubLimitData['resources']['core']['reset']);
-            throw new \Exception('Limite de l\'API GitHub atteinte. Le rafraichissement sera accessible à ' . $refreshDate);
+            throw new CoreException('Limite de l\'API GitHub atteinte. Le rafraichissement sera accessible à ' . $refreshDate);
         } elseif (strstr($content, 'Bad credentials')) {
             // Le token GitHub n'est pas bon
-            throw new \Exception('Problème de Token GitHub');
+            throw new CoreException('Problème de Token GitHub');
         } else {
             // Test si c'est un dépôt d'organisation
             if (strstr($content, '"message":"Not Found"')) {
@@ -115,7 +116,7 @@ class GitManager
                 $content = DownloadManager::downloadContent($this->githubApiDomain . '/users/' . $this->gitId . '/repos?per_page=100');
                 // Test si c'est un dépot d'utilisateur
                 if (strstr($content, '"message":"Not Found"') || strlen($content) < 10) {
-                    throw new \Exception('Le dépôt ' . $this->gitId . ' n\'existe pas.');
+                    throw new CoreException('Le dépôt ' . $this->gitId . ' n\'existe pas.');
                 } else {
                     $result = $content;
                 }
@@ -142,6 +143,7 @@ class GitManager
      * @param string $sourceName Nom de la source
      * @param array $repositoriesList Liste des dépots
      * @param bool $force Forcer les mises à jour
+     * @throws \Exception
      */
     public function updateRepositories($sourceName, $repositoriesList, $force)
     {
@@ -165,7 +167,7 @@ class GitManager
      */
     protected function getIgnoreList()
     {
-        $result = array();
+        $result = [];
         $jsonList = $this->dataStorage->getJsonData('repo_ignore_' . $this->gitId);
         if ($jsonList !== null) {
             $result = $jsonList;
@@ -182,7 +184,7 @@ class GitManager
      */
     public function getItems($sourceName)
     {
-        $result = array();
+        $result = [];
         $repositories = $this->getRepositoriesList();
         $ignoreList = $this->getIgnoreList();
         foreach ($repositories as $repository) {

--- a/src/Market/MarketItem.php
+++ b/src/Market/MarketItem.php
@@ -197,10 +197,10 @@ class MarketItem
     {
         $name = sprintf("repo_data_%s", str_replace("/", "_", $this->fullName));
         $json = $this->dataStorage->getJsonData($name);
-        $attrs = array("name", "gitName", "gitId", "fullName",
+        $attrs = ["name", "gitName", "gitId", "fullName",
             "description", "url", "id", "author",
             "category", "iconPath", "defaultBranch", "branchesList",
-            "licence", "changelogLink", "documentationLink", "screenshots");
+            "licence", "changelogLink", "documentationLink", "screenshots"];
         if ($json === null) {
             return false;
         }

--- a/src/Market/NextDomMarket.php
+++ b/src/Market/NextDomMarket.php
@@ -33,6 +33,7 @@
 
 namespace NextDom\Market;
 
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DataStorage;
 
 /**
@@ -87,7 +88,7 @@ class NextDomMarket
                 $result = $this->refreshJson($force);
             }
         } else {
-            throw new \Exception('Pas de connection internet', 500);
+            throw new CoreException('Pas de connection internet', 500);
         }
         return $result;
     }
@@ -190,7 +191,7 @@ class NextDomMarket
      */
     public function getItemsFromJson(): array
     {
-        $result = array();
+        $result = [];
         $plugins = $this->dataStorage->getJsonData('repo_data_' . $this->source['name']);
         foreach ($plugins as $plugin) {
             if ($plugin['id'] !== 'AlternativeMarketForJeedom') {

--- a/src/Market/RepoMarketApi.php
+++ b/src/Market/RepoMarketApi.php
@@ -18,10 +18,16 @@
 
 namespace NextDom\Repo;
 
+use NextDom\Enums\AjaxParams;
+use NextDom\Enums\Common;
+use NextDom\Enums\ConfigKey;
+use NextDom\Enums\LogTarget;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\Api;
 use NextDom\Helpers\LogHelper;
+use NextDom\Helpers\NetworkHelper;
 use NextDom\Helpers\NextDomHelper;
+use NextDom\Helpers\Utils;
 use NextDom\Managers\ConfigManager;
 use NextDom\Managers\UserManager;
 use NextDom\Model\Entity\Cron;
@@ -36,22 +42,22 @@ if (UserManager::isBanned() && false) {
     die();
 }
 try {
-    if (!Api::apiAccess(init('apikey'), 'apimarket')) {
+    if (!Api::apiAccess(Utils::init('apikey'), 'apimarket')) {
         UserManager::failedLogin();
-        throw new CoreException(__('Vous n\'êtes pas autorisé à effectuer cette action 1, IP : ', __FILE__) . getClientIp());
+        throw new CoreException(__('Vous n\'êtes pas autorisé à effectuer cette action 1, IP : ') . NetworkHelper::getClientIp());
     }
-    if (init('action') == 'resync') {
-        if (NextDomHelper::isStarted() && ConfigManager::byKey('enableCron', 'core', 1, true) == 0) {
-            die(__('Tous les crons sont actuellement désactivés', __FILE__));
+    if (Utils::init(AjaxParams::ACTION) == 'resync') {
+        if (NextDomHelper::isStarted() && ConfigManager::byKey(ConfigKey::ENABLE_CRON, Common::CORE, 1, true) == 0) {
+            die(__('Tous les crons sont actuellement désactivés'));
         }
         $cron = new Cron();
         $cron->setClass('RepoMarket');
-        $cron->setFunction(init('test'));
+        $cron->setFunction(Utils::init(AjaxParams::TEST));
         $cron->setOnce(1);
         $cron->save();
         $cron->start();
     }
 } catch (\Exception $e) {
     echo $e->getMessage();
-    LogHelper::add('jeeEvent', 'error', $e->getMessage());
+    LogHelper::addError(LogTarget::JEE_EVENT, $e->getMessage());
 }

--- a/src/Market/RepoMarketDisplay.php
+++ b/src/Market/RepoMarketDisplay.php
@@ -2,6 +2,7 @@
 
 namespace NextDom\Repo;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Enums\ConfigKey;
 use NextDom\Enums\JeedomMarketCert;
 use NextDom\Exceptions\CoreException;
@@ -13,11 +14,11 @@ use NextDom\Managers\UpdateManager;
 
 AuthentificationHelper::isConnectedAsAdminOrFail();
 
-if (Utils::init('id') != '') {
+if (Utils::init(AjaxParams::ID) != '') {
     $market = RepoMarket::byId(Utils::init('id'));
 }
-if (Utils::init('logicalId') != '' && Utils::init('type') != '') {
-    $market = RepoMarket::byLogicalIdAndType(Utils::init('logicalId'), Utils::init('type'));
+if (Utils::init(AjaxParams::LOGICAL_ID) != '' && Utils::init(AjaxParams::TYPE) != '') {
+    $market = RepoMarket::byLogicalIdAndType(Utils::init(AjaxParams::LOGICAL_ID), Utils::init(AjaxParams::TYPE));
 }
 if (!isset($market)) {
     throw new CoreException('404 not found');
@@ -29,6 +30,31 @@ $update = UpdateManager::byLogicalId($market->getLogicalId());
 Utils::sendVarToJS('market_display_info', $marketInformations);
 $marketCertification = $market->getCertification();
 
+switch ($market->getType()) {
+    case 'widget':
+        $defaultImage = '/public/img/NextDom_Widget_Gray.png';
+        break;
+    case 'plugin':
+        $defaultImage = '/public/img/NextDom_Plugin_Gray.png';
+        break;
+    case 'script':
+        $defaultImage = '/public/img/NextDom_Script_Gray.png';
+        break;
+    default:
+        $defaultImage = 'public/img/NextDom_NoPicture_Gray.png';
+        break;
+}
+$urlPath = ConfigManager::byKey(ConfigKey::MARKET_ADDRESS) . '/' . $market->getImg('icon');
+
+$certificationClass = [
+    JeedomMarketCert::OFFICIAL => 'official',
+    JeedomMarketCert::ADVISED => 'advised',
+    JeedomMarketCert::LEGACY => 'legacy',
+    JeedomMarketCert::OBSOLETE => 'obsolete',
+    JeedomMarketCert::PREMIUM => 'premium',
+    JeedomMarketCert::PARTNER => 'partner'
+];
+
 ?>
 <style>
     .centered {
@@ -38,22 +64,7 @@ $marketCertification = $market->getCertification();
 <div class="row form-group">
     <div class="col-sm-2 centered">
         <?php
-        switch ($market->getType()) {
-            case 'widget':
-                $default_image = '/public/img/NextDom_Widget_Gray.png';
-                break;
-            case 'plugin':
-                $default_image = '/public/img/NextDom_Plugin_Gray.png';
-                break;
-            case 'script':
-                $default_image = '/public/img/NextDom_Script_Gray.png';
-                break;
-            default:
-                $default_image = 'public/img/NextDom_NoPicture_Gray.png';
-                break;
-        }
-        $urlPath = ConfigManager::byKey(ConfigKey::MARKET_ADDRESS) . '/' . $market->getImg('icon');
-        echo '<img src="' . $default_image . '" data-original="' . $urlPath . '"  class="lazy img-responsive" style="height: 150px;"/>';
+        echo '<img src="' . $defaultImage . '" data-original="' . $urlPath . '"  class="lazy img-responsive" style="height: 150px;"/>';
         ?>
     </div>
     <div class='col-sm-4'>
@@ -61,14 +72,6 @@ $marketCertification = $market->getCertification();
         <div class="marketAttr form-group market-modale-name" data-l1key="name"></div>
         <div class="span_author cursor form-group market-modale-author" data-author="<?php echo $market->getAuthor(); ?>">{{Développé par}} <?php echo $market->getAuthor(); ?></div>
         <?php
-        $certificationClass = [
-            JeedomMarketCert::OFFICIAL => 'official',
-            JeedomMarketCert::ADVISED => 'advised',
-            JeedomMarketCert::LEGACY => 'legacy',
-            JeedomMarketCert::OBSOLETE => 'obsolete',
-            JeedomMarketCert::PREMIUM => 'premium',
-            JeedomMarketCert::PARTNER => 'partner'
-        ];
         if ($marketCertification !== '' && array_key_exists($marketCertification, $certificationClass)) {
             echo '<div class="form-group market-modale-certification market-' . $certificationClass[$marketCertification] . '">' . $marketCertification . '</div>';
         }
@@ -241,12 +244,12 @@ $marketCertification = $market->getCertification();
                             </div>
                             <div class="col-sm-6 centered">
                                 <?php if (ConfigManager::byKey('market::apikey') != '' || (ConfigManager::byKey('market::username') != '' && ConfigManager::byKey('market::password') != '')) { ?>
-                                        <div class="form-group">
-                                            <label class="col-sm-4 control-label">{{Ma Note}}</label>
-                                        </div>
-                                        <div class="form-group">
-                                            <span><input style="display:none;" type="number" class="rating" id="in_myRating" data-max="5" data-empty-value="0" data-min="1" data-clearable="Effacer" value="<?php echo $market->getRating('user') ?>"/></span>
-                                        </div>
+                                    <div class="form-group">
+                                        <label class="col-sm-4 control-label">{{Ma Note}}</label>
+                                    </div>
+                                    <div class="form-group">
+                                        <span><input style="display:none;" type="number" class="rating" id="in_myRating" data-max="5" data-empty-value="0" data-min="1" data-clearable="Effacer" value="<?php echo $market->getRating('user') ?>"/></span>
+                                    </div>
                                 <?php }
                                 ?>
                             </div>
@@ -297,38 +300,38 @@ $marketCertification = $market->getCertification();
                                 <span class="marketAttr"><?php echo $market->getNbInstall() ?></span>
                             </div>
 
-                        <div class='col-sm-1'>
-                            <label class="control-label">{{Type}}</label><br/>
-                            <span class="marketAttr" data-l1key="type"></span>
-                        </div>
-                        <div class='col-sm-2'>
-                            <label class="control-label">{{Langue disponible}}</label><br/>
-                            <?php
-                            echo '<img src="/public/img/flags/francais.png" width="30" />';
-                            if ($market->getLanguage('en_US') == 1) {
-                                echo '<img src="/public/img/flags/anglais.png" width="30" />';
-                            }
-                            if ($market->getLanguage('de_DE') == 1) {
-                                echo '<img src="/public/img/flags/allemand.png" width="30" />';
-                            }
-                            if ($market->getLanguage('sp_SP') == 1) {
-                                echo '<img src="/public/img/flags/espagnol.png" width="30" />';
-                            }
-                            if ($market->getLanguage('ru_RU') == 1) {
-                                echo '<img src="/public/img/flags/russe.png" width="30" />';
-                            }
-                            if ($market->getLanguage('id_ID') == 1) {
-                                echo '<img src="/public/img/flags/indonesien.png" width="30" />';
-                            }
-                            if ($market->getLanguage('it_IT') == 1) {
-                                echo '<img src="/public/img/flags/italien.png" width="30" />';
-                            }
-                            ?>
-                        </div>
-                        <div class='col-sm-3'>
-                            <label class="control-label">{{Dernière mise à jour le}}</label><br/>
-                            <?php echo $market->getDatetime('stable') ?>
-                        </div>
+                            <div class='col-sm-1'>
+                                <label class="control-label">{{Type}}</label><br/>
+                                <span class="marketAttr" data-l1key="type"></span>
+                            </div>
+                            <div class='col-sm-2'>
+                                <label class="control-label">{{Langue disponible}}</label><br/>
+                                <?php
+                                echo '<img src="/public/img/flags/francais.png" width="30" />';
+                                if ($market->getLanguage('en_US') == 1) {
+                                    echo '<img src="/public/img/flags/anglais.png" width="30" />';
+                                }
+                                if ($market->getLanguage('de_DE') == 1) {
+                                    echo '<img src="/public/img/flags/allemand.png" width="30" />';
+                                }
+                                if ($market->getLanguage('sp_SP') == 1) {
+                                    echo '<img src="/public/img/flags/espagnol.png" width="30" />';
+                                }
+                                if ($market->getLanguage('ru_RU') == 1) {
+                                    echo '<img src="/public/img/flags/russe.png" width="30" />';
+                                }
+                                if ($market->getLanguage('id_ID') == 1) {
+                                    echo '<img src="/public/img/flags/indonesien.png" width="30" />';
+                                }
+                                if ($market->getLanguage('it_IT') == 1) {
+                                    echo '<img src="/public/img/flags/italien.png" width="30" />';
+                                }
+                                ?>
+                            </div>
+                            <div class='col-sm-3'>
+                                <label class="control-label">{{Dernière mise à jour le}}</label><br/>
+                                <?php echo $market->getDatetime('stable') ?>
+                            </div>
                     </form>
                 </div>
             </div>

--- a/src/Market/RepoMarketList.php
+++ b/src/Market/RepoMarketList.php
@@ -2,6 +2,7 @@
 
 namespace NextDom\Repo;
 
+use NextDom\Enums\AjaxParams;
 use NextDom\Helpers\AuthentificationHelper;
 use NextDom\Helpers\Utils;
 use NextDom\Managers\ConfigManager;
@@ -11,31 +12,31 @@ AuthentificationHelper::isConnectedAsAdminOrFail();
 
 $searchLimit = Utils::init('limit', 100);
 if ($searchLimit == 0) {
-  $searchLimit = '';
+    $searchLimit = '';
 }
-$type = Utils::init('type', null);
+$type = Utils::init(AjaxParams::TYPE, null);
 $categorie = Utils::init('categorie', null);
-$name = Utils::init('name', null);
+$name = Utils::init(AjaxParams::NAME, null);
 $author = Utils::init('author', null);
 if ($name == 'false') {
     $name = null;
 }
 if ($author == null && $name === null && $categorie === null && Utils::init('certification', null) === null && Utils::init('cost', null) === null && $type == 'plugin') {
     $default = true;
-    $markets = RepoMarket::byFilter(array(
+    $markets = RepoMarket::byFilter([
         'status' => 'stable',
         'type' => 'plugin',
         'timeState' => 'popular'
-    ));
-    $markets2 = RepoMarket::byFilter(array(
+    ]);
+    $markets2 = RepoMarket::byFilter([
         'status' => 'stable',
         'type' => 'plugin',
         'timeState' => 'newest'
-    ));
+    ]);
     $markets = array_merge($markets, $markets2);
 } else {
     $default = false;
-    $markets = RepoMarket::byFilter(array(
+    $markets = RepoMarket::byFilter([
         'status' => null,
         'type' => $type,
         'categorie' => $categorie,
@@ -45,7 +46,7 @@ if ($author == null && $name === null && $categorie === null && Utils::init('cer
         'timeState' => Utils::init('timeState'),
         'certification' => Utils::init('certification', null),
         'limit' => $searchLimit
-    ));
+    ]);
 }
 function buildUrl($_key, $_value)
 {
@@ -102,7 +103,7 @@ function displayWidgetName($_name)
             $result .= $name[2];
             break;
     }
-    return $result .= $name[3];
+    return $result . $name[3];
 }
 
 function displayWidgetType($_name)
@@ -158,6 +159,7 @@ function displayWidgetSubtype($_name)
     }
     return $result;
 }
+
 ?>
 
 <link rel="stylesheet" href="/public/css/pages/markets.css">
@@ -248,7 +250,7 @@ function displayWidgetSubtype($_name)
             if ($type == "") {
                 echo '{{Market Jeedom}}</h3>';
             } else {
-                echo ucfirst($type) .'{{ Jeedom}}</h3>';
+                echo ucfirst($type) . '{{ Jeedom}}</h3>';
             }
             if (ConfigManager::byKey('market::username') != '') {
                 echo '<span class="label label-info badge pull-right">' . ConfigManager::byKey('market::username');
@@ -267,7 +269,7 @@ function displayWidgetSubtype($_name)
             if (count($markets) >= $searchLimit) {
                 echo '<div>';
                 echo '<span class="alert alert-warning market-limited">{{Attention l\'affichage est limité à }}' . $searchLimit . ' {{résultats, utilisez les filtres ou la recherche si ce que vous cherchez n\'apparaît pas...}}</span>';
-                echo '<a class="btn btn-action pull-right" id="bt_resetSearchLimit" data-href="' . buildUrl('limit', '0') .'"><i aria-hidden="true" class="fas fa-times"></i>{{Sans limites}}</a>';
+                echo '<a class="btn btn-action pull-right" id="bt_resetSearchLimit" data-href="' . buildUrl('limit', '0') . '"><i aria-hidden="true" class="fas fa-times"></i>{{Sans limites}}</a>';
                 echo '</div>';
             } else {
                 echo '<div><span class="market-unlimited">' . count($markets);
@@ -278,7 +280,7 @@ function displayWidgetSubtype($_name)
                 }
                 echo ' {{disponibles dans cette catégorie...}}</span>';
                 if (count($markets) >= 100) {
-                    echo '<a class="btn btn-action pull-right" id="bt_SearchLimit" data-href="' . buildUrl('limit', '100') .'"><i aria-hidden="true" class="fas fa-filter"></i>{{Limiter à 100}}</a>';
+                    echo '<a class="btn btn-action pull-right" id="bt_SearchLimit" data-href="' . buildUrl('limit', '100') . '"><i aria-hidden="true" class="fas fa-filter"></i>{{Limiter à 100}}</a>';
                 }
                 echo '</div>';
             }
@@ -364,7 +366,7 @@ function displayWidgetSubtype($_name)
                         $certificationClass = '';
                 }
                 if ($market->getType() != 'widget') {
-                    echo '<div class="market-certification market-' . $certificationClass .'">' . strtoupper($market->getCertification()) . '</div>';
+                    echo '<div class="market-certification market-' . $certificationClass . '">' . strtoupper($market->getCertification()) . '</div>';
                 }
                 if ($install == 'notInstall') {
                     echo '<i aria-hidden="true" class="fas fa-check market-install"></i>';
@@ -383,7 +385,7 @@ function displayWidgetSubtype($_name)
                         $default_image = 'public/img/NextDom_NoPicture_Gray.png';
                 }
                 $urlPath = ConfigManager::byKey('market::address') . '/' . $market->getImg('icon');
-                echo '<div><img class="lazy lazyload market-icon" src="' . $default_image . '" data-original="'. $urlPath . '"/></div>';
+                echo '<div><img class="lazy lazyload market-icon" src="' . $default_image . '" data-original="' . $urlPath . '"/></div>';
                 echo '<span class="market-name">' . $shortName . '</span>';
                 echo '<span class="market-author"><i>{{par}}</i> ' . $market->getAuthor() . '</span>';
                 echo '<span class="market-rating">';
@@ -397,14 +399,14 @@ function displayWidgetSubtype($_name)
                 echo '</span>';
                 if ($cost > 0) {
                     echo '<span class="market-cost">';
-                        if ($market->getPurchase() == 1) {
-                            echo '<i aria-hidden="true" class="fas fa-check-circle"></i>';
-                        } else {
-                            if ($cost != $realCost) {
-                                echo '<span style="text-decoration:line-through;">' . $realCost . ' {{€}}</span>';
-                            }
-                            echo $cost . ' {{€}}';
+                    if ($market->getPurchase() == 1) {
+                        echo '<i aria-hidden="true" class="fas fa-check-circle"></i>';
+                    } else {
+                        if ($cost != $realCost) {
+                            echo '<span style="text-decoration:line-through;">' . $realCost . ' {{€}}</span>';
                         }
+                        echo $cost . ' {{€}}';
+                    }
                     echo '</span>';
                 } else {
                     if ($cost < 0) {
@@ -424,114 +426,114 @@ function displayWidgetSubtype($_name)
 </section>
 
 <script>
-    $(function () {
-        $("img.lazy").lazyload();
-        initTableSorter();
-        setTimeout(function(){
-            $('.pluginContainer').packery();
-        },200);
-        setTimeout(function () {
-            $('#table_market tbody tr.install').hide();
-        }, 500);
-        $('.bt_pluginFilter').on('click', function () {
-            $('#md_modal').load($(this).attr('data-href'));
-        });
-        $('#sel_certif').on('change', function () {
-            $('#md_modal').load($(this).attr('data-href') + '&certification=' + encodeURI($(this).value()));
-        });
-        $('#sel_categorie').on('change', function () {
-            $('#md_modal').load($(this).attr('data-href') + '&categorie=' + encodeURI($(this).value()));
-        });
-        $('#bt_search').on('click', function () {
-            $('#md_modal').load($(this).attr('data-href') + '&categorie=' + '&name=' + encodeURI($('#in_search').value()));
-        });
-        $('#bt_resetSearch').on('click', function () {
-            $('#md_modal').load($(this).attr('data-href'));
-        });
-        $('#in_search').keyup(function (e) {
-            marketFilterRepo();
-        });
-        $('#bt_returnMarketList').on('click', function () {
-            $('#md_modal').load($(this).attr('data-href'));
-        });
-        $('.marketMultiple').on('click', function () {
-            $('#md_modal').load($(this).attr('data-href') + '&name=' + encodeURI('.' + $(this).attr('data-market_name')));
-        });
-        $('.bt_installFilter').on('click', function () {
-            $('.bt_installFilter').removeClass('btn-primary').removeClass('btn-default');
-            $('.pluginContainer').show();
-            $('.marketOverload').show();
-            if ($(this).attr('data-state') == 1) {
-                $('.notInstall').hide();
-            }
-            if ($(this).attr('data-state') == -1) {
-                $('.install').hide();
-            }
-            $(this).addClass('btn-primary');
-            $('.bt_installFilter').each(function () {
-                if (!$(this).hasClass("btn-primary")) {
-                    $(this).addClass('btn-default');
-                }
-            });
-            $('.pluginContainer').each(function () {
-                var hasVisible = false;
-                $(this).find('.marketOverload').each(function () {
-                    if ($(this).is(':visible')) {
-                        hasVisible = true;
-                    }
-                });
-                if (hasVisible) {
-                    $('legend[data-category=' + $(this).attr('data-category') + ']').show();
-                    $(this).packery();
-                } else {
-                    $(this).hide();
-                    $('legend[data-category=' + $(this).attr('data-category') + ']').hide();
-                }
-            });
-        });
-        $('.marketOverload').on('click', function () {
-            $('#md_modal2').dialog({title: "{{Market Jeedom}}"});
-            $('#md_modal2').load('index.php?v=d&modal=update.display&type=' + $(this).attr('data-market_type') + '&id=' + $(this).attr('data-market_id') + '&repo=market').dialog('open');
-        });
-        $('#bt_marketCollapse').on('click',function(){
-           $('.panel-collapse').each(function () {
-              if (!$(this).hasClass("in")) {
-                  $(this).css({'height' : '' });
-                  $(this).addClass("in");
-              }
-           });
-           $('#bt_marketCollapse').hide();
-           $('#bt_marketUncollapse').show()
-        });
-        $('#bt_marketUncollapse').on('click',function(){
-           $('.panel-collapse').each(function () {
-              if ($(this).hasClass("in")) {
-                  $(this).removeClass("in");
-              }
-           });
-           $('#bt_marketUncollapse').hide();
-           $('#bt_marketCollapse').show()
-        });
-        $('#bt_resetSearchLimit').on('click', function () {
-            $('#md_modal').load($(this).attr('data-href'));
-        });
-        $('#bt_SearchLimit').on('click', function () {
-            $('#md_modal').load($(this).attr('data-href'));
-        });
+  $(function () {
+    $("img.lazy").lazyload();
+    initTableSorter();
+    setTimeout(function () {
+      $('.pluginContainer').packery();
+    }, 200);
+    setTimeout(function () {
+      $('#table_market tbody tr.install').hide();
+    }, 500);
+    $('.bt_pluginFilter').on('click', function () {
+      $('#md_modal').load($(this).attr('data-href'));
     });
-
-    function marketFilterRepo() {
-        var pluginValue = '';
-        var currentSearchValue = $('#in_search').val().toLowerCase();
-        $('.marketOverload').show();
-        $('.marketOverload').each(function () {
-            if (currentSearchValue != '') {
-                pluginValue = $(this).attr('data-name').toLowerCase();
-                if (pluginValue.indexOf(currentSearchValue) == -1) {
-                    $(this).hide();
-                }
-            }
+    $('#sel_certif').on('change', function () {
+      $('#md_modal').load($(this).attr('data-href') + '&certification=' + encodeURI($(this).value()));
+    });
+    $('#sel_categorie').on('change', function () {
+      $('#md_modal').load($(this).attr('data-href') + '&categorie=' + encodeURI($(this).value()));
+    });
+    $('#bt_search').on('click', function () {
+      $('#md_modal').load($(this).attr('data-href') + '&categorie=' + '&name=' + encodeURI($('#in_search').value()));
+    });
+    $('#bt_resetSearch').on('click', function () {
+      $('#md_modal').load($(this).attr('data-href'));
+    });
+    $('#in_search').keyup(function (e) {
+      marketFilterRepo();
+    });
+    $('#bt_returnMarketList').on('click', function () {
+      $('#md_modal').load($(this).attr('data-href'));
+    });
+    $('.marketMultiple').on('click', function () {
+      $('#md_modal').load($(this).attr('data-href') + '&name=' + encodeURI('.' + $(this).attr('data-market_name')));
+    });
+    $('.bt_installFilter').on('click', function () {
+      $('.bt_installFilter').removeClass('btn-primary').removeClass('btn-default');
+      $('.pluginContainer').show();
+      $('.marketOverload').show();
+      if ($(this).attr('data-state') == 1) {
+        $('.notInstall').hide();
+      }
+      if ($(this).attr('data-state') == -1) {
+        $('.install').hide();
+      }
+      $(this).addClass('btn-primary');
+      $('.bt_installFilter').each(function () {
+        if (!$(this).hasClass("btn-primary")) {
+          $(this).addClass('btn-default');
+        }
+      });
+      $('.pluginContainer').each(function () {
+        var hasVisible = false;
+        $(this).find('.marketOverload').each(function () {
+          if ($(this).is(':visible')) {
+            hasVisible = true;
+          }
         });
-        $('.pluginContainer').packery();
-    };
+        if (hasVisible) {
+          $('legend[data-category=' + $(this).attr('data-category') + ']').show();
+          $(this).packery();
+        } else {
+          $(this).hide();
+          $('legend[data-category=' + $(this).attr('data-category') + ']').hide();
+        }
+      });
+    });
+    $('.marketOverload').on('click', function () {
+      $('#md_modal2').dialog({title: "{{Market Jeedom}}"});
+      $('#md_modal2').load('index.php?v=d&modal=update.display&type=' + $(this).attr('data-market_type') + '&id=' + $(this).attr('data-market_id') + '&repo=market').dialog('open');
+    });
+    $('#bt_marketCollapse').on('click', function () {
+      $('.panel-collapse').each(function () {
+        if (!$(this).hasClass("in")) {
+          $(this).css({'height': ''});
+          $(this).addClass("in");
+        }
+      });
+      $('#bt_marketCollapse').hide();
+      $('#bt_marketUncollapse').show()
+    });
+    $('#bt_marketUncollapse').on('click', function () {
+      $('.panel-collapse').each(function () {
+        if ($(this).hasClass("in")) {
+          $(this).removeClass("in");
+        }
+      });
+      $('#bt_marketUncollapse').hide();
+      $('#bt_marketCollapse').show()
+    });
+    $('#bt_resetSearchLimit').on('click', function () {
+      $('#md_modal').load($(this).attr('data-href'));
+    });
+    $('#bt_SearchLimit').on('click', function () {
+      $('#md_modal').load($(this).attr('data-href'));
+    });
+  });
+
+  function marketFilterRepo() {
+    var pluginValue = '';
+    var currentSearchValue = $('#in_search').val().toLowerCase();
+    $('.marketOverload').show();
+    $('.marketOverload').each(function () {
+      if (currentSearchValue != '') {
+        pluginValue = $(this).attr('data-name').toLowerCase();
+        if (pluginValue.indexOf(currentSearchValue) == -1) {
+          $(this).hide();
+        }
+      }
+    });
+    $('.pluginContainer').packery();
+  };
 </script>

--- a/src/Model/DataClass/SystemHealth.php
+++ b/src/Model/DataClass/SystemHealth.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace NextDom\Model\DataClass;
+
+
+class SystemHealth
+{
+    public $icon;
+    public $nameCode;
+    public $state;
+    public $result;
+    public $comment;
+    public $key;
+
+    public function __construct($icon, $nameCode, $state, $result, $comment, $key)
+    {
+        $this->icon = $icon;
+        $this->nameCode = $nameCode;
+        $this->state = $state;
+        $this->result = $result;
+        $this->comment = $comment;
+        $this->key = $key;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getIcon()
+    {
+        return $this->icon;
+    }
+
+    /**
+     * Get health name
+     * @return string
+     * @throws \Exception
+     */
+    public function getName()
+    {
+        return __($this->nameCode);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * @param mixed $state
+     * @return SystemHealth
+     */
+    public function setState($state)
+    {
+        $this->state = $state;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param mixed $result
+     */
+    public function setResult($result)
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
+     * @param mixed $comment
+     */
+    public function setComment($comment)
+    {
+        $this->comment = $comment;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+}

--- a/src/Model/Entity/Cache.php
+++ b/src/Model/Entity/Cache.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\DateFormat;
 use NextDom\Helpers\Utils;
 use NextDom\Managers\CacheManager;
 
@@ -38,7 +39,7 @@ class Cache
      */
     public function save()
     {
-        $this->setDatetime(date('Y-m-d H:i:s'));
+        $this->setDatetime(date(DateFormat::FULL));
         if ($this->getLifetime() == 0) {
             return CacheManager::getCache()->save($this->getKey(), $this);
         } else {

--- a/src/Model/Entity/Cron.php
+++ b/src/Model/Entity/Cron.php
@@ -18,6 +18,8 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\DateFormat;
+use NextDom\Enums\LogTarget;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\LogHelper;
@@ -147,7 +149,8 @@ class Cron implements EntityInterface
      *
      * @return bool True is task is enabled
      */
-    public function isEnabled() {
+    public function isEnabled()
+    {
         return $this->enable == 1;
     }
 
@@ -519,7 +522,7 @@ class Cron implements EntityInterface
             $this->setState('stop');
             $this->setPID();
         } else {
-            LogHelper::add('cron', 'info', __('Arrêt de ') . $this->getClass() . '::' . $this->getFunction() . '(), PID : ' . $this->getPID());
+            LogHelper::addInfo(LogTarget::CRON, __('Arrêt de ') . $this->getClass() . '::' . $this->getFunction() . '(), PID : ' . $this->getPID());
             if ($this->getPID() > 0) {
                 SystemHelper::kill($this->getPID());
                 $retry = 0;
@@ -651,7 +654,7 @@ class Cron implements EntityInterface
                 return true;
             }
         } catch (\Exception $e) {
-            LogHelper::add('cron', 'debug', 'Error on isDue : ' . $e->getMessage() . ', cron : ' . $this->getSchedule());
+            LogHelper::addDebug(LogTarget::CRON, 'Error on isDue : ' . $e->getMessage() . ', cron : ' . $this->getSchedule());
         }
         return false;
     }
@@ -676,7 +679,7 @@ class Cron implements EntityInterface
     {
         try {
             $cronExpression = new \Cron\CronExpression($this->getSchedule(), new \Cron\FieldFactory);
-            return $cronExpression->getNextRunDate()->format('Y-m-d H:i:s');
+            return $cronExpression->getNextRunDate()->format(DateFormat::FULL);
         } catch (\Exception $e) {
 
         }

--- a/src/Model/Entity/EqLogic.php
+++ b/src/Model/Entity/EqLogic.php
@@ -19,11 +19,14 @@ namespace NextDom\Model\Entity;
 
 use NextDom\Enums\BatteryStatus;
 use NextDom\Enums\CacheKey;
+use NextDom\Enums\CmdType;
+use NextDom\Enums\Common;
 use NextDom\Enums\ConfigKey;
 use NextDom\Enums\DateFormat;
 use NextDom\Enums\EqLogicCategory;
 use NextDom\Enums\EqLogicConfigKey;
 use NextDom\Enums\EqLogicViewType;
+use NextDom\Enums\NextDomObj;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\AuthentificationHelper;
 use NextDom\Helpers\DBHelper;
@@ -38,8 +41,8 @@ use NextDom\Managers\EqLogicManager;
 use NextDom\Managers\EqRealManager;
 use NextDom\Managers\EventManager;
 use NextDom\Managers\InteractDefManager;
-use NextDom\Managers\MessageManager;
 use NextDom\Managers\JeeObjectManager;
+use NextDom\Managers\MessageManager;
 use NextDom\Managers\PlanHeaderManager;
 use NextDom\Managers\PluginManager;
 use NextDom\Managers\ScenarioManager;
@@ -76,8 +79,6 @@ class EqLogic implements EntityInterface
     protected $_timeoutUpdated = false;
     protected $_batteryUpdated = false;
     protected $_changed = false;
-    private $_cmds = [];
-
     /**
      * @var integer
      *
@@ -176,165 +177,16 @@ class EqLogic implements EntityInterface
      * @ORM\Column(name="object_id", type="integer", nullable=true)
      */
     protected $object_id;
+    private $_cmds = [];
 
     /**
-     * Get Id
+     * Get eqLogic visibility
      *
-     * @return int EqLogic id
+     * @return bool True if eqLogic is visible
      */
-    public function getId()
+    public function isVisible()
     {
-        return $this->id;
-    }
-
-    /**
-     * Change id
-     *
-     * @param int|string $newId New id or '' if you want to reset id
-     *
-     * @return $this
-     */
-    public function setId($newId)
-    {
-        $this->_changed = Utils::attrChanged($this->_changed, $this->id, $newId);
-        $this->id = $newId;
-        return $this;
-    }
-
-    /**
-     * Get EqLogic name
-     *
-     * @return string EqLogic name
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * Set eqLogic name
-     *
-     * @param string $name New name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        // Remove forbidden characters
-        $name = str_replace(['&', '#', ']', '[', '%', "'", "\\", "/"], '', $name);
-        if ($name !== $this->name) {
-            $this->_needRefreshWidget = true;
-            $this->_changed = true;
-        }
-        $this->name = $name;
-        return $this;
-    }
-
-    /**
-     * Get generic type for simple eqLogic
-     *
-     * @return string Generic type
-     */
-    public function getGenericType()
-    {
-        return $this->generic_type;
-    }
-
-    /**
-     * Set generic type for simple EqLogic
-     *
-     * @param string $genericType Generic type
-     *
-     * @return $this
-     */
-    public function setGenericType($genericType)
-    {
-        $this->_changed = Utils::attrChanged($this->_changed, $this->generic_type, $genericType);
-        $this->generic_type = $genericType;
-        return $this;
-    }
-
-    /**
-     * Set logicalId (Id used by plugins)
-     *
-     * @return string Logical Id
-     */
-    public function getLogicalId()
-    {
-        return $this->logicalId;
-    }
-
-    /**
-     * Get logicalId (Id used by plugins)
-     *
-     * @param string $logicalId logical Id
-     *
-     * @return $this
-     */
-    public function setLogicalId($logicalId)
-    {
-        $this->_changed = Utils::attrChanged($this->_changed, $this->logicalId, $logicalId);
-        $this->logicalId = $logicalId;
-        return $this;
-    }
-
-    /**
-     * Get eqLogic type name (linked plugin)
-     *
-     * @return string EqLogic type (plugin ID)
-     */
-    public function getEqType_name()
-    {
-        return $this->eqType_name;
-    }
-
-
-    /**
-     * Set eqLogic type name (linked plugin)
-     *
-     * @param string $eqTypeName EqLogic type (plugin ID)
-     *
-     * @return $this
-     */
-    public function setEqType_name($eqTypeName)
-    {
-        $this->_changed = Utils::attrChanged($this->_changed, $this->eqType_name, $eqTypeName);
-        $this->eqType_name = $eqTypeName;
-        return $this;
-    }
-
-    /**
-     * Get object specific configuration data
-     *
-     * @param string $configKey Configuration key
-     * @param string $defaultValue Default value if not found
-     *
-     * @return mixed
-     */
-    public function getConfiguration($configKey = '', $defaultValue = '')
-    {
-        return Utils::getJsonAttr($this->configuration, $configKey, $defaultValue);
-    }
-
-    /**
-     * Set object specific configuration data
-     *
-     * @param string $configKey Configuration key
-     * @param string $configValue Value to define
-     *
-     * @return $this
-     */
-    public function setConfiguration($configKey, $configValue)
-    {
-        if (in_array($configKey, [EqLogicConfigKey::BATTERY_WARNING_THRESHOLD, EqLogicConfigKey::BATTERY_DANGER_THRESHOLD])) {
-            if ($this->getConfiguration($configKey, '') != $configValue) {
-                $this->_batteryUpdated = true;
-            }
-        }
-        $configuration = Utils::setJsonAttr($this->configuration, $configKey, $configValue);
-        $this->_changed = Utils::attrChanged($this->_changed, $this->configuration, $configuration);
-        $this->configuration = $configuration;
-        return $this;
+        return $this->getIsVisible() == 1;
     }
 
     /**
@@ -366,170 +218,6 @@ class EqLogic implements EntityInterface
             $this->_changed = true;
             $this->isVisible = $isVisible;
         }
-        return $this;
-    }
-
-    /**
-     * Get eqLogic enabled state
-     *
-     * @param int $defaultValue Default value if not set
-     *
-     * @return int
-     */
-    public function getIsEnable($defaultValue = 0)
-    {
-        if ($this->isEnable == '' || !is_numeric($this->isEnable)) {
-            return $defaultValue;
-        }
-        return $this->isEnable;
-    }
-
-    /**
-     * Set if the eqLogic is enabled
-     *
-     * @param int $isEnable 1 if eqLogic is enabled or 0 to disable
-     *
-     * @return $this
-     *
-     * @throws \Exception
-     */
-    public function setIsEnable($isEnable)
-    {
-        if ($this->isEnable != $isEnable) {
-            $this->_needRefreshWidget = true;
-            $this->_changed = true;
-        }
-        if ($isEnable) {
-            $this->setStatus(['lastCommunication' => date(DateFormat::FULL), 'timeout' => 0]);
-        }
-        $this->isEnable = $isEnable;
-        return $this;
-    }
-
-    /**
-     * Get eqLogic timeout
-     *
-     * @param int|string $defaultValue Default value if timeout is not define
-     *
-     * @return int|null
-     */
-    public function getTimeout($defaultValue = null)
-    {
-        if ($this->timeout == '' || !is_numeric($this->timeout)) {
-            return $defaultValue;
-        }
-        return $this->timeout;
-    }
-
-    /**
-     * Get eqLogic timeout
-     *
-     * @param int $timeout Timeout
-     *
-     * @return $this
-     */
-    public function setTimeout($timeout)
-    {
-        if ($timeout == '' || is_nan(intval($timeout)) || $timeout < 1) {
-            $timeout = null;
-        }
-        if ($timeout != $this->getTimeout()) {
-            $this->_timeoutUpdated = true;
-            $this->_changed = true;
-        }
-        $this->timeout = $timeout;
-        return $this;
-    }
-
-
-    /**
-     * Test if the object belongs to a category
-     *
-     * @param string $categoryKey Key of the category
-     * @param string $defaultValue Default value if not set
-     *
-     * @return mixed 1 if object belongs the category
-     */
-    public function getCategory($categoryKey = '', $defaultValue = '')
-    {
-        if ($categoryKey == 'other' && strpos($this->category, "1") === false) {
-            return 1;
-        }
-        return Utils::getJsonAttr($this->category, $categoryKey, $defaultValue);
-    }
-
-    /**
-     * Define if the object belongs to a category
-     *
-     * @param string $categoryKey Key of the category
-     * @param int $belong 1 if eqLogic belong the category or 0
-     *
-     * @return $this
-     */
-    public function setCategory($categoryKey, $belong)
-    {
-        if ($this->getCategory($categoryKey) != $belong) {
-            $this->_needRefreshWidget = true;
-        }
-        $category = Utils::setJsonAttr($this->category, $categoryKey, $belong);
-        $this->_changed = Utils::attrChanged($this->_changed, $this->category, $category);
-        $this->category = $category;
-        return $this;
-    }
-
-    /**
-     * Get primary category
-     *
-     * @return string
-     */
-    public function getPrimaryCategory()
-    {
-        $categoryOrder = [
-            EqLogicCategory::SECURITY,
-            EqLogicCategory::HEATING,
-            EqLogicCategory::LIGHT,
-            EqLogicCategory::AUTOMATISM,
-            EqLogicCategory::ENERGY,
-            EqLogicCategory::MULTIMEDIA
-            ];
-        foreach ($categoryOrder as $categoryCode) {
-            if ($this->getCategory($categoryCode, 0) == 1) {
-                return $categoryCode;
-            }
-        }
-        return '';
-    }
-
-    /**
-     * Get display parameters
-     *
-     * @param string $displayKey Parameter key
-     * @param mixed $defaultValue Default value if not defined
-     *
-     * @return mixed Parameters depends of the key
-     */
-    public function getDisplay($displayKey = '', $defaultValue = '')
-    {
-        return Utils::getJsonAttr($this->display, $displayKey, $defaultValue);
-    }
-
-    /**
-     * Set a display parameters
-     *
-     * @param string $displayKey Key for storage
-     * @param mixed $displayValue Data to store
-     *
-     * @return $this
-     */
-    public function setDisplay($displayKey, $displayValue)
-    {
-        if ($this->getDisplay($displayKey) != $displayValue) {
-            $this->_needRefreshWidget = true;
-        }
-        $display = Utils::setJsonAttr($this->display, $displayKey, $displayValue);
-        $this->_changed = Utils::attrChanged($this->_changed, $this->display, $display);
-        $this->display = $display;
-
         return $this;
     }
 
@@ -583,31 +271,6 @@ class EqLogic implements EntityInterface
     }
 
     /**
-     * Get list of eqLogic tags
-     *
-     * @return mixed List of eqLogic tags
-     */
-    public function getTags()
-    {
-        return $this->tags;
-    }
-
-    /**
-     * Define list of eqLogics tags
-     *
-     * @param mixed $tags List of tags
-     *
-     * @return $this
-     */
-    public function setTags($tags)
-    {
-        $_tags = str_replace(["'", '<', '>'], "", $tags);
-        $this->_changed = Utils::attrChanged($this->_changed, $this->tags, $_tags);
-        $this->tags = $_tags;
-        return $this;
-    }
-
-    /**
      * TODO: Unused
      * @param null $defaultValue
      * @return int|null
@@ -643,109 +306,6 @@ class EqLogic implements EntityInterface
         return EqRealManager::byId($this->eqReal_id);
     }
 
-
-    /**
-     * Get id of the attached object
-     *
-     * @return int Id of the attached object
-     */
-    public function getObject_id()
-    {
-        return $this->object_id;
-    }
-
-    /**
-     * Set attached room id
-     *
-     * @param int $object_id Room id
-     *
-     * @return $this
-     */
-    public function setObject_id($object_id = null)
-    {
-        $object_id = (!is_numeric($object_id)) ? null : $object_id;
-        $this->_changed = Utils::attrChanged($this->_changed, $this->object_id, $object_id);
-        $this->object_id = $object_id;
-        return $this;
-    }
-
-
-    /**
-     * Get attached object
-     *
-     * @return JeeObject|null Attached object or null
-     *
-     * @throws \Exception
-     */
-    public function getObject()
-    {
-        if ($this->_object === null) {
-            $this->setObject(JeeObjectManager::byId($this->object_id));
-        }
-        return $this->_object;
-    }
-
-
-    /**
-     * Set attached object
-     *
-     * @param JeeObject $_object Object to link
-     *
-     * @return $this
-     */
-    public function setObject($_object)
-    {
-        $this->_object = $_object;
-        return $this;
-    }
-
-    /**
-     * Get debug state
-     *
-     * @return bool True if debug is activated
-     */
-    public function getDebug()
-    {
-        return $this->_debug;
-    }
-
-    /**
-     * Set debug state
-     *
-     * @param bool $newDebugState True for activate debug
-     */
-    public function setDebug($newDebugState)
-    {
-        if ($newDebugState) {
-            echo "Mode debug activé\n";
-        }
-        $this->_debug = $newDebugState;
-    }
-
-
-    /**
-     * Get changed data state
-     *
-     * @return bool True if a data changed since last save
-     */
-    public function getChanged()
-    {
-        return $this->_changed;
-    }
-
-    /**
-     * Set changed data state
-     *
-     * @param bool $newChangedStatus New data changed state
-     *
-     * @return $this
-     */
-    public function setChanged($newChangedStatus)
-    {
-        $this->_changed = $newChangedStatus;
-        return $this;
-    }
-
     /**
      * Get data in cache linked to the eqLogic
      *
@@ -763,6 +323,30 @@ class EqLogic implements EntityInterface
     }
 
     /**
+     * Get Id
+     *
+     * @return int EqLogic id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Change id
+     *
+     * @param int|string $newId New id or '' if you want to reset id
+     *
+     * @return $this
+     */
+    public function setId($newId)
+    {
+        $this->_changed = Utils::attrChanged($this->_changed, $this->id, $newId);
+        $this->id = $newId;
+        return $this;
+    }
+
+    /**
      * Store data in cache
      *
      * @param string $cacheKey Key of the data
@@ -773,6 +357,297 @@ class EqLogic implements EntityInterface
     public function setCache($cacheKey, $cacheValue = null)
     {
         CacheManager::set(CacheKey::EQLOGIC_CACHE_ATTR . $this->getId(), Utils::setJsonAttr(CacheManager::byKey(CacheKey::EQLOGIC_CACHE_ATTR . $this->getId())->getValue(), $cacheKey, $cacheValue));
+    }
+
+    /**
+     * Get HTML code for battery widget
+     *
+     * @param string $display Display type (dashboard or mobile)
+     *
+     * @return string HTML code
+     *
+     * @throws \Exception
+     */
+    public function batteryWidget(string $display = EqLogicViewType::DASHBOARD): string
+    {
+        $level = 'good';
+        $numericLevel = '3';
+        $batteryType = $this->getConfiguration(EqLogicConfigKey::BATTERY_TYPE, 'none');
+        $batteryTime = $this->getConfiguration(EqLogicConfigKey::BATTERY_TIME, 'NA');
+        $lastBatteryCheck = 'NA';
+        if ($batteryTime !== 'NA') {
+            $lastBatteryCheck = round((strtotime(date(DateFormat::FULL_DAY)) - strtotime(date(DateFormat::FULL_DAY, strtotime($batteryTime)))) / 86400, 1);
+        }
+        if (strpos($batteryType, ' ') !== false) {
+            $batteryType = substr(strrchr($batteryType, " "), 1);
+        }
+        $plugins = $this->getEqType_name();
+        $attachedObject = __('Aucun');
+        if (is_object($this->getObject())) {
+            $attachedObject = $this->getObject()->getName();
+        }
+        if ($this->getStatus('battery') <= $this->getConfiguration(EqLogicConfigKey::BATTERY_DANGER_THRESHOLD, ConfigManager::byKey('battery::danger'))) {
+            $level = 'critical';
+            $numericLevel = '0';
+        } else if ($this->getStatus('battery') <= $this->getConfiguration(EqLogicConfigKey::BATTERY_WARNING_THRESHOLD, ConfigManager::byKey('battery::warning'))) {
+            $level = 'warning';
+            $numericLevel = '1';
+        } else if ($this->getStatus('battery') <= 75) {
+            $numericLevel = '2';
+        }
+        $cssClassAttr = $level . ' ' . $batteryType . ' ' . $plugins . ' ' . $attachedObject;
+        $idAttr = $level . '__' . $batteryType . '__' . $plugins . '__' . $attachedObject;
+        $html = '<div id="' . $idAttr . '" class="eqLogic eqLogic-widget eqLogic-battery ' . $cssClassAttr . '">';
+        if ($display == 'mobile') {
+            $html .= '<span class="eqLogic-name">' . $this->getName() . '</span>';
+        } else {
+            $html .= '<a class="eqLogic-name" href="' . $this->getLinkToConfiguration() . '">' . $this->getName() . '</a>';
+        }
+        $html .= '<span class="eqLogic-place">' . $attachedObject . '</span>';
+        $html .= '<div class="eqLogic-battery-icon"><i class="icon nextdom-battery' . $numericLevel . ' tooltips" title="' . $this->getStatus('battery', -2) . '%"></i></div>';
+        $html .= '<div class="eqLogic-percent">' . $this->getStatus('battery', -2) . '%</div>';
+        $html .= '<div>' . __('Le') . ' ' . date("Y-m-d H:i:s", strtotime($this->getStatus('batteryDatetime', __('inconnue')))) . '</div>';
+        if ($this->getConfiguration('battery_type', '') != '') {
+            $html .= '<span class="informations pull-right" title="Piles">' . $this->getConfiguration('battery_type', '') . '</span>';
+        }
+        $html .= '<span class="informations pull-left" title="Plugin">' . ucfirst($this->getEqType_name()) . '</span>';
+        if ($this->getConfiguration(EqLogicConfigKey::BATTERY_DANGER_THRESHOLD) != '' || $this->getConfiguration(EqLogicConfigKey::BATTERY_WARNING_THRESHOLD) != '') {
+            $html .= '<i class="manual-threshold icon techno-fingerprint41 pull-right" title="Seuil manuel défini"></i>';
+        }
+        if ($batteryTime != 'NA') {
+            $html .= '<i class="icon divers-calendar2 pull-right eqLogic-calendar" title="Pile(s) changée(s) il y a ' . $lastBatteryCheck . ' jour(s) (' . $batteryTime . ')"> (' . $lastBatteryCheck . 'j)</i>';
+        } else {
+            $html .= '<i class="icon divers-calendar2 pull-right eqLogic-calendar" title="Pas de date de changement de pile(s) renseignée"></i>';
+        }
+        return $html . '</div>';
+    }
+
+    /**
+     * Get object specific configuration data
+     *
+     * @param string $configKey Configuration key
+     * @param string $defaultValue Default value if not found
+     *
+     * @return mixed
+     */
+    public function getConfiguration($configKey = '', $defaultValue = '')
+    {
+        return Utils::getJsonAttr($this->configuration, $configKey, $defaultValue);
+    }
+
+    /**
+     * Set object specific configuration data
+     *
+     * @param string $configKey Configuration key
+     * @param string $configValue Value to define
+     *
+     * @return $this
+     */
+    public function setConfiguration($configKey, $configValue)
+    {
+        if (in_array($configKey, [EqLogicConfigKey::BATTERY_WARNING_THRESHOLD, EqLogicConfigKey::BATTERY_DANGER_THRESHOLD]) &&
+            $this->getConfiguration($configKey, '') != $configValue) {
+            $this->_batteryUpdated = true;
+        }
+        $configuration = Utils::setJsonAttr($this->configuration, $configKey, $configValue);
+        $this->_changed = Utils::attrChanged($this->_changed, $this->configuration, $configuration);
+        $this->configuration = $configuration;
+        return $this;
+    }
+
+    /**
+     * Get eqLogic type name (linked plugin)
+     *
+     * @return string EqLogic type (plugin ID)
+     */
+    public function getEqType_name()
+    {
+        return $this->eqType_name;
+    }
+
+    /**
+     * Set eqLogic type name (linked plugin)
+     *
+     * @param string $eqTypeName EqLogic type (plugin ID)
+     *
+     * @return $this
+     */
+    public function setEqType_name($eqTypeName)
+    {
+        $this->_changed = Utils::attrChanged($this->_changed, $this->eqType_name, $eqTypeName);
+        $this->eqType_name = $eqTypeName;
+        return $this;
+    }
+
+    /**
+     * Get attached object
+     *
+     * @return JeeObject|null Attached object or null
+     *
+     * @throws \Exception
+     */
+    public function getObject()
+    {
+        if ($this->_object === null) {
+            $this->setObject(JeeObjectManager::byId($this->object_id));
+        }
+        return $this->_object;
+    }
+
+    /**
+     * Set attached object
+     *
+     * @param JeeObject $_object Object to link
+     *
+     * @return $this
+     */
+    public function setObject($_object)
+    {
+        $this->_object = $_object;
+        return $this;
+    }
+
+    /**
+     * Get status from cache
+     *
+     * @param string $statusKey Status key
+     * @param string $defaultValue Default value of the status
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getStatus($statusKey = '', $defaultValue = '')
+    {
+        $status = CacheManager::byKey(CacheKey::EQLOGIC_STATUS_ATTR . $this->getId())->getValue();
+        return Utils::getJsonAttr($status, $statusKey, $defaultValue);
+    }
+
+    /**
+     * Get EqLogic name
+     *
+     * @return string EqLogic name
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set eqLogic name
+     *
+     * @param string $name New name
+     *
+     * @return $this
+     */
+    public function setName($name)
+    {
+        // Remove forbidden characters
+        $name = str_replace(['&', '#', ']', '[', '%', "'", "\\", "/"], '', $name);
+        if ($name !== $this->name) {
+            $this->_needRefreshWidget = true;
+            $this->_changed = true;
+        }
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * Get configuration URL
+     *
+     * @return string Configuration URL
+     */
+    public function getLinkToConfiguration()
+    {
+        return 'index.php?v=d&p=' . $this->getEqType_name() . '&m=' . $this->getEqType_name() . '&id=' . $this->getId();
+    }
+
+    /**
+     * Check and update a command information
+     *
+     * @param string|Cmd $logicalId Logical id or cmd object
+     * @param mixed $newValue Value to update
+     * @param null $updateEventTime Date of the update
+     *
+     * @return bool True if new value is different of the old value.
+     *
+     * @throws \Exception
+     */
+    public function checkAndUpdateCmd($logicalId, $newValue, $updateEventTime = null)
+    {
+        if (!$this->isEnabled()) {
+            return false;
+        }
+        if (is_object($logicalId)) {
+            $cmd = $logicalId;
+        } else {
+            $cmd = $this->getCmd(CmdType::INFO, $logicalId);
+        }
+        if (!is_object($cmd)) {
+            return false;
+        }
+        $oldValue = $cmd->execCmd();
+        if (($oldValue != $cmd->formatValue($newValue)) || $oldValue === '') {
+            $cmd->event($newValue, $updateEventTime);
+            return true;
+        }
+        if ($updateEventTime !== null && $updateEventTime !== false) {
+            if (strtotime($cmd->getCollectDate()) < strtotime($updateEventTime)) {
+                $cmd->event($newValue, $updateEventTime);
+                return true;
+            }
+        } else if ($cmd->getConfiguration(EqLogicConfigKey::REPEAT_EVENT_MANAGEMENT, 'auto') == 'always') {
+            $cmd->event($newValue, $updateEventTime);
+            return true;
+        }
+        $cmd->setCache('collectDate', date(DateFormat::FULL));
+        return false;
+    }
+
+    /**
+     * Get eqLogic enable status
+     *
+     * @return bool True if eqLogic is enabled
+     */
+    public function isEnabled()
+    {
+        return $this->getIsEnable() == 1;
+    }
+
+    /**
+     * Get eqLogic enabled state
+     *
+     * @param int $defaultValue Default value if not set
+     *
+     * @return int
+     */
+    public function getIsEnable($defaultValue = 0)
+    {
+        if ($this->isEnable == '' || !is_numeric($this->isEnable)) {
+            return $defaultValue;
+        }
+        return $this->isEnable;
+    }
+
+    /**
+     * Set if the eqLogic is enabled
+     *
+     * @param int $isEnable 1 if eqLogic is enabled or 0 to disable
+     *
+     * @return $this
+     *
+     * @throws \Exception
+     */
+    public function setIsEnable($isEnable)
+    {
+        if ($this->isEnable != $isEnable) {
+            $this->_needRefreshWidget = true;
+            $this->_changed = true;
+        }
+        if ($isEnable) {
+            $this->setStatus(['lastCommunication' => date(DateFormat::FULL), 'timeout' => 0]);
+        }
+        $this->isEnable = $isEnable;
+        return $this;
     }
 
     /**
@@ -811,223 +686,6 @@ class EqLogic implements EntityInterface
             $this->_cmds[$logicalId . '.' . $multiple . '.' . $cmdType] = $result;
         }
         return $result;
-    }
-
-    /**
-     * Get status from cache
-     *
-     * @param string $statusKey Status key
-     * @param string $defaultValue Default value of the status
-     *
-     * @return mixed
-     * @throws \Exception
-     */
-    public function getStatus($statusKey = '', $defaultValue = '')
-    {
-        $status = CacheManager::byKey(CacheKey::EQLOGIC_STATUS_ATTR . $this->getId())->getValue();
-        return Utils::getJsonAttr($status, $statusKey, $defaultValue);
-    }
-
-    /**
-     * Get HTML code for battery widget
-     *
-     * @param string $display Display type (dashboard or mobile)
-     *
-     * @return string HTML code
-     *
-     * @throws \Exception
-     */
-    public function batteryWidget(string $display = EqLogicViewType::DASHBOARD): string
-    {
-        $level = 'good';
-        $numericLevel = '3';
-        $batteryType = $this->getConfiguration(EqLogicConfigKey::BATTERY_TYPE, 'none');
-        $batteryTime = $this->getConfiguration(EqLogicConfigKey::BATTERY_TIME, 'NA');
-        $lastBatteryCheck = 'NA';
-        if ($batteryTime !== 'NA') {
-            $lastBatteryCheck = round((strtotime(date(DateFormat::FULL_DAY)) - strtotime(date(DateFormat::FULL_DAY, strtotime($batteryTime)))) / 86400, 1);
-        }
-        if (strpos($batteryType, ' ') !== false) {
-            $batteryType = substr(strrchr($batteryType, " "), 1);
-        }
-        $plugins = $this->getEqType_name();
-        $attachedObject = 'Aucun';
-        if (is_object($this->getObject())) {
-            $attachedObject = $this->getObject()->getName();
-        }
-        if ($this->getStatus('battery') <= $this->getConfiguration(EqLogicConfigKey::BATTERY_DANGER_THRESHOLD, ConfigManager::byKey('battery::danger'))) {
-            $level = 'critical';
-            $numericLevel = '0';
-        } else if ($this->getStatus('battery') <= $this->getConfiguration(EqLogicConfigKey::BATTERY_WARNING_THRESHOLD, ConfigManager::byKey('battery::warning'))) {
-            $level = 'warning';
-            $numericLevel = '1';
-        } else if ($this->getStatus('battery') <= 75) {
-            $numericLevel = '2';
-        }
-        $cssClassAttr = $level . ' ' . $batteryType . ' ' . $plugins . ' ' . $attachedObject;
-        $idAttr = $level . '__' . $batteryType . '__' . $plugins . '__' . $attachedObject;
-        $html = '<div id="' . $idAttr . '" class="eqLogic eqLogic-widget eqLogic-battery ' . $cssClassAttr . '">';
-        if ($display == 'mobile') {
-            $html .= '<span class="eqLogic-name">' . $this->getName() . '</span>';
-        } else {
-            $html .= '<a class="eqLogic-name" href="' . $this->getLinkToConfiguration() . '">' . $this->getName() . '</a>';
-        }
-        $html .= '<span class="eqLogic-place">' . $attachedObject . '</span>';
-        $html .= '<div class="eqLogic-battery-icon"><i class="icon nextdom-battery' . $numericLevel . ' tooltips" title="' . $this->getStatus('battery', -2) . '%"></i></div>';
-        $html .= '<div class="eqLogic-percent">' . $this->getStatus('battery', -2) . '%</div>';
-        $html .= '<div>' . __('Le') . ' ' . date("Y-m-d H:i:s", strtotime($this->getStatus('batteryDatetime', __('inconnue')))) . '</div>';
-        if ($this->getConfiguration('battery_type', '') != '') {
-            $html .= '<span class="informations pull-right" title="Piles">' . $this->getConfiguration('battery_type', '') . '</span>';
-        }
-        $html .= '<span class="informations pull-left" title="Plugin">' . ucfirst($this->getEqType_name()) . '</span>';
-        if ($this->getConfiguration(EqLogicConfigKey::BATTERY_DANGER_THRESHOLD) != '' || $this->getConfiguration(EqLogicConfigKey::BATTERY_WARNING_THRESHOLD) != '') {
-            $html .= '<i class="manual-threshold icon techno-fingerprint41 pull-right" title="Seuil manuel défini"></i>';
-        }
-        if ($batteryTime != 'NA') {
-            $html .= '<i class="icon divers-calendar2 pull-right eqLogic-calendar" title="Pile(s) changée(s) il y a ' . $lastBatteryCheck . ' jour(s) (' . $batteryTime . ')"> (' . $lastBatteryCheck . 'j)</i>';
-        } else {
-            $html .= '<i class="icon divers-calendar2 pull-right eqLogic-calendar" title="Pas de date de changement de pile(s) renseignée"></i>';
-        }
-        $html .= '</div>';
-        return $html;
-    }
-
-    /**
-     * Update battery status
-     *
-     * @param string $percent
-     * @param string $batteyDateTime
-     *
-     * @throws \Exception
-     */
-    public function batteryStatus($percent = '', $batteyDateTime = '')
-    {
-        if ($this->getConfiguration(EqLogicConfigKey::NO_BATTERY_CHECK, 0) == 1) {
-            return;
-        }
-        if ($percent === '') {
-            $percent = $this->getStatus('battery');
-            $batteyDateTime = $this->getStatus('batteryDatetime');
-        }
-        if ($percent > 100) {
-            $percent = 100;
-        }
-        if ($percent < 0) {
-            $percent = 0;
-        }
-        $warningThreshold = $this->getConfiguration(EqLogicConfigKey::BATTERY_WARNING_THRESHOLD, ConfigManager::byKey('battery::warning'));
-        $dangerThreshold = $this->getConfiguration(EqLogicConfigKey::BATTERY_DANGER_THRESHOLD, ConfigManager::byKey('battery::danger'));
-        if ($percent != '' && $percent < $dangerThreshold) {
-            $prevStatus = $this->getStatus(BatteryStatus::DANGER, 0);
-            $logicalId = 'lowBattery' . $this->getId();
-            $message = 'Le module ' . $this->getEqType_name() . ' ' . $this->getHumanName() . ' a moins de ' . $dangerThreshold . '% de batterie (niveau danger avec ' . $percent . '% de batterie)';
-            if ($this->getConfiguration('battery_type') != '') {
-                $message .= ' (' . $this->getConfiguration('battery_type') . ')';
-            }
-            $this->setStatus(BatteryStatus::DANGER, 1);
-            if ($prevStatus == 0) {
-                if (ConfigManager::ByKey('alert::addMessageOnBatterydanger') == 1) {
-                    MessageManager::add($this->getEqType_name(), $message, '', $logicalId);
-                }
-                $cmds = explode(('&&'), ConfigManager::byKey('alert::batterydangerCmd'));
-                if (count($cmds) > 0 && trim(ConfigManager::byKey('alert::batterydangerCmd')) != '') {
-                    foreach ($cmds as $id) {
-                        $cmd = CmdManager::byId(str_replace('#', '', $id));
-                        if (is_object($cmd)) {
-                            $cmd->execCmd([
-                                'title' => __('[' . ConfigManager::byKey('name', 'core', 'NEXTDOM') . '] ') . $message,
-                                'message' => ConfigManager::byKey('name', 'core', 'NEXTDOM') . ' : ' . $message,
-                            ]);
-                        }
-                    }
-                }
-            }
-        } else if ($percent != '' && $percent < $warningThreshold) {
-            $prevStatus = $this->getStatus(BatteryStatus::WARNING, 0);
-            $logicalId = 'warningBattery' . $this->getId();
-            $message = 'Le module ' . $this->getEqType_name() . ' ' . $this->getHumanName() . ' a moins de ' . $warningThreshold . '% de batterie (niveau warning avec ' . $percent . '% de batterie)';
-            if ($this->getConfiguration('battery_type') != '') {
-                $message .= ' (' . $this->getConfiguration('battery_type') . ')';
-            }
-            $this->setStatus(BatteryStatus::WARNING, 1);
-            $this->setStatus(BatteryStatus::DANGER, 0);
-            if ($prevStatus == 0) {
-                if (ConfigManager::ByKey('alert::addMessageOnBatterywarning') == 1) {
-                    MessageManager::add($this->getEqType_name(), $message, '', $logicalId);
-                }
-                $cmds = explode(('&&'), ConfigManager::byKey('alert::batterywarningCmd'));
-                if (count($cmds) > 0 && trim(ConfigManager::byKey('alert::batterywarningCmd')) != '') {
-                    foreach ($cmds as $id) {
-                        $cmd = CmdManager::byId(str_replace('#', '', $id));
-                        if (is_object($cmd)) {
-                            $cmd->execCmd([
-                                'title' => __('[' . ConfigManager::byKey('name', 'core', 'NEXTDOM') . '] ') . $message,
-                                'message' => ConfigManager::byKey('name', 'core', 'NEXTDOM') . ' : ' . $message,
-                            ]);
-                        }
-                    }
-                }
-            }
-        } else {
-            MessageManager::removeByPluginLogicalId($this->getEqType_name(), 'warningBattery' . $this->getId());
-            MessageManager::removeByPluginLogicalId($this->getEqType_name(), 'lowBattery' . $this->getId());
-            $this->setStatus(BatteryStatus::DANGER, 0);
-            $this->setStatus(BatteryStatus::WARNING, 0);
-        }
-
-        $this->setStatus(['battery' => $percent, 'batteryDatetime' => ($batteyDateTime != '') ? $batteyDateTime : date(DateFormat::FULL)]);
-    }
-
-    /**
-     * Get configuration URL
-     *
-     * @return string Configuration URL
-     */
-    public function getLinkToConfiguration()
-    {
-        return 'index.php?v=d&p=' . $this->getEqType_name() . '&m=' . $this->getEqType_name() . '&id=' . $this->getId();
-    }
-
-    /**
-     * Check and update a command information
-     *
-     * @param string|Cmd $logicalId Logical id or cmd object
-     * @param mixed $newValue Value to update
-     * @param null $updateEventTime Date of the update
-     *
-     * @return bool True if new value is different of the old value.
-     *
-     * @throws \Exception
-     */
-    public function checkAndUpdateCmd($logicalId, $newValue, $updateEventTime = null)
-    {
-        if ($this->getIsEnable() == 0) {
-            return false;
-        }
-        if (is_object($logicalId)) {
-            $cmd = $logicalId;
-        } else {
-            $cmd = $this->getCmd('info', $logicalId);
-        }
-        if (!is_object($cmd)) {
-            return false;
-        }
-        $oldValue = $cmd->execCmd();
-        if (($oldValue != $cmd->formatValue($newValue)) || $oldValue === '') {
-            $cmd->event($newValue, $updateEventTime);
-            return true;
-        }
-        if ($updateEventTime !== null && $updateEventTime !== false) {
-            if (strtotime($cmd->getCollectDate()) < strtotime($updateEventTime)) {
-                $cmd->event($newValue, $updateEventTime);
-                return true;
-            }
-        } else if ($cmd->getConfiguration(EqLogicConfigKey::REPEAT_EVENT_MANAGEMENT, 'auto') == 'always') {
-            $cmd->event($newValue, $updateEventTime);
-            return true;
-        }
-        $cmd->setCache('collectDate', date(DateFormat::FULL));
-        return false;
     }
 
     /**
@@ -1171,6 +829,29 @@ class EqLogic implements EntityInterface
     }
 
     /**
+     * Get changed data state
+     *
+     * @return bool True if a data changed since last save
+     */
+    public function getChanged()
+    {
+        return $this->_changed;
+    }
+
+    /**
+     * Set changed data state
+     *
+     * @param bool $newChangedStatus New data changed state
+     *
+     * @return $this
+     */
+    public function setChanged($newChangedStatus)
+    {
+        $this->_changed = $newChangedStatus;
+        return $this;
+    }
+
+    /**
      * Remove widget render in cache
      */
     public function emptyCacheWidget()
@@ -1187,6 +868,39 @@ class EqLogic implements EntityInterface
     }
 
     /**
+     * Get display parameters
+     *
+     * @param string $displayKey Parameter key
+     * @param mixed $defaultValue Default value if not defined
+     *
+     * @return mixed Parameters depends of the key
+     */
+    public function getDisplay($displayKey = '', $defaultValue = '')
+    {
+        return Utils::getJsonAttr($this->display, $displayKey, $defaultValue);
+    }
+
+    /**
+     * Set a display parameters
+     *
+     * @param string $displayKey Key for storage
+     * @param mixed $displayValue Data to store
+     *
+     * @return $this
+     */
+    public function setDisplay($displayKey, $displayValue)
+    {
+        if ($this->getDisplay($displayKey) != $displayValue) {
+            $this->_needRefreshWidget = true;
+        }
+        $display = Utils::setJsonAttr($this->display, $displayKey, $displayValue);
+        $this->_changed = Utils::attrChanged($this->_changed, $this->display, $display);
+        $this->display = $display;
+
+        return $this;
+    }
+
+    /**
      * Refresh widget if change occurs since la render
      */
     public function refreshWidget()
@@ -1194,6 +908,92 @@ class EqLogic implements EntityInterface
         $this->_needRefreshWidget = false;
         $this->emptyCacheWidget();
         EventManager::add('eqLogic::update', ['eqLogic_id' => $this->getId()]);
+    }
+
+    /**
+     * Update battery status
+     *
+     * @param string $percent
+     * @param string $batteyDateTime
+     *
+     * @throws \Exception
+     */
+    public function batteryStatus($percent = '', $batteyDateTime = '')
+    {
+        if ($this->getConfiguration(EqLogicConfigKey::NO_BATTERY_CHECK, 0) == 1) {
+            return;
+        }
+        if ($percent === '') {
+            $percent = $this->getStatus('battery');
+            $batteyDateTime = $this->getStatus('batteryDatetime');
+        }
+        if ($percent > 100) {
+            $percent = 100;
+        }
+        if ($percent < 0) {
+            $percent = 0;
+        }
+        $warningThreshold = $this->getConfiguration(EqLogicConfigKey::BATTERY_WARNING_THRESHOLD, ConfigManager::byKey('battery::warning'));
+        $dangerThreshold = $this->getConfiguration(EqLogicConfigKey::BATTERY_DANGER_THRESHOLD, ConfigManager::byKey('battery::danger'));
+        if ($percent != '' && $percent < $dangerThreshold) {
+            $prevStatus = $this->getStatus(BatteryStatus::DANGER, 0);
+            $logicalId = 'lowBattery' . $this->getId();
+            $message = 'Le module ' . $this->getEqType_name() . ' ' . $this->getHumanName() . ' a moins de ' . $dangerThreshold . '% de batterie (niveau danger avec ' . $percent . '% de batterie)';
+            if ($this->getConfiguration('battery_type') != '') {
+                $message .= ' (' . $this->getConfiguration('battery_type') . ')';
+            }
+            $this->setStatus(BatteryStatus::DANGER, 1);
+            if ($prevStatus == 0) {
+                if (ConfigManager::ByKey('alert::addMessageOnBatterydanger') == 1) {
+                    MessageManager::add($this->getEqType_name(), $message, '', $logicalId);
+                }
+                $cmds = explode(('&&'), ConfigManager::byKey('alert::batterydangerCmd'));
+                if (count($cmds) > 0 && trim(ConfigManager::byKey('alert::batterydangerCmd')) != '') {
+                    foreach ($cmds as $id) {
+                        $cmd = CmdManager::byId(str_replace('#', '', $id));
+                        if (is_object($cmd)) {
+                            $cmd->execCmd([
+                                'title' => __('[' . ConfigManager::byKey('name', 'core', 'NEXTDOM') . '] ') . $message,
+                                'message' => ConfigManager::byKey('name', 'core', 'NEXTDOM') . ' : ' . $message,
+                            ]);
+                        }
+                    }
+                }
+            }
+        } else if ($percent != '' && $percent < $warningThreshold) {
+            $prevStatus = $this->getStatus(BatteryStatus::WARNING, 0);
+            $logicalId = 'warningBattery' . $this->getId();
+            $message = 'Le module ' . $this->getEqType_name() . ' ' . $this->getHumanName() . ' a moins de ' . $warningThreshold . '% de batterie (niveau warning avec ' . $percent . '% de batterie)';
+            if ($this->getConfiguration('battery_type') != '') {
+                $message .= ' (' . $this->getConfiguration('battery_type') . ')';
+            }
+            $this->setStatus(BatteryStatus::WARNING, 1);
+            $this->setStatus(BatteryStatus::DANGER, 0);
+            if ($prevStatus == 0) {
+                if (ConfigManager::ByKey('alert::addMessageOnBatterywarning') == 1) {
+                    MessageManager::add($this->getEqType_name(), $message, '', $logicalId);
+                }
+                $cmds = explode(('&&'), ConfigManager::byKey('alert::batterywarningCmd'));
+                if (count($cmds) > 0 && trim(ConfigManager::byKey('alert::batterywarningCmd')) != '') {
+                    foreach ($cmds as $id) {
+                        $cmd = CmdManager::byId(str_replace('#', '', $id));
+                        if (is_object($cmd)) {
+                            $cmd->execCmd([
+                                'title' => __('[' . ConfigManager::byKey('name', 'core', 'NEXTDOM') . '] ') . $message,
+                                'message' => ConfigManager::byKey('name', 'core', 'NEXTDOM') . ' : ' . $message,
+                            ]);
+                        }
+                    }
+                }
+            }
+        } else {
+            MessageManager::removeByPluginLogicalId($this->getEqType_name(), 'warningBattery' . $this->getId());
+            MessageManager::removeByPluginLogicalId($this->getEqType_name(), 'lowBattery' . $this->getId());
+            $this->setStatus(BatteryStatus::DANGER, 0);
+            $this->setStatus(BatteryStatus::WARNING, 0);
+        }
+
+        $this->setStatus(['battery' => $percent, 'batteryDatetime' => ($batteyDateTime != '') ? $batteyDateTime : date(DateFormat::FULL)]);
     }
 
     /**
@@ -1270,11 +1070,117 @@ class EqLogic implements EntityInterface
     }
 
     /**
+     * Get eqLogic timeout
+     *
+     * @param int|string $defaultValue Default value if timeout is not define
+     *
+     * @return int|null
+     */
+    public function getTimeout($defaultValue = null)
+    {
+        if ($this->timeout == '' || !is_numeric($this->timeout)) {
+            return $defaultValue;
+        }
+        return $this->timeout;
+    }
+
+    /**
+     * Get eqLogic timeout
+     *
+     * @param int $timeout Timeout
+     *
+     * @return $this
+     */
+    public function setTimeout($timeout)
+    {
+        if ($timeout == '' || is_nan(intval($timeout)) || $timeout < 1) {
+            $timeout = null;
+        }
+        if ($timeout != $this->getTimeout()) {
+            $this->_timeoutUpdated = true;
+            $this->_changed = true;
+        }
+        $this->timeout = $timeout;
+        return $this;
+    }
+
+    /**
      * @return bool
      */
     public function hasOnlyEventOnlyCmd()
     {
         return true;
+    }
+
+    /**
+     * Get HTML code depends of the view
+     *
+     * @param string $viewType Type of view : mobile, dashboard, scenario
+     *
+     * @return array|mixed
+     *
+     * @throws CoreException
+     * @throws \NextDom\Exceptions\OperatingSystemException
+     * @throws \ReflectionException
+     */
+    public function toHtml($viewType = EqLogicViewType::DASHBOARD)
+    {
+        $replace = $this->preToHtml($viewType);
+        if (!is_array($replace)) {
+            return $replace;
+        }
+        $version = NextDomHelper::versionAlias($viewType);
+
+        if ($this->getDisplay('layout::' . $version) == 'table') {
+            $replace['#eqLogic_class#'] = 'eqLogic_layout_table';
+            $table = EqLogicManager::generateHtmlTable($this->getDisplay('layout::' . $version . '::table::nbLine', 1), $this->getDisplay('layout::' . $version . '::table::nbColumn', 1), $this->getDisplay('layout::' . $version . '::table::parameters'));
+            $br_before = 0;
+            foreach ($this->getCmd(null, null, true) as $cmd) {
+                if (isset($replace['#refresh_id#']) && $cmd->getId() == $replace['#refresh_id#']) {
+                    continue;
+                }
+                $tag = '#cmd::' . $this->getDisplay('layout::' . $version . '::table::cmd::' . $cmd->getId() . '::line', 1) . '::' . $this->getDisplay('layout::' . $version . '::table::cmd::' . $cmd->getId() . '::column', 1) . '#';
+                if ($br_before == 0 && $cmd->getDisplay('forceReturnLineBefore', 0) == 1) {
+                    $table['tag'][$tag] .= '<br/>';
+                }
+                $table['tag'][$tag] .= $cmd->toHtml($viewType, '', $replace['#cmd-background-color#']);
+                $br_before = 0;
+                if ($cmd->getDisplay('forceReturnLineAfter', 0) == 1) {
+                    $table['tag'][$tag] .= '<br/>';
+                    $br_before = 1;
+                }
+            }
+            $replace['#cmd#'] = Utils::templateReplace($table['tag'], $table['html']);
+        } else {
+            $replace['#eqLogic_class#'] = 'eqLogic_layout_default';
+            $cmd_html = '';
+            $br_before = 0;
+            foreach ($this->getCmd(null, null, true) as $cmd) {
+                if (isset($replace['#refresh_id#']) && $cmd->getId() == $replace['#refresh_id#']) {
+                    continue;
+                }
+                if ($br_before == 0 && $cmd->getDisplay('forceReturnLineBefore', 0) == 1) {
+                    $cmd_html .= '<br/>';
+                }
+                $cmd_html .= $cmd->toHtml($viewType, '', $replace['#cmd-background-color#']);
+                $br_before = 0;
+                if ($cmd->getDisplay('forceReturnLineAfter', 0) == 1) {
+                    $cmd_html .= '<br/>';
+                    $br_before = 1;
+                }
+            }
+            $replace['#cmd#'] = $cmd_html;
+        }
+
+        if (!isset(self::$_templateArray[$version])) {
+            $default_widgetTheme = ConfigManager::byKey('widget::theme');
+            if (isset($_SESSION) && is_object(UserManager::getStoredUser()) && UserManager::getStoredUser()->getOptions('widget::theme', null) !== null) {
+                $default_widgetTheme = UserManager::getStoredUser()->getOptions('widget::theme');
+            }
+            self::$_templateArray[$version] = FileSystemHelper::getCoreTemplateFileContent($version, 'eqLogic', '', $default_widgetTheme);
+
+        }
+        return $this->postToHtml($viewType, Utils::templateReplace($replace, self::$_templateArray[$version]));
     }
 
     /**
@@ -1297,7 +1203,7 @@ class EqLogic implements EntityInterface
         if (!$this->hasRight('r')) {
             return '';
         }
-        if (!$this->getIsEnable()) {
+        if (!$this->isEnabled()) {
             return '';
         }
         $version = NextDomHelper::versionAlias($viewType, false);
@@ -1377,15 +1283,15 @@ class EqLogic implements EntityInterface
         if ($this->getDisplay('border-radius-default' . $version, 1) != 1) {
             $replace['#border-radius#'] = $this->getDisplay('border-radius' . $version, '4') . 'px';
         }
-        $refresh_cmd = $this->getCmd('action', 'refresh');
+        $refresh_cmd = $this->getCmd(CmdType::ACTION, 'refresh');
         if (!is_object($refresh_cmd)) {
-            foreach ($this->getCmd('action') as $cmd) {
+            foreach ($this->getCmd(CmdType::ACTION) as $cmd) {
                 if ($cmd->getConfiguration('isRefreshCmd') == 1) {
                     $refresh_cmd = $cmd;
                 }
             }
         }
-        if (is_object($refresh_cmd) && $refresh_cmd->getIsVisible() == 1 && $refresh_cmd->getDisplay('showOn' . $version, 1) == 1) {
+        if (is_object($refresh_cmd) && $refresh_cmd->isVisible() && $refresh_cmd->getDisplay('showOn' . $version, 1) == 1) {
             $replace['#refresh_id#'] = $refresh_cmd->getId();
         }
         if ($this->getDisplay('showObjectNameOn' . $version, 0) == 1) {
@@ -1430,17 +1336,14 @@ class EqLogic implements EntityInterface
                     $replace['#' . $pKey . '#'] = $default;
                     continue;
                 }
-                switch ($parameter['type']) {
-                    case 'color':
-                        if ($this->getDisplay('advanceWidgetParameter' . $pKey . $version . '-transparent', 0) == 1) {
-                            $replace['#' . $pKey . '#'] = 'transparent';
-                        } else {
-                            $replace['#' . $pKey . '#'] = $this->getDisplay('advanceWidgetParameter' . $pKey . $version, $default);
-                        }
-                        break;
-                    default:
+                if ($parameter['type'] == 'color') {
+                    if ($this->getDisplay('advanceWidgetParameter' . $pKey . $version . '-transparent', 0) == 1) {
+                        $replace['#' . $pKey . '#'] = 'transparent';
+                    } else {
                         $replace['#' . $pKey . '#'] = $this->getDisplay('advanceWidgetParameter' . $pKey . $version, $default);
-                        break;
+                    }
+                } else {
+                    $replace['#' . $pKey . '#'] = $this->getDisplay('advanceWidgetParameter' . $pKey . $version, $default);
                 }
             }
         }
@@ -1455,99 +1358,6 @@ class EqLogic implements EntityInterface
             $replace['#opacity#'] = $opacity;
         }
         return $replace;
-    }
-
-    /**
-     * Store HTML view in cache
-     *
-     * @param string $viewType Define target view type
-     * @param string $htmlCode HTML code to store
-     *
-     * @return string $htmlCode
-     * @throws \Exception
-     */
-    public function postToHtml(string $viewType, string $htmlCode)
-    {
-        $user_id = '';
-        if (isset($_SESSION) && is_object(UserManager::getStoredUser())) {
-            $user_id = UserManager::getStoredUser()->getId();
-        }
-        CacheManager::set(CacheKey::WIDGET_HTML . $this->getId() . $viewType . $user_id, $htmlCode);
-        return $htmlCode;
-    }
-
-    /**
-     * Get HTML code depends of the view
-     *
-     * @param string $viewType Type of view : mobile, dashboard, scenario
-     *
-     * @return array|mixed
-     *
-     * @throws CoreException
-     * @throws \NextDom\Exceptions\OperatingSystemException
-     * @throws \ReflectionException
-     */
-    public function toHtml($viewType = EqLogicViewType::DASHBOARD)
-    {
-        $replace = $this->preToHtml($viewType);
-        if (!is_array($replace)) {
-            return $replace;
-        }
-        $version = NextDomHelper::versionAlias($viewType);
-
-        switch ($this->getDisplay('layout::' . $version)) {
-            case 'table':
-                $replace['#eqLogic_class#'] = 'eqLogic_layout_table';
-                $table = EqLogicManager::generateHtmlTable($this->getDisplay('layout::' . $version . '::table::nbLine', 1), $this->getDisplay('layout::' . $version . '::table::nbColumn', 1), $this->getDisplay('layout::' . $version . '::table::parameters'));
-                $br_before = 0;
-                foreach ($this->getCmd(null, null, true) as $cmd) {
-                    if (isset($replace['#refresh_id#']) && $cmd->getId() == $replace['#refresh_id#']) {
-                        continue;
-                    }
-                    $tag = '#cmd::' . $this->getDisplay('layout::' . $version . '::table::cmd::' . $cmd->getId() . '::line', 1) . '::' . $this->getDisplay('layout::' . $version . '::table::cmd::' . $cmd->getId() . '::column', 1) . '#';
-                    if ($br_before == 0 && $cmd->getDisplay('forceReturnLineBefore', 0) == 1) {
-                        $table['tag'][$tag] .= '<br/>';
-                    }
-                    $table['tag'][$tag] .= $cmd->toHtml($viewType, '', $replace['#cmd-background-color#']);
-                    $br_before = 0;
-                    if ($cmd->getDisplay('forceReturnLineAfter', 0) == 1) {
-                        $table['tag'][$tag] .= '<br/>';
-                        $br_before = 1;
-                    }
-                }
-                $replace['#cmd#'] = Utils::templateReplace($table['tag'], $table['html']);
-                break;
-            default:
-                $replace['#eqLogic_class#'] = 'eqLogic_layout_default';
-                $cmd_html = '';
-                $br_before = 0;
-                foreach ($this->getCmd(null, null, true) as $cmd) {
-                    if (isset($replace['#refresh_id#']) && $cmd->getId() == $replace['#refresh_id#']) {
-                        continue;
-                    }
-                    if ($br_before == 0 && $cmd->getDisplay('forceReturnLineBefore', 0) == 1) {
-                        $cmd_html .= '<br/>';
-                    }
-                    $cmd_html .= $cmd->toHtml($viewType, '', $replace['#cmd-background-color#']);
-                    $br_before = 0;
-                    if ($cmd->getDisplay('forceReturnLineAfter', 0) == 1) {
-                        $cmd_html .= '<br/>';
-                        $br_before = 1;
-                    }
-                }
-                $replace['#cmd#'] = $cmd_html;
-                break;
-        }
-
-        if (!isset(self::$_templateArray[$version])) {
-            $default_widgetTheme = ConfigManager::byKey('widget::theme');
-            if (isset($_SESSION) && is_object(UserManager::getStoredUser()) && UserManager::getStoredUser()->getOptions('widget::theme', null) !== null) {
-                $default_widgetTheme = UserManager::getStoredUser()->getOptions('widget::theme');
-            }
-            self::$_templateArray[$version] = FileSystemHelper::getCoreTemplateFileContent($version, 'eqLogic', '', $default_widgetTheme);
-
-        }
-        return $this->postToHtml($viewType, Utils::templateReplace($replace, self::$_templateArray[$version]));
     }
 
     /**
@@ -1581,6 +1391,113 @@ class EqLogic implements EntityInterface
     }
 
     /**
+     * Get list of eqLogic tags
+     *
+     * @return mixed List of eqLogic tags
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * Define list of eqLogics tags
+     *
+     * @param mixed $tags List of tags
+     *
+     * @return $this
+     */
+    public function setTags($tags)
+    {
+        $_tags = str_replace(["'", '<', '>'], "", $tags);
+        $this->_changed = Utils::attrChanged($this->_changed, $this->tags, $_tags);
+        $this->tags = $_tags;
+        return $this;
+    }
+
+    /**
+     * Get primary category
+     *
+     * @return string
+     */
+    public function getPrimaryCategory()
+    {
+        $categoryOrder = [
+            EqLogicCategory::SECURITY,
+            EqLogicCategory::HEATING,
+            EqLogicCategory::LIGHT,
+            EqLogicCategory::AUTOMATISM,
+            EqLogicCategory::ENERGY,
+            EqLogicCategory::MULTIMEDIA
+        ];
+        foreach ($categoryOrder as $categoryCode) {
+            if ($this->getCategory($categoryCode, 0) == 1) {
+                return $categoryCode;
+            }
+        }
+        return '';
+    }
+
+    /**
+     * Test if the object belongs to a category
+     *
+     * @param string $categoryKey Key of the category
+     * @param string $defaultValue Default value if not set
+     *
+     * @return mixed 1 if object belongs the category
+     */
+    public function getCategory($categoryKey = '', $defaultValue = '')
+    {
+        if ($categoryKey == 'other' && strpos($this->category, "1") === false) {
+            return 1;
+        }
+        return Utils::getJsonAttr($this->category, $categoryKey, $defaultValue);
+    }
+
+    /**
+     * Define if the object belongs to a category
+     *
+     * @param string $categoryKey Key of the category
+     * @param int $belong 1 if eqLogic belong the category or 0
+     *
+     * @return $this
+     */
+    public function setCategory($categoryKey, $belong)
+    {
+        if ($this->getCategory($categoryKey) != $belong) {
+            $this->_needRefreshWidget = true;
+        }
+        $category = Utils::setJsonAttr($this->category, $categoryKey, $belong);
+        $this->_changed = Utils::attrChanged($this->_changed, $this->category, $category);
+        $this->category = $category;
+        return $this;
+    }
+
+    /**
+     * Set logicalId (Id used by plugins)
+     *
+     * @return string Logical Id
+     */
+    public function getLogicalId()
+    {
+        return $this->logicalId;
+    }
+
+    /**
+     * Get logicalId (Id used by plugins)
+     *
+     * @param string $logicalId logical Id
+     *
+     * @return $this
+     */
+    public function setLogicalId($logicalId)
+    {
+        $this->_changed = Utils::attrChanged($this->_changed, $this->logicalId, $logicalId);
+        $this->logicalId = $logicalId;
+        return $this;
+    }
+
+    /**
      * Get widget specific possibility
      *
      * @param string $keyPossibility Key of the possibility
@@ -1595,11 +1512,7 @@ class EqLogic implements EntityInterface
         $reflectedClass = new \ReflectionClass($this->getEqType_name());
         $method_toHtml = $reflectedClass->getMethod('toHtml');
         $result = [];
-        if ($method_toHtml->class == EqLogic::class) {
-            $result['custom'] = true;
-        } else {
-            $result['custom'] = false;
-        }
+        $result[Common::CUSTOM] = $method_toHtml->class == EqLogic::class;
         $reflectedClass = $this->getEqType_name();
         if (property_exists($reflectedClass, '_widgetPossibility')) {
             /** @noinspection PhpUndefinedFieldInspection */
@@ -1619,19 +1532,43 @@ class EqLogic implements EntityInterface
                         return $result[$k];
                     }
                 }
-                if (is_array($result) && strpos($keyPossibility, 'custom') !== false) {
+                if (is_array($result) && strpos($keyPossibility, Common::CUSTOM) !== false) {
                     return $defaultValue;
                 }
                 return $result;
             }
         }
         if ($keyPossibility != '') {
-            if (isset($result['custom']) && !isset($result[$keyPossibility])) {
-                return $result['custom'];
+            if (isset($result[Common::CUSTOM]) && !isset($result[$keyPossibility])) {
+                return $result[Common::CUSTOM];
             }
             return (isset($result[$keyPossibility])) ? $result[$keyPossibility] : $defaultValue;
         }
         return $result;
+    }
+
+    /**
+     * Get generic type for simple eqLogic
+     *
+     * @return string Generic type
+     */
+    public function getGenericType()
+    {
+        return $this->generic_type;
+    }
+
+    /**
+     * Set generic type for simple EqLogic
+     *
+     * @param string $genericType Generic type
+     *
+     * @return $this
+     */
+    public function setGenericType($genericType)
+    {
+        $this->_changed = Utils::attrChanged($this->_changed, $this->generic_type, $genericType);
+        $this->generic_type = $genericType;
+        return $this;
     }
 
     /**
@@ -1645,9 +1582,9 @@ class EqLogic implements EntityInterface
      */
     public function getBackgroundColor($version = 'dashboard')
     {
-        $category = $this->getPrimaryCategory();
-        if ($category != '') {
-            return NextDomHelper::getConfiguration('eqLogic:category:' . $category . ':color');
+        $primaryCategory = $this->getPrimaryCategory();
+        if ($primaryCategory != '') {
+            return NextDomHelper::getConfiguration('eqLogic:category:' . $primaryCategory . ':color');
         }
         return NextDomHelper::getConfiguration('eqLogic:category:default:color');
     }
@@ -1674,6 +1611,25 @@ class EqLogic implements EntityInterface
     }
 
     /**
+     * Store HTML view in cache
+     *
+     * @param string $viewType Define target view type
+     * @param string $htmlCode HTML code to store
+     *
+     * @return string $htmlCode
+     * @throws \Exception
+     */
+    public function postToHtml(string $viewType, string $htmlCode)
+    {
+        $user_id = '';
+        if (isset($_SESSION) && is_object(UserManager::getStoredUser())) {
+            $user_id = UserManager::getStoredUser()->getId();
+        }
+        CacheManager::set(CacheKey::WIDGET_HTML . $this->getId() . $viewType . $user_id, $htmlCode);
+        return $htmlCode;
+    }
+
+    /**
      * Get max command alter for this eqLogic
      *
      * @return mixed Max command alert
@@ -1682,20 +1638,20 @@ class EqLogic implements EntityInterface
      */
     public function getMaxCmdAlert()
     {
-        $return = 'none';
+        $result = 'none';
         $max = 0;
         global $NEXTDOM_INTERNAL_CONFIG;
-        foreach ($this->getCmd('info') as $cmd) {
+        foreach ($this->getCmd(CmdType::INFO) as $cmd) {
             $cmdLevel = $cmd->getCache('alertLevel');
             if (!isset($NEXTDOM_INTERNAL_CONFIG['alerts'][$cmdLevel])) {
                 continue;
             }
             if ($NEXTDOM_INTERNAL_CONFIG['alerts'][$cmdLevel]['level'] > $max) {
-                $return = $cmdLevel;
+                $result = $cmdLevel;
                 $max = $NEXTDOM_INTERNAL_CONFIG['alerts'][$cmdLevel]['level'];
             }
         }
-        return $return;
+        return $result;
     }
 
     /**
@@ -1746,6 +1702,29 @@ class EqLogic implements EntityInterface
         if ($this->getDebug()) {
             echo $_message . "\n";
         }
+    }
+
+    /**
+     * Get debug state
+     *
+     * @return bool True if debug is activated
+     */
+    public function getDebug()
+    {
+        return $this->_debug;
+    }
+
+    /**
+     * Set debug state
+     *
+     * @param bool $newDebugState True for activate debug
+     */
+    public function setDebug($newDebugState)
+    {
+        if ($newDebugState) {
+            echo "Mode debug activé\n";
+        }
+        $this->_debug = $newDebugState;
     }
 
     /**
@@ -1812,8 +1791,8 @@ class EqLogic implements EntityInterface
                         $cmd->setEqLogic_id($this->getId());
                     } else {
                         $command['name'] = $cmd->getName();
-                        if (isset($command['display'])) {
-                            unset($command['display']);
+                        if (isset($command[Common::DISPLAY])) {
+                            unset($command[Common::DISPLAY]);
                         }
                     }
                     Utils::a2o($cmd, $command);
@@ -1899,8 +1878,8 @@ class EqLogic implements EntityInterface
         if (isset($result['configuration']) && count($result['configuration']) == 0) {
             unset($result['configuration']);
         }
-        if (isset($result['display']) && count($result['display']) == 0) {
-            unset($result['display']);
+        if (isset($result[Common::DISPLAY]) && count($result[Common::DISPLAY]) == 0) {
+            unset($result[Common::DISPLAY]);
         }
         if ($withCommands) {
             $result['cmd'] = [];
@@ -1997,19 +1976,19 @@ class EqLogic implements EntityInterface
         ];
         $use = $this->getUse();
         $usedBy = $this->getUsedBy();
-        Utils::addGraphLink($this, 'eqLogic', $this->getCmd(), 'cmd', $data, $distance, $drill, ['dashvalue' => '1,0', 'lengthfactor' => 0.6]);
-        Utils::addGraphLink($this, 'eqLogic', $use['cmd'], 'cmd', $data, $distance, $drill);
-        Utils::addGraphLink($this, 'eqLogic', $use['scenario'], 'scenario', $data, $distance, $drill);
-        Utils::addGraphLink($this, 'eqLogic', $use['eqLogic'], 'eqLogic', $data, $distance, $drill);
-        Utils::addGraphLink($this, 'eqLogic', $use['dataStore'], 'dataStore', $data, $distance, $drill);
-        Utils::addGraphLink($this, 'eqLogic', $usedBy['cmd'], 'cmd', $data, $distance, $drill);
-        Utils::addGraphLink($this, 'eqLogic', $usedBy['scenario'], 'scenario', $data, $distance, $drill);
-        Utils::addGraphLink($this, 'eqLogic', $usedBy['eqLogic'], 'eqLogic', $data, $distance, $drill);
-        Utils::addGraphLink($this, 'eqLogic', $usedBy['interactDef'], 'interactDef', $data, $distance, $drill, ['dashvalue' => '2,6', 'lengthfactor' => 0.6]);
-        Utils::addGraphLink($this, 'eqLogic', $usedBy['plan'], 'plan', $data, $distance, $drill, ['dashvalue' => '2,6', 'lengthfactor' => 0.6]);
-        Utils::addGraphLink($this, 'eqLogic', $usedBy['view'], 'view', $data, $distance, $drill, ['dashvalue' => '2,6', 'lengthfactor' => 0.6]);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $this->getCmd(), NextDomObj::CMD, $data, $distance, $drill, [Common::DASH_VALUE => '1,0', Common::LENGTH_FACTOR => 0.6]);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $use[NextDomObj::CMD], NextDomObj::CMD, $data, $distance, $drill);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $use[NextDomObj::SCENARIO], NextDomObj::SCENARIO, $data, $distance, $drill);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $use[NextDomObj::EQLOGIC], NextDomObj::EQLOGIC, $data, $distance, $drill);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $use[NextDomObj::DATASTORE], NextDomObj::DATASTORE, $data, $distance, $drill);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $usedBy[NextDomObj::CMD], NextDomObj::CMD, $data, $distance, $drill);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $usedBy[NextDomObj::SCENARIO], NextDomObj::SCENARIO, $data, $distance, $drill);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $usedBy[NextDomObj::EQLOGIC], NextDomObj::EQLOGIC, $data, $distance, $drill);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $usedBy[NextDomObj::INTERACT_DEF], NextDomObj::INTERACT_DEF, $data, $distance, $drill, [Common::DASH_VALUE => '2,6', Common::LENGTH_FACTOR => 0.6]);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $usedBy[NextDomObj::PLAN], NextDomObj::PLAN, $data, $distance, $drill, [Common::DASH_VALUE => '2,6', Common::LENGTH_FACTOR => 0.6]);
+        Utils::addGraphLink($this, NextDomObj::EQLOGIC, $usedBy[NextDomObj::VIEW], NextDomObj::VIEW, $data, $distance, $drill, [Common::DASH_VALUE => '2,6', Common::LENGTH_FACTOR => 0.6]);
         if (!isset($data['object' . $this->getObject_id()])) {
-            Utils::addGraphLink($this, 'eqLogic', $this->getObject(), 'object', $data, $distance, $drill, ['dashvalue' => '1,0', 'lengthfactor' => 0.6]);
+            Utils::addGraphLink($this, NextDomObj::EQLOGIC, $this->getObject(), NextDomObj::OBJECT, $data, $distance, $drill, [Common::DASH_VALUE => '1,0', Common::LENGTH_FACTOR => 0.6]);
         }
         return $data;
     }
@@ -2070,6 +2049,31 @@ class EqLogic implements EntityInterface
     }
 
     /**
+     * Get id of the attached object
+     *
+     * @return int Id of the attached object
+     */
+    public function getObject_id()
+    {
+        return $this->object_id;
+    }
+
+    /**
+     * Set attached room id
+     *
+     * @param int $object_id Room id
+     *
+     * @return $this
+     */
+    public function setObject_id($object_id = null)
+    {
+        $object_id = (!is_numeric($object_id)) ? null : $object_id;
+        $this->_changed = Utils::attrChanged($this->_changed, $this->object_id, $object_id);
+        $this->object_id = $object_id;
+        return $this;
+    }
+
+    /**
      * Get object data in array
      *
      * @return array
@@ -2078,9 +2082,9 @@ class EqLogic implements EntityInterface
      */
     public function toArray()
     {
-        $return = Utils::o2a($this, true);
-        $return['status'] = $this->getStatus();
-        return $return;
+        $result = Utils::o2a($this, true);
+        $result['status'] = $this->getStatus();
+        return $result;
     }
 
     /**

--- a/src/Model/Entity/EqReal.php
+++ b/src/Model/Entity/EqReal.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\Utils;
 use NextDom\Managers\DataStoreManager;
@@ -124,7 +125,7 @@ class EqReal implements EntityInterface
     public function save()
     {
         if ($this->getName() == '') {
-            throw new \Exception(__('Le nom de l\'équipement réel ne peut pas être vide'));
+            throw new CoreException(__('Le nom de l\'équipement réel ne peut pas être vide'));
         }
         return DBHelper::save($this);
     }

--- a/src/Model/Entity/History.php
+++ b/src/Model/Entity/History.php
@@ -86,11 +86,11 @@ class History
                 $time -= $time % 300;
                 $this->setDatetime(date(DateFormat::FULL, $time));
                 if ($this->getValue() === 0) {
-                    $values = array(
+                    $values = [
                         'cmd_id' => $this->getCmd_id(),
                         'datetime' => date('Y-m-d H:i:00', strtotime($this->getDatetime()) + 300),
                         'value' => $this->getValue(),
-                    );
+                    ];
                     $sql = 'REPLACE INTO history
                     SET cmd_id=:cmd_id,
                     `datetime`=:datetime,
@@ -98,10 +98,10 @@ class History
                     DBHelper::exec($sql, $values);
                     return;
                 }
-                $values = array(
+                $values = [
                     'cmd_id' => $this->getCmd_id(),
                     'datetime' => $this->getDatetime(),
-                );
+                ];
                 $sql = 'SELECT `value`
                 FROM history
                 WHERE cmd_id=:cmd_id
@@ -127,11 +127,11 @@ class History
                 $this->setDatetime(date('Y-m-d H:00:00', strtotime($this->getDatetime())));
             }
         }
-        $values = array(
+        $values = [
             'cmd_id' => $this->getCmd_id(),
             'datetime' => $this->getDatetime(),
             'value' => $this->getValue(),
-        );
+        ];
         if ($values['value'] === '') {
             $values['value'] = null;
         }

--- a/src/Model/Entity/InteractDef.php
+++ b/src/Model/Entity/InteractDef.php
@@ -17,6 +17,9 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\CmdSubType;
+use NextDom\Enums\CmdType;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\Utils;
 use NextDom\Managers\ConfigManager;
@@ -208,7 +211,7 @@ class InteractDef implements EntityInterface
     public function save()
     {
         if ($this->getQuery() == '') {
-            throw new \Exception(__('La commande (demande) ne peut pas être vide'));
+            throw new CoreException(__('La commande (demande) ne peut pas être vide'));
         }
         DBHelper::save($this);
         return true;
@@ -265,7 +268,7 @@ class InteractDef implements EntityInterface
     public function generateQueryVariant()
     {
         $inputs = InteractDefManager::generateTextVariant($this->getQuery());
-        $return = array();
+        $return = [];
         $object_filter = $this->getFiltres('object');
         $type_filter = $this->getFiltres('type');
         $subtype_filter = $this->getFiltres('subtype');
@@ -291,7 +294,7 @@ class InteractDef implements EntityInterface
                         if (isset($plugin_filter[$eqLogic->getEqType_name()]) && $plugin_filter[$eqLogic->getEqType_name()] == 0) {
                             continue;
                         }
-                        if (isset($visible_filter['eqLogic']) && $visible_filter['eqLogic'] == 1 && $eqLogic->getIsVisible() != 1) {
+                        if (isset($visible_filter['eqLogic']) && $visible_filter['eqLogic'] == 1 && !$eqLogic->isVisible()) {
                             continue;
                         }
 
@@ -315,7 +318,7 @@ class InteractDef implements EntityInterface
                             continue;
                         }
                         foreach ($eqLogic->getCmd() as $cmd) {
-                            if (isset($visible_filter['cmd']) && $visible_filter['cmd'] == 1 && $cmd->getIsVisible() != 1) {
+                            if (isset($visible_filter['cmd']) && $visible_filter['cmd'] == 1 && !$cmd->isVisible()) {
                                 continue;
                             }
                             if (isset($subtype_filter[$cmd->getSubType()]) && $subtype_filter[$cmd->getSubType()] == 0) {
@@ -334,30 +337,30 @@ class InteractDef implements EntityInterface
                                 }
                             }
 
-                            $replace = array(
+                            $replace = [
                                 '#objet#' => strtolower($jeeObject->getName()),
                                 '#commande#' => strtolower($cmd->getName()),
                                 '#equipement#' => strtolower($eqLogic->getName()),
-                            );
-                            $options = array();
-                            if ($cmd->getType() == 'action') {
-                                if ($cmd->getSubtype() == 'color') {
+                            ];
+                            $options = [];
+                            if ($cmd->isType(CmdType::ACTION)) {
+                                if ($cmd->isSubType(CmdSubType::COLOR)) {
                                     $options['color'] = '#color#';
                                 }
-                                if ($cmd->getSubtype() == 'slider') {
+                                if ($cmd->isSubType(CmdSubType::SLIDER)) {
                                     $options['slider'] = '#slider#';
                                 }
-                                if ($cmd->getSubtype() == 'message') {
+                                if ($cmd->isSubType(CmdSubType::MESSAGE)) {
                                     $options['message'] = '#message#';
                                     $options['title'] = '#title#';
                                 }
                             }
                             $query = str_replace(array_keys($replace), $replace, $input);
-                            $return[$query] = array(
+                            $return[$query] = [
                                 'query' => $query,
-                                'cmd' => array(array('cmd' => '#' . $cmd->getId() . '#', 'options' => $options)),
+                                'cmd' => [['cmd' => '#' . $cmd->getId() . '#', 'options' => $options]],
 
-                            );
+                            ];
                         }
                     }
                 }
@@ -366,14 +369,14 @@ class InteractDef implements EntityInterface
 
         if (count($return) == 0) {
             foreach ($inputs as $input) {
-                $return[] = array(
+                $return[] = [
                     'query' => $input,
                     'cmd' => $this->getActions('cmd'),
-                );
+                ];
             }
         }
         if ($this->getOptions('synonymes') != '') {
-            $synonymes = array();
+            $synonymes = [];
             foreach (explode('|', $this->getOptions('synonymes')) as $value) {
                 $values = explode('=', $value);
                 if (count($values) != 2) {
@@ -469,7 +472,7 @@ class InteractDef implements EntityInterface
             if (preg_match($exclude_regexp, $_query)) {
                 return false;
             }
-            $disallow = array(
+            $disallow = [
                 'le salle',
                 'le chambre',
                 'la dressing',
@@ -589,7 +592,7 @@ class InteractDef implements EntityInterface
                 'de espace',
                 'de salle de bain',
                 '(dans|quelqu\'un) entr(é|e)e',
-            );
+            ];
             if (preg_match('/( |^)' . implode('( |$)|( |^)', $disallow) . '( |$)/i', $_query)) {
                 return false;
             }
@@ -632,7 +635,7 @@ class InteractDef implements EntityInterface
      * @param int $_drill
      * @return array|null
      */
-    public function getLinkData(&$_data = array('node' => array(), 'link' => array()), $_level = 0, $_drill = 3)
+    public function getLinkData(&$_data = ['node' => [], 'link' => []], $_level = 0, $_drill = 3)
     {
         if (isset($_data['node']['interactDef' . $this->getId()])) {
             return null;
@@ -642,7 +645,7 @@ class InteractDef implements EntityInterface
             return $_data;
         }
         $icon = Utils::findCodeIcon('fa-comments-o');
-        $_data['node']['interactDef' . $this->getId()] = array(
+        $_data['node']['interactDef' . $this->getId()] = [
             'id' => 'interactDef' . $this->getId(),
             'name' => substr($this->getHumanName(), 0, 20),
             'icon' => $icon['icon'],
@@ -653,7 +656,7 @@ class InteractDef implements EntityInterface
             'textx' => 0,
             'title' => $this->getHumanName(),
             'url' => 'index.php?v=d&p=interact&id=' . $this->getId(),
-        );
+        ];
         return null;
     }
 

--- a/src/Model/Entity/InteractQuery.php
+++ b/src/Model/Entity/InteractQuery.php
@@ -17,6 +17,8 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\DateFormat;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\LogHelper;
 use NextDom\Helpers\NextDomHelper;
@@ -76,10 +78,10 @@ class InteractQuery implements EntityInterface
     public function save()
     {
         if ($this->getQuery() == '') {
-            throw new \Exception(__('La commande vocale ne peut pas être vide'));
+            throw new CoreException(__('La commande vocale ne peut pas être vide'));
         }
         if ($this->getInteractDef_id() == '') {
-            throw new \Exception(__('InteractDef_id ne peut pas être vide'));
+            throw new CoreException(__('InteractDef_id ne peut pas être vide'));
         }
         DBHelper::save($this);
         return $this;
@@ -156,7 +158,7 @@ class InteractQuery implements EntityInterface
             }
         }
         $reply = $interactDef->selectReply();
-        $replace = array('#query#' => $this->getQuery());
+        $replace = ['#query#' => $this->getQuery()];
         foreach ($_parameters as $key => $value) {
             $replace['#' . $key . '#'] = $value;
         }
@@ -171,17 +173,17 @@ class InteractQuery implements EntityInterface
         $executeDate = null;
 
         if (isset($replace['#duration#'])) {
-            $dateConvert = array(
+            $dateConvert = [
                 'heure' => 'hour',
                 'mois' => 'month',
                 'semaine' => 'week',
                 'année' => 'year',
-            );
+            ];
             $replace['#duration#'] = str_replace(array_keys($dateConvert), $dateConvert, $replace['#duration#']);
             $executeDate = strtotime('+' . $replace['#duration#']);
         }
         if (isset($replace['#time#'])) {
-            $time = str_replace(array('h'), array(':'), $replace['#time#']);
+            $time = str_replace(['h'], [':'], $replace['#time#']);
             if (strlen($time) == 1) {
                 $time .= ':00';
             } else if (strlen($time) == 2) {
@@ -213,12 +215,12 @@ class InteractQuery implements EntityInterface
             $cron = new Cron();
             $cron->setClass('interactQuery');
             $cron->setFunction('doIn');
-            $cron->setOption(array_merge(array('interactQuery_id' => intval($this->getId())), $_parameters));
-            $cron->setLastRun(date('Y-m-d H:i:s'));
+            $cron->setOption(array_merge(['interactQuery_id' => intval($this->getId())], $_parameters));
+            $cron->setLastRun(date(DateFormat::FULL));
             $cron->setOnce(1);
             $cron->setSchedule(CronManager::convertDateToCron($executeDate));
             $cron->save();
-            $replace['#valeur#'] = date('Y-m-d H:i:s', $executeDate);
+            $replace['#valeur#'] = date(DateFormat::FULL, $executeDate);
             $result = ScenarioExpressionManager::setTags(str_replace(array_keys($replace), $replace, $reply));
             return $result;
         }
@@ -227,7 +229,7 @@ class InteractQuery implements EntityInterface
         if (is_array($this->getActions('cmd'))) {
             foreach ($this->getActions('cmd') as $action) {
                 try {
-                    $options = array();
+                    $options = [];
                     if (isset($action['options'])) {
                         $options = $action['options'];
                     }
@@ -254,7 +256,7 @@ class InteractQuery implements EntityInterface
                             }
                         }
                     }
-                    $tags = array();
+                    $tags = [];
                     if (isset($options['tags'])) {
                         $options['tags'] = Utils::arg2array($options['tags']);
                         foreach ($options['tags'] as $key => $value) {

--- a/src/Model/Entity/JsonRPC.php
+++ b/src/Model/Entity/JsonRPC.php
@@ -31,7 +31,7 @@ class JsonRPC
     protected $id = 99999;
     protected $startTime;
     protected $applicationName;
-    protected $additionnalParams = array();
+    protected $additionnalParams = [];
 
     /**
      *
@@ -62,14 +62,14 @@ class JsonRPC
      */
     public function makeError($_code, $_message)
     {
-        $return = array(
+        $return = [
             'jsonrpc' => '2.0',
             'id' => $this->id,
-            'error' => array(
+            'error' => [
                 'code' => $_code,
                 'message' => $_message,
-            ),
-        );
+            ],
+        ];
         $return = array_merge($return, $this->getAdditionnalParams());
         if (Utils::init('callback') != '') {
             echo Utils::init('callback') . '(' . json_encode($return) . ')';
@@ -97,7 +97,7 @@ class JsonRPC
      */
     public function setAdditionnalParams($_key, $_value)
     {
-        if (in_array($_key, array('result', 'jsonrpc', 'id'))) {
+        if (in_array($_key, ['result', 'jsonrpc', 'id'])) {
             return;
         }
         $this->additionnalParams = Utils::setJsonAttr($this->additionnalParams, $_key, $_value);
@@ -108,11 +108,11 @@ class JsonRPC
      */
     public function makeSuccess($_result = 'ok')
     {
-        $return = array(
+        $return = [
             'jsonrpc' => '2.0',
             'id' => $this->id,
             'result' => $_result,
-        );
+        ];
         $return = array_merge($return, $this->getAdditionnalParams());
         if (Utils::init('callback') != '') {
             echo Utils::init('callback') . '(' . json_encode($return) . ')';

--- a/src/Model/Entity/JsonRPCClient.php
+++ b/src/Model/Entity/JsonRPCClient.php
@@ -31,7 +31,7 @@ class JsonRPCClient
     protected $result;
     protected $rawResult;
     protected $apikey = '';
-    protected $options = array();
+    protected $options = [];
     protected $apiAddr;
     protected $cb_function = '';
     protected $cb_class = '';
@@ -44,7 +44,7 @@ class JsonRPCClient
      * @param $_apikey
      * @param $_options
      */
-    public function __construct($_apiAddr, $_apikey, $_options = array())
+    public function __construct($_apiAddr, $_apikey, $_options = [])
     {
         $this->apiAddr = $_apiAddr;
         $this->apikey = $_apikey;
@@ -64,13 +64,13 @@ class JsonRPCClient
     {
         $_params['apikey'] = $this->apikey;
         $_params = array_merge($_params, $this->options);
-        $request = array(
-            'request' => json_encode(array(
+        $request = [
+            'request' => json_encode([
                 'jsonrpc' => '2.0',
                 'id' => mt_rand(1, 9999),
                 'method' => $_method,
                 'params' => $_params,
-            )));
+            ])];
         $this->rawResult = preg_replace('/[^[:print:]]/', '', trim($this->send($request, $_timeout, $_file, $_maxRetry)));
 
         if ($this->rawResult === false) {

--- a/src/Model/Entity/Listener.php
+++ b/src/Model/Entity/Listener.php
@@ -17,6 +17,8 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\LogTarget;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\LogHelper;
 use NextDom\Helpers\SystemHelper;
@@ -79,7 +81,7 @@ class Listener implements EntityInterface
      */
     public function run($_event, $_value, $_datetime = null)
     {
-        $option = array();
+        $option = [];
         if (count($this->getOption()) > 0) {
             $option = $this->getOption();
         }
@@ -127,7 +129,7 @@ class Listener implements EntityInterface
     public function execute($_event, $_value, $_datetime = '')
     {
         try {
-            $option = array();
+            $option = [];
             if (count($this->getOption()) > 0) {
                 $option = $this->getOption();
             }
@@ -141,7 +143,7 @@ class Listener implements EntityInterface
                 if (class_exists($targetClass) && method_exists($targetClass, $function)) {
                     $targetClass::$function($option);
                 } else {
-                    LogHelper::add('listener', 'debug', __('[Erreur] Classe ou fonction non trouvée ') . $this->getName());
+                    LogHelper::addDebug(LogTarget::LISTENER, __('[Erreur] Classe ou fonction non trouvée ') . $this->getName());
                     $this->remove();
                     return;
                 }
@@ -150,12 +152,12 @@ class Listener implements EntityInterface
                 if (function_exists($function)) {
                     $function($option);
                 } else {
-                    LogHelper::addError('listener', __('[Erreur] Non trouvée ') . $this->getName());
+                    LogHelper::addError(LogTarget::LISTENER, __('[Erreur] Non trouvée ') . $this->getName());
                     return;
                 }
             }
         } catch (\Exception $e) {
-            LogHelper::add(init('plugin_id', 'plugin'), 'error', $e->getMessage());
+            LogHelper::addError(Utils::init('plugin_id', 'plugin'), $e->getMessage());
         }
     }
 
@@ -240,7 +242,7 @@ class Listener implements EntityInterface
     public function preSave()
     {
         if ($this->getFunction() == '') {
-            throw new \Exception(__('La fonction ne peut pas être vide'));
+            throw new CoreException(__('La fonction ne peut pas être vide'));
         }
     }
 
@@ -261,7 +263,7 @@ class Listener implements EntityInterface
 
     public function emptyEvent()
     {
-        $this->event = array();
+        $this->event = [];
     }
 
     /**
@@ -272,7 +274,7 @@ class Listener implements EntityInterface
     {
         $event = $this->getEvent();
         if (!is_array($event)) {
-            $event = array();
+            $event = [];
         }
         $id = '';
         if ($_type == 'cmd') {
@@ -289,7 +291,7 @@ class Listener implements EntityInterface
      */
     public function getEvent()
     {
-        return Utils::isJson($this->event, array());
+        return Utils::isJson($this->event, []);
     }
 
     /**

--- a/src/Model/Entity/Message.php
+++ b/src/Model/Entity/Message.php
@@ -93,20 +93,20 @@ class Message implements EntityInterface
         }
         if ($this->getLogicalId() == '') {
             $this->setLogicalId($this->getPlugin() . '::' . ConfigManager::genKey());
-            $values = array(
+            $values = [
                 'message' => $this->getMessage(),
                 'plugin' => $this->getPlugin(),
-            );
+            ];
             $sql = 'SELECT count(*)
                     FROM ' . self::DB_CLASS_NAME . '
                     WHERE plugin = :plugin
                     AND message = :message';
             $result = DBHelper::getOne($sql, $values);
         } else {
-            $values = array(
+            $values = [
                 'logicalId' => $this->getLogicalId(),
                 'plugin' => $this->getPlugin(),
-            );
+            ];
             $sql = 'SELECT count(*)
             FROM message
             WHERE plugin=:plugin
@@ -116,17 +116,17 @@ class Message implements EntityInterface
         if ($result['count(*)'] != 0) {
             return null;
         }
-        EventManager::add('notify', array('title' => __('Message de ') . $this->getPlugin(), 'message' => $this->getMessage(), 'category' => 'message'));
+        EventManager::add('notify', ['title' => __('Message de ') . $this->getPlugin(), 'message' => $this->getMessage(), 'category' => 'message']);
         if ($_writeMessage) {
             DBHelper::save($this);
-            $params = array(
+            $params = [
                 '#plugin#' => $this->getPlugin(),
                 '#message#' => $this->getMessage(),
-            );
+            ];
             $actions = ConfigManager::byKey('actionOnMessage');
             if (is_array($actions) && count($actions) > 0) {
                 foreach ($actions as $action) {
-                    $options = array();
+                    $options = [];
                     if (isset($action['options'])) {
                         $options = $action['options'];
                     }

--- a/src/Model/Entity/Note.php
+++ b/src/Model/Entity/Note.php
@@ -88,30 +88,6 @@ class Note implements EntityInterface
     }
 
     /**
-     * Get the name of the note
-     *
-     * @return string Name of the note
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * Set the name of the note
-     *
-     * @param string $newName Name of the note
-     *
-     * @return $this
-     */
-    public function setName($newName)
-    {
-        $this->_changed = Utils::attrChanged($this->_changed, $this->name, $newName);
-        $this->name = $newName;
-        return $this;
-    }
-
-    /**
      * Get the text of the note
      *
      * @return string Text of the note
@@ -167,6 +143,30 @@ class Note implements EntityInterface
         if (trim($this->getName()) == '') {
             throw new CoreException(__('entity.note.name-cannot-be-empty'));
         }
+    }
+
+    /**
+     * Get the name of the note
+     *
+     * @return string Name of the note
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the name of the note
+     *
+     * @param string $newName Name of the note
+     *
+     * @return $this
+     */
+    public function setName($newName)
+    {
+        $this->_changed = Utils::attrChanged($this->_changed, $this->name, $newName);
+        $this->name = $newName;
+        return $this;
     }
 
     /**

--- a/src/Model/Entity/Plan.php
+++ b/src/Model/Entity/Plan.php
@@ -108,7 +108,7 @@ class Plan implements EntityInterface
         if ($this->getCss('z-index') == '') {
             $this->setCss('z-index', 1000);
         }
-        if (in_array($this->getLink_type(), array('eqLogic', 'cmd', 'scenario'))) {
+        if (in_array($this->getLink_type(), ['eqLogic', 'cmd', 'scenario'])) {
             PlanManager::removeByLinkTypeLinkIdPlanHedaerId($this->getLink_type(), $this->getLink_id(), $this->getPlanHeader_id());
         }
     }
@@ -279,7 +279,7 @@ class Plan implements EntityInterface
                 if (is_object($cmd) && $this->getId() == $cmd->getEqLogic_id()) {
                     continue;
                 }
-                $options = array();
+                $options = [];
                 if (isset($action['options'])) {
                     $options = $action['options'];
                 }
@@ -314,6 +314,7 @@ class Plan implements EntityInterface
      * @return array|null
      * @throws \NextDom\Exceptions\CoreException
      * @throws \ReflectionException
+     * @throws \NextDom\Exceptions\OperatingSystemException
      */
     public function getHtml($_version = 'dplan')
     {
@@ -325,10 +326,10 @@ class Plan implements EntityInterface
                 if (!is_object($link)) {
                     return null;
                 }
-                return array(
+                return [
                     'plan' => Utils::o2a($this),
                     'html' => $link->toHtml($_version),
-                );
+                ];
                 break;
             case PlanLinkType::PLAN:
                 $html = '<span class="cursor plan-link-widget" data-link_id="' . $this->getLink_id() . '" data-offsetX="' . $this->getDisplay(PlanDisplayType::OFFSET_X) . '" data-offsetY="' . $this->getDisplay(PlanDisplayType::OFFSET_Y) . '">';
@@ -336,10 +337,10 @@ class Plan implements EntityInterface
                 $html .= $this->getDisplay(PlanDisplayType::ICON) . ' ' . $this->getDisplay(PlanDisplayType::NAME);
                 $html .= '</a>';
                 $html .= '</span>';
-                return array(
+                return [
                     'plan' => Utils::o2a($this),
                     'html' => $html,
-                );
+                ];
                 break;
             case PlanLinkType::VIEW:
                 $link = 'index.php?p=view&view_id=' . $this->getLink_id();
@@ -348,10 +349,10 @@ class Plan implements EntityInterface
                 $html .= $this->getDisplay(PlanDisplayType::ICON) . ' ' . $this->getDisplay(PlanDisplayType::NAME);
                 $html .= '</a>';
                 $html .= '</span>';
-                return array(
+                return [
                     'plan' => Utils::o2a($this),
                     'html' => $html,
-                );
+                ];
                 break;
             case PlanLinkType::GRAPH:
                 $background_color = 'background-color : white;';
@@ -359,13 +360,13 @@ class Plan implements EntityInterface
                     $background_color = '';
                 }
                 $html = '<div class="graph-widget" data-graph_id="' . $this->getLink_id() . '" style="' . $background_color . 'border : solid 1px black;min-height:50px;min-width:50px;">';
-                $html .= '<span class="graphOptions" style="display:none;">' . json_encode($this->getDisplay(PlanDisplayType::GRAPH, array())) . '</span>';
+                $html .= '<span class="graphOptions" style="display:none;">' . json_encode($this->getDisplay(PlanDisplayType::GRAPH, [])) . '</span>';
                 $html .= '<div class="graph" id="graph' . $this->getLink_id() . '" style="width : 100%;height : 100%;"></div>';
                 $html .= '</div>';
-                return array(
+                return [
                     'plan' => Utils::o2a($this),
                     'html' => $html,
-                );
+                ];
             case PlanLinkType::TEXT:
                 $html = '<div class="text-widget" data-text_id="' . $this->getLink_id() . '" style="color:' . $this->getCss('color', 'black') . ';">';
                 if ($this->getDisplay(PlanDisplayType::NAME) != '' || $this->getDisplay(PlanDisplayType::ICON) != '') {
@@ -374,26 +375,26 @@ class Plan implements EntityInterface
                     $html .= $this->getDisplay(PlanDisplayType::TEXT);
                 }
                 $html .= '</div>';
-                return array(
+                return [
                     'plan' => Utils::o2a($this),
                     'html' => $html,
-                );
+                ];
                 break;
             case PlanLinkType::IMAGE:
                 $html = '<div class="image-widget" data-image_id="' . $this->getLink_id() . '" style="min-width:10px;min-height:10px;">';
                 if ($this->getConfiguration('display_mode', 'image') == 'image') {
                     $html .= '<img style="width:100%;height:100%" src="' . $this->getDisplay(PlanDisplayType::PATH, 'public/img/NextDom_NoPicture_Gray.png') . '"/>';
                 } else {
-                    $camera = EqLogicManager::byId(str_replace(array('#', 'eqLogic'), array('', ''), $this->getConfiguration('camera')));
+                    $camera = EqLogicManager::byId(str_replace(['#', 'eqLogic'], ['', ''], $this->getConfiguration('camera')));
                     if (is_object($camera)) {
                         $html .= $camera->toHtml($_version, true);
                     }
                 }
                 $html .= '</div>';
-                return array(
+                return [
                     'plan' => Utils::o2a($this),
                     'html' => $html,
-                );
+                ];
                 break;
             case PlanLinkType::ZONE:
                 if ($this->getConfiguration('zone_mode', 'simple') == 'widget') {
@@ -404,14 +405,14 @@ class Plan implements EntityInterface
                     if ($this->getConfiguration('showOnClic') == 1) {
                         $cssClass .= 'zoneEqLogicOnClic ';
                     }
-                    $html = '<div class="zone-widget cursor zoneEqLogic ' . $cssClass . '" data-position="' . $this->getConfiguration('position') . '" data-eqLogic_id="' . str_replace(array('#', 'eqLogic'), array('', ''), $this->getConfiguration('eqLogic')) . '" data-zone_id="' . $this->getLink_id() . '" style="min-width:20px;min-height:20px;"></div>';
+                    $html = '<div class="zone-widget cursor zoneEqLogic ' . $cssClass . '" data-position="' . $this->getConfiguration('position') . '" data-eqLogic_id="' . str_replace(['#', 'eqLogic'], ['', ''], $this->getConfiguration('eqLogic')) . '" data-zone_id="' . $this->getLink_id() . '" style="min-width:20px;min-height:20px;"></div>';
                 } else {
                     $html = '<div class="zone-widget cursor" data-zone_id="' . $this->getLink_id() . '" style="min-width:20px;min-height:20px;"></div>';
                 }
-                return array(
+                return [
                     'plan' => NextDomHelper::toHumanReadable(Utils::o2a($this)),
                     'html' => $html,
-                );
+                ];
                 break;
             case PlanLinkType::SUMMARY:
                 $background_color = 'background-color : ' . $this->getCss('background-color', 'black') . ';';

--- a/src/Model/Entity/Plan3dHeader.php
+++ b/src/Model/Entity/Plan3dHeader.php
@@ -17,6 +17,8 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\DateFormat;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Utils;
@@ -59,7 +61,7 @@ class Plan3dHeader implements EntityInterface
     public function preSave()
     {
         if (trim($this->getName()) == '') {
-            throw new \Exception(__('Le nom du l\'objet ne peut pas être vide'));
+            throw new CoreException(__('Le nom du l\'objet ne peut pas être vide'));
         }
     }
 
@@ -93,7 +95,7 @@ class Plan3dHeader implements EntityInterface
         if (file_exists($cibDir) && $this->getConfiguration('path', '') != '') {
             rrmdir($cibDir);
         }
-        NextDomHelper::addRemoveHistory(array('id' => $this->getId(), 'name' => $this->getName(), 'date' => date('Y-m-d H:i:s'), 'type' => 'plan3d'));
+        NextDomHelper::addRemoveHistory(['id' => $this->getId(), 'name' => $this->getName(), 'date' => date(DateFormat::FULL), 'type' => 'plan3d']);
         DBHelper::remove($this);
     }
 

--- a/src/Model/Entity/PlanHeader.php
+++ b/src/Model/Entity/PlanHeader.php
@@ -17,6 +17,8 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\DateFormat;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\FileSystemHelper;
 use NextDom\Helpers\NetworkHelper;
@@ -72,7 +74,7 @@ class PlanHeader implements EntityInterface
      * @return string
      * @throws \Exception
      */
-    public function report($_format = 'pdf', $_parameters = array())
+    public function report($_format = 'pdf', $_parameters = [])
     {
         $url = NetworkHelper::getNetworkAccess('internal') . '/index.php?v=d&p=plan';
         $url .= '&plan_id=' . $this->getId();
@@ -169,7 +171,7 @@ class PlanHeader implements EntityInterface
     public function preSave()
     {
         if (trim($this->getName()) == '') {
-            throw new \Exception(__('Le nom du plan ne peut pas être vide'));
+            throw new CoreException(__('Le nom du plan ne peut pas être vide'));
         }
         if ($this->getConfiguration('desktopSizeX') == '') {
             $this->setConfiguration('desktopSizeX', 500);
@@ -232,12 +234,13 @@ class PlanHeader implements EntityInterface
 
     public function remove()
     {
-        NextDomHelper::addRemoveHistory(array('id' => $this->getId(), 'name' => $this->getName(), 'date' => date('Y-m-d H:i:s'), 'type' => 'plan'));
+        NextDomHelper::addRemoveHistory(['id' => $this->getId(), 'name' => $this->getName(), 'date' => date(DateFormat::FULL), 'type' => 'plan']);
         DBHelper::remove($this);
     }
 
     /**
      * @return string
+     * @throws CoreException
      */
     public function displayImage()
     {
@@ -246,7 +249,7 @@ class PlanHeader implements EntityInterface
         }
         $dir = NEXTDOM_DATA . '/data/custom/plans/';
         if (!file_exists($dir)) {
-            FileSystemHelper::mkdirIfNotExists($dir,0755,true);
+            FileSystemHelper::mkdirIfNotExists($dir, 0755, true);
         }
         if ($this->getImage('sha512') == '') {
             $this->setImage('sha512', Utils::sha512($this->getImage('data')));
@@ -258,7 +261,7 @@ class PlanHeader implements EntityInterface
             file_put_contents($filepath, base64_decode($this->getImage('data')));
         }
         $size = $this->getImage('size');
-        return '<img style="z-index:997" src="'. '/data/custom/plans/' . $filename . '" data-size_y="' . $size[1] . '" data-size_x="' . $size[0] . '">';
+        return '<img style="z-index:997" src="' . '/data/custom/plans/' . $filename . '" data-size_y="' . $size[1] . '" data-size_x="' . $size[0] . '">';
     }
 
     /**
@@ -268,7 +271,7 @@ class PlanHeader implements EntityInterface
      * @return array|null
      * @throws \Exception
      */
-    public function getLinkData(&$_data = array('node' => array(), 'link' => array()), $_level = 0, $_drill = 3)
+    public function getLinkData(&$_data = ['node' => [], 'link' => []], $_level = 0, $_drill = 3)
     {
         if (isset($_data['node']['plan' . $this->getId()])) {
             return null;
@@ -278,7 +281,7 @@ class PlanHeader implements EntityInterface
             return $_data;
         }
         $icon = Utils::findCodeIcon('fa-paint-brush');
-        $_data['node']['plan' . $this->getId()] = array(
+        $_data['node']['plan' . $this->getId()] = [
             'id' => 'interactDef' . $this->getId(),
             'name' => substr($this->getName(), 0, 20),
             'icon' => $icon['icon'],
@@ -289,7 +292,7 @@ class PlanHeader implements EntityInterface
             'textx' => 0,
             'title' => __('Design :') . ' ' . $this->getName(),
             'url' => 'index.php?v=d&p=plan&view_id=' . $this->getId(),
-        );
+        ];
         return null;
     }
 

--- a/src/Model/Entity/Plugin.php
+++ b/src/Model/Entity/Plugin.php
@@ -18,6 +18,7 @@
 namespace NextDom\Model\Entity;
 
 use NextDom\Enums\DateFormat;
+use NextDom\Enums\LogTarget;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\FileSystemHelper;
 use NextDom\Helpers\LogHelper;
@@ -129,25 +130,25 @@ class Plugin implements EntityInterface
             $this->mobile = (isset($data['mobile'])) ? $data['mobile'] : $data['id'];
         }
         if (isset($data['include'])) {
-            $this->include = array(
+            $this->include = [
                 'file' => $data['include']['file'],
                 'type' => $data['include']['type'],
-            );
+            ];
         } else {
-            $this->include = array(
+            $this->include = [
                 'file' => $data['id'],
                 'type' => 'class',
-            );
+            ];
         }
-        $this->functionality['interact'] = array('exists' => method_exists($this->getId(), 'interact'), 'controlable' => 1);
-        $this->functionality['cron'] = array('exists' => method_exists($this->getId(), 'cron'), 'controlable' => 1);
-        $this->functionality['cron5'] = array('exists' => method_exists($this->getId(), 'cron5'), 'controlable' => 1);
-        $this->functionality['cron15'] = array('exists' => method_exists($this->getId(), 'cron15'), 'controlable' => 1);
-        $this->functionality['cron30'] = array('exists' => method_exists($this->getId(), 'cron30'), 'controlable' => 1);
-        $this->functionality['cronHourly'] = array('exists' => method_exists($this->getId(), 'cronHourly'), 'controlable' => 1);
-        $this->functionality['cronDaily'] = array('exists' => method_exists($this->getId(), 'cronDaily'), 'controlable' => 1);
-        $this->functionality['deadcmd'] = array('exists' => method_exists($this->getId(), 'deadCmd'), 'controlable' => 0);
-        $this->functionality['health'] = array('exists' => method_exists($this->getId(), 'health'), 'controlable' => 0);
+        $this->functionality['interact'] = ['exists' => method_exists($this->getId(), 'interact'), 'controlable' => 1];
+        $this->functionality['cron'] = ['exists' => method_exists($this->getId(), 'cron'), 'controlable' => 1];
+        $this->functionality['cron5'] = ['exists' => method_exists($this->getId(), 'cron5'), 'controlable' => 1];
+        $this->functionality['cron15'] = ['exists' => method_exists($this->getId(), 'cron15'), 'controlable' => 1];
+        $this->functionality['cron30'] = ['exists' => method_exists($this->getId(), 'cron30'), 'controlable' => 1];
+        $this->functionality['cronHourly'] = ['exists' => method_exists($this->getId(), 'cronHourly'), 'controlable' => 1];
+        $this->functionality['cronDaily'] = ['exists' => method_exists($this->getId(), 'cronDaily'), 'controlable' => 1];
+        $this->functionality['deadcmd'] = ['exists' => method_exists($this->getId(), 'deadCmd'), 'controlable' => 0];
+        $this->functionality['health'] = ['exists' => method_exists($this->getId(), 'health'), 'controlable' => 0];
     }
 
     /**
@@ -171,15 +172,6 @@ class Plugin implements EntityInterface
         return $this;
     }
 
-    public function getPathToConfiguration(): string
-    {
-        $result = '';
-        if (file_exists(NEXTDOM_ROOT . '/plugins/' . $this->id . '/plugin_info/configuration.php')) {
-            $result = 'plugins/' . $this->id . '/plugin_info/configuration.php';
-        }
-        return $result;
-    }
-
     /**
      * Obtenir le fichier de configuration du plugin
      *
@@ -189,6 +181,15 @@ class Plugin implements EntityInterface
     {
         @trigger_error('This method is deprecated. Use getPathToConfiguration', E_USER_DEPRECATED);
         return $this->getPathToConfiguration();
+    }
+
+    public function getPathToConfiguration(): string
+    {
+        $result = '';
+        if (file_exists(NEXTDOM_ROOT . '/plugins/' . $this->id . '/plugin_info/configuration.php')) {
+            $result = 'plugins/' . $this->id . '/plugin_info/configuration.php';
+        }
+        return $result;
     }
 
     /**
@@ -202,10 +203,10 @@ class Plugin implements EntityInterface
      *
      * @throws \Exception
      */
-    public function report($outputFormat = 'pdf', $parameters = array())
+    public function report($outputFormat = 'pdf', $parameters = [])
     {
         if ($this->getDisplay() == '') {
-            throw new \Exception(__('core.cant-report'));
+            throw new CoreException(__('core.cant-report'));
         }
         $url = NetworkHelper::getNetworkAccess('internal') . '/index.php?v=d&p=' . $this->getDisplay();
         $url .= '&m=' . $this->getId();
@@ -267,7 +268,7 @@ class Plugin implements EntityInterface
     {
         $pluginId = $this->getId();
         if ($this->getHasDependency() != 1 || !method_exists($pluginId, 'dependancy_info')) {
-            return array('state' => 'nok', 'log' => 'nok');
+            return ['state' => 'nok', 'log' => 'nok'];
         }
         $cache = CacheManager::byKey('dependancy' . $this->getID());
         if ($refresh) {
@@ -346,11 +347,11 @@ class Plugin implements EntityInterface
         if (abs(strtotime(DateFormat::NOW) - strtotime(ConfigManager::byKey('lastDependancyInstallTime', $plugin_id))) <= 60) {
             $cache = CacheManager::byKey('dependancy' . $this->getID());
             $cache->remove();
-            throw new \Exception(__('Vous devez attendre au moins 60 secondes entre deux lancements d\'installation de dépendances'));
+            throw new CoreException(__('Vous devez attendre au moins 60 secondes entre deux lancements d\'installation de dépendances'));
         }
         $dependancy_info = $this->getDependencyInfo(true);
         if ($dependancy_info['state'] == 'in_progress') {
-            throw new \Exception(__('Les dépendances sont déjà en cours d\'installation'));
+            throw new CoreException(__('Les dépendances sont déjà en cours d\'installation'));
         }
         foreach (PluginManager::listPlugin(true) as $plugin) {
             if ($plugin->getId() == $this->getId()) {
@@ -358,7 +359,7 @@ class Plugin implements EntityInterface
             }
             $dependancy_info = $plugin->getDependencyInfo();
             if ($dependancy_info['state'] == 'in_progress') {
-                throw new \Exception(__('Les dépendances d\'un autre plugin sont déjà en cours, veuillez attendre qu\'elles soient finies : ') . $plugin->getId());
+                throw new CoreException(__('Les dépendances d\'un autre plugin sont déjà en cours, veuillez attendre qu\'elles soient finies : ') . $plugin->getId());
             }
         }
         $cmd = $plugin_id::dependancy_install();
@@ -373,10 +374,10 @@ class Plugin implements EntityInterface
                     exec(SystemHelper::getCmdSudo() . '/bin/bash ' . $script . ' >> ' . $cmd['log'] . ' 2>&1 &');
                     sleep(1);
                 } else {
-                    LogHelper::add($plugin_id, 'error', __('Veuillez exécuter le script : ') . '/bin/bash ' . $script);
+                    LogHelper::addError($plugin_id, __('Veuillez exécuter le script : ') . '/bin/bash ' . $script);
                 }
             } else {
-                LogHelper::add($plugin_id, 'error', __('Aucun script ne correspond à votre type de Linux : ') . $cmd['script'] . __(' avec #stype# : ') . SystemHelper::getCommand('type'));
+                LogHelper::addError($plugin_id, __('Aucun script ne correspond à votre type de Linux : ') . $cmd['script'] . __(' avec #stype# : ') . SystemHelper::getCommand('type'));
             }
         }
         $cache = CacheManager::byKey('dependancy' . $this->getID());
@@ -398,7 +399,7 @@ class Plugin implements EntityInterface
                 }
             }
         } catch (\Throwable $e) {
-            LogHelper::add($plugin_id, 'error', __('Erreur sur la fonction deamon_stop du plugin : ') . $e->getMessage());
+            LogHelper::addError($plugin_id, __('Erreur sur la fonction deamon_stop du plugin : ') . $e->getMessage());
         }
     }
 
@@ -423,7 +424,7 @@ class Plugin implements EntityInterface
 
         $plugin_id = $this->getId();
         if ($this->getHasOwnDeamon() != 1 || !method_exists($plugin_id, 'deamon_info')) {
-            return array('launchable_message' => '', 'launchable' => 'nok', 'state' => 'nok', 'log' => 'nok', 'auto' => 0);
+            return ['launchable_message' => '', 'launchable' => 'nok', 'state' => 'nok', 'log' => 'nok', 'auto' => 0];
         }
         $result = $plugin_id::deamon_info();
         if ($this->getHasDependency() == 1 && method_exists($plugin_id, 'dependancy_info') && $result['launchable'] == 'ok') {
@@ -498,27 +499,27 @@ class Plugin implements EntityInterface
                 }
                 if ($deamon_info['launchable'] == 'ok' && $deamon_info['state'] == 'nok' && method_exists($pluginId, 'deamon_start')) {
                     $inprogress = CacheManager::byKey('deamonStart' . $this->getId() . 'inprogress');
-                    $info = $inprogress->getValue(array('datetime' => strtotime('now') - 60));
+                    $info = $inprogress->getValue(['datetime' => strtotime('now') - 60]);
                     $info['datetime'] = (isset($info['datetime'])) ? $info['datetime'] : strtotime('now') - 60;
                     if (abs(strtotime(DateFormat::NOW) - $info['datetime']) < 45) {
                         if ($auto) {
                             return;
                         }
-                        throw new \Exception(__('Vous devez attendre au moins 45 secondes entre deux lancements du démon. Dernier lancement : ' . date("Y-m-d H:i:s", $info['datetime'])));
+                        throw new CoreException(__('Vous devez attendre au moins 45 secondes entre deux lancements du démon. Dernier lancement : ' . date("Y-m-d H:i:s", $info['datetime'])));
                     }
                     if (ConfigManager::byKey('deamonRestartNumber', $pluginId, 0) > 3) {
-                        LogHelper::add($pluginId, 'error', __('Attention je pense qu\'il y a un soucis avec le démon que j\'ai relancé plus de 3 fois consecutivement'));
+                        LogHelper::addError($pluginId, __('Attention je pense qu\'il y a un soucis avec le démon que j\'ai relancé plus de 3 fois consecutivement'));
                     }
                     if (!$forceRestart) {
                         ConfigManager::save('deamonRestartNumber', ConfigManager::byKey('deamonRestartNumber', $pluginId, 0) + 1, $pluginId);
                     }
-                    CacheManager::set('deamonStart' . $this->getId() . 'inprogress', array('datetime' => strtotime('now')));
+                    CacheManager::set('deamonStart' . $this->getId() . 'inprogress', ['datetime' => strtotime('now')]);
                     ConfigManager::save('lastDeamonLaunchTime', date(DateFormat::FULL), $pluginId);
                     $pluginId::deamon_start();
                 }
             }
         } catch (\Throwable $e) {
-            LogHelper::add($pluginId, 'error', __('Erreur sur la fonction deamon_start du plugin : ') . $e->getMessage());
+            LogHelper::addError($pluginId, __('Erreur sur la fonction deamon_start du plugin : ') . $e->getMessage());
         }
     }
 
@@ -576,12 +577,12 @@ class Plugin implements EntityInterface
         }
         try {
             if ($state == 1) {
-                LogHelper::add($this->getId(), 'info', 'Début d\'activation du plugin');
+                LogHelper::addInfo($this->getId(), 'Début d\'activation du plugin');
                 $this->deamon_stop();
 
                 $deamon_info = $this->deamon_info();
                 sleep(1);
-                LogHelper::add($this->getId(), 'info', 'Info sur le démon : ' . print_r($deamon_info, true));
+                LogHelper::addInfo($this->getId(), 'Info sur le démon : ' . print_r($deamon_info, true));
                 if ($deamon_info['state'] == 'ok') {
                     $this->deamon_stop();
                 }
@@ -599,7 +600,7 @@ class Plugin implements EntityInterface
                 rrmdir(NextDomHelper::getTmpFolder($this->getId()));
             }
             if (isset($out) && trim($out) != '') {
-                LogHelper::add($this->getId(), 'info', "Installation/remove/update result : " . $out);
+                LogHelper::addInfo($this->getId(), "Installation/remove/update result : " . $out);
             }
         } catch (\Throwable $e) {
             ConfigManager::save('active', $alreadyActive, $this->getId());
@@ -647,30 +648,21 @@ class Plugin implements EntityInterface
     {
         if ($direct) {
             // Lancement de la procédure de préinstallation
+            $targetFile = 'install.php';
             if (strpos($functionToCall, 'pre_') !== false) {
-                LogHelper::add('plugin', 'debug', 'Recherche de ' . NEXTDOM_ROOT . '/plugins/' . $this->getId() . '/plugin_info/pre_install.php');
-                if (file_exists(NEXTDOM_ROOT . '/plugins/' . $this->getId() . '/plugin_info/pre_install.php')) {
-                    LogHelper::add('plugin', 'debug', 'Fichier d\'installation trouvé pour  : ' . $this->getId());
-                    require_once NEXTDOM_ROOT . '/plugins/' . $this->getId() . '/plugin_info/pre_install.php';
-                    ob_start();
-                    $function = $this->getId() . '_' . $functionToCall;
-                    if (function_exists($this->getId() . '_' . $functionToCall)) {
-                        $function();
-                    }
-                    return ob_get_clean();
+                $targetFile = 'pre_install.php';
+            }
+            LogHelper::addDebug(LogTarget::PLUGIN, 'Recherche de ' . NEXTDOM_ROOT . '/plugins/' . $this->getId() . '/plugin_info/' . $targetFile);
+            if (file_exists(NEXTDOM_ROOT . '/plugins/' . $this->getId() . '/plugin_info/' . $targetFile)) {
+                LogHelper::addDebug(LogTarget::PLUGIN, 'Fichier d\'installation trouvé pour  : ' . $this->getId());
+                /** @noinspection PhpIncludeInspection */
+                require_once NEXTDOM_ROOT . '/plugins/' . $this->getId() . '/plugin_info/' . $targetFile;
+                ob_start();
+                $function = $this->getId() . '_' . $functionToCall;
+                if (function_exists($this->getId() . '_' . $functionToCall)) {
+                    $function();
                 }
-            } else {
-                LogHelper::add('plugin', 'debug', 'Recherche de ' . NEXTDOM_ROOT . '/plugins/' . $this->getId() . '/plugin_info/install.php');
-                if (file_exists(NEXTDOM_ROOT . '/plugins/' . $this->getId() . '/plugin_info/install.php')) {
-                    LogHelper::add('plugin', 'debug', 'Fichier d\'installation trouvé pour  : ' . $this->getId());
-                    require_once NEXTDOM_ROOT . '/plugins/' . $this->getId() . '/plugin_info/install.php';
-                    ob_start();
-                    $function = $this->getId() . '_' . $functionToCall;
-                    if (function_exists($this->getId() . '_' . $functionToCall)) {
-                        $function();
-                    }
-                    return ob_get_clean();
-                }
+                return ob_get_clean();
             }
         } else {
             return $this->launch($functionToCall, true);
@@ -691,10 +683,10 @@ class Plugin implements EntityInterface
     public function launch($functionToCall, $callInstallFunction = false)
     {
         if ($functionToCall == '') {
-            throw new \Exception('La fonction à lancer ne peut être vide');
+            throw new CoreException('La fonction à lancer ne peut être vide');
         }
         if (!$callInstallFunction && (!class_exists($this->getId()) || !method_exists($this->getId(), $functionToCall))) {
-            throw new \Exception('Il n\'existe aucune méthode : ' . $this->getId() . '::' . $functionToCall . '()');
+            throw new CoreException('Il n\'existe aucune méthode : ' . $this->getId() . '::' . $functionToCall . '()');
         }
         $cmd = NEXTDOM_ROOT . '/src/Api/start_plugin_func.php ';
         $cmd .= ' plugin_id=' . $this->getId();
@@ -703,7 +695,7 @@ class Plugin implements EntityInterface
         if (NextDomHelper::checkOngoingThread($cmd) > 0) {
             return true;
         }
-        LogHelper::add($this->getId(), 'debug', __('Lancement de : ') . $cmd);
+        LogHelper::addDebug($this->getId(), __('Lancement de : ') . $cmd);
         if ($callInstallFunction) {
             return SystemHelper::php($cmd . ' >> /dev/null 2>&1');
         } else {

--- a/src/Model/Entity/Scenario.php
+++ b/src/Model/Entity/Scenario.php
@@ -145,7 +145,7 @@ class Scenario implements EntityInterface
      */
     protected $id;
     /**
-     * @var \NextDom\Model\Entity\JeeObject
+     * @var int
      *
      * ORM\ManyToOne(targetEntity="NextDom\Model\Entity\Object")
      * ORM\JoinColumns({
@@ -153,11 +153,11 @@ class Scenario implements EntityInterface
      * })
      */
     protected $object_id;
-    protected $_elements = array();
+    protected $_elements = [];
     protected $_changeState = false;
     protected $_realTrigger = '';
     protected $_return = true;
-    protected $_tags = array();
+    protected $_tags = [];
     protected $_do = true;
     protected $_log;
     protected $_changed = false;
@@ -175,6 +175,11 @@ class Scenario implements EntityInterface
         return $this->isVisible;
     }
 
+    public function isVisible()
+    {
+        return intval($this->isVisible) == 1;
+    }
+
     /**
      * @param $isVisible
      * @return $this
@@ -183,11 +188,6 @@ class Scenario implements EntityInterface
     {
         $this->isVisible = $isVisible;
         return $this;
-    }
-
-    public function isVisible()
-    {
-        return intval($this->isVisible) == 1;
     }
 
     /**
@@ -217,7 +217,7 @@ class Scenario implements EntityInterface
     public function testTrigger($event): bool
     {
         foreach ($this->getTrigger() as $trigger) {
-            $trigger = str_replace(array('#variable(', ')#'), array('variable(', ')'), $trigger);
+            $trigger = str_replace(['#variable(', ')#'], ['variable(', ')'], $trigger);
             if ($trigger == $event) {
                 return true;
             } elseif (strpos($trigger, $event) !== false && NextDomHelper::evaluateExpression($trigger)) {
@@ -233,7 +233,7 @@ class Scenario implements EntityInterface
      */
     public function getTrigger()
     {
-        return Utils::isJson($this->trigger, array($this->trigger));
+        return Utils::isJson($this->trigger, [$this->trigger]);
     }
 
     /**
@@ -326,6 +326,16 @@ class Scenario implements EntityInterface
     }
 
     /**
+     * Get active state of the scenario
+     *
+     * @return bool Active state
+     */
+    public function isActive(): bool
+    {
+        return $this->isActive == 1;
+    }
+
+    /**
      *
      * @param int $isActive
      * @return $this
@@ -341,97 +351,13 @@ class Scenario implements EntityInterface
     }
 
     /**
-     * Get active state of the scenario
      *
-     * @return bool Active state
-     */
-    public function isActive(): bool {
-        return $this->isActive == 1;
-    }
-
-    /**
-     *
-     * @param string $key
-     * @param mixed $defaultValue
-     *
-     * @return mixed
-     */
-    public function getConfiguration($key = '', $defaultValue = '')
-    {
-        return Utils::getJsonAttr($this->configuration, $key, $defaultValue);
-    }
-
-    /**
-     *
-     * @param string $key
-     * @param mixed $value
-     *
-     * @return $this
-     */
-    public function setConfiguration($key, $value)
-    {
-        $this->configuration = Utils::setJsonAttr($this->configuration, $key, $value);
-        return $this;
-    }
-
-    /**
-     * Execute the scenario
-     *
-     * @param string $trigger
-     * @param string $message
      * @return mixed
      * @throws \Exception
      */
-    public function execute($trigger = '', $message = '')
+    public function getState()
     {
-        $tags = $this->getCache('tags');
-        if ($tags != '') {
-            $this->setTags($tags);
-            $this->setCache('tags', '');
-        }
-        if ($this->getIsActive() != 1) {
-            $this->setLog(__('Impossible d\'exécuter le scénario : ') . $this->getHumanName() . __(' sur : ') . $message . __(' car il est désactivé'));
-            $this->persistLog();
-            return null;
-        }
-        if ($this->getConfiguration('timeDependency', 0) == 1 && !NextDomHelper::isDateOk()) {
-            $this->setLog(__('Lancement du scénario : ') . $this->getHumanName() . __(' annulé car il utilise une condition de type temporelle et que la date système n\'est pas OK'));
-            $this->persistLog();
-            return null;
-        }
-
-        $cmd = CmdManager::byId(str_replace('#', '', $trigger));
-        if (is_object($cmd)) {
-            LogHelper::addInfo(LogTarget::EVENT, __('Exécution du scénario ') . $this->getHumanName() . __(' déclenché par : ') . $cmd->getHumanName());
-            if ($this->getConfiguration('timeline::enable')) {
-                TimeLineHelper::addTimelineEvent(array('type' => NextDomObj::SCENARIO, 'id' => $this->getId(), 'name' => $this->getHumanName(true), 'datetime' => date(DateFormat::FULL), 'trigger' => $cmd->getHumanName(true)));
-            }
-        } else {
-            LogHelper::addInfo(LogTarget::EVENT, __('Exécution du scénario ') . $this->getHumanName() . __(' déclenché par : ') . $trigger);
-            if ($this->getConfiguration('timeline::enable')) {
-                TimeLineHelper::addTimelineEvent(array('type' => NextDomObj::SCENARIO, 'id' => $this->getId(), 'name' => $this->getHumanName(true), 'datetime' => date(DateFormat::FULL), 'trigger' => $trigger == 'schedule' ? 'programmation' : $trigger));
-            }
-        }
-        if (count($this->getTags()) == 0) {
-            $this->setLog('Start : ' . trim($message, "'") . '.');
-        } else {
-            $this->setLog('Start : ' . trim($message, "'") . '. Tags : ' . json_encode($this->getTags()));
-        }
-        $this->setLastLaunch(date(DateFormat::FULL));
-        $this->setState(ScenarioState::IN_PROGRESS);
-        $this->setPID(getmypid());
-        $this->setRealTrigger($trigger);
-        foreach ($this->getElement() as $element) {
-            if (!$this->getDo()) {
-                break;
-            }
-            $element->execute($this);
-        }
-        $this->setState('stop');
-        $this->setPID();
-        $this->setLog(__('Fin correcte du scénario'));
-        $this->persistLog();
-        return $this->getReturn();
+        return $this->getCache('state');
     }
 
     /**
@@ -472,6 +398,98 @@ class Scenario implements EntityInterface
     }
 
     /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param $name
+     * @return $this
+     */
+    public function setName($name)
+    {
+        if ($name != $this->getName()) {
+            $this->_changeState = true;
+            $this->_changed = true;
+        }
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     *
+     * @param mixed $_partial
+     * @return bool|null
+     */
+    public function persistLog($_partial = false)
+    {
+        if ($this->getConfiguration('logmode', 'default') == 'none') {
+            return null;
+        }
+        $path = NEXTDOM_LOG . '/scenarioLog';
+        if (!file_exists($path)) {
+            mkdir($path);
+        }
+        $path .= '/scenario' . $this->getId() . '.log';
+        if ($_partial) {
+            file_put_contents($path, $this->getLog(), FILE_APPEND);
+        } else {
+            file_put_contents($path, "------------------------------------\n" . $this->getLog(), FILE_APPEND);
+        }
+        return true;
+    }
+
+    /**
+     *
+     * @param string $key
+     * @param mixed $defaultValue
+     *
+     * @return mixed
+     */
+    public function getConfiguration($key = '', $defaultValue = '')
+    {
+        return Utils::getJsonAttr($this->configuration, $key, $defaultValue);
+    }
+
+    /**
+     *
+     * @param string $key
+     * @param mixed $value
+     *
+     * @return $this
+     */
+    public function setConfiguration($key, $value)
+    {
+        $this->configuration = Utils::setJsonAttr($this->configuration, $key, $value);
+        return $this;
+    }
+
+    /**
+     *
+     * @return mixed
+     */
+    public function getLog()
+    {
+        return $this->_log;
+    }
+
+    /**
+     *
+     * @param string $log
+     */
+    public function setLog($log)
+    {
+        $this->_log .= '[' . date(DateFormat::FULL) . '][SCENARIO] ' . $log . "\n";
+        if ($this->getConfiguration('logmode', 'default') == 'realtime') {
+            $this->persistLog(true);
+            $this->_log = '';
+        }
+    }
+
+    /**
      * Store data in cache
      *
      * Data are stored in scenarioCacheAttr + Scenario_ID
@@ -484,6 +502,66 @@ class Scenario implements EntityInterface
     public function setCache($key, $valueToStore = null)
     {
         CacheManager::set(CacheKey::SCENARIO_CACHE_ATTR . $this->getId(), Utils::setJsonAttr(CacheManager::byKey(CacheKey::SCENARIO_CACHE_ATTR . $this->getId())->getValue(), $key, $valueToStore));
+    }
+
+    /**
+     * Execute the scenario
+     *
+     * @param string $trigger
+     * @param string $message
+     * @return mixed
+     * @throws \Exception
+     */
+    public function execute($trigger = '', $message = '')
+    {
+        $tags = $this->getCache('tags');
+        if ($tags != '') {
+            $this->setTags($tags);
+            $this->setCache('tags', '');
+        }
+        if ($this->getIsActive() != 1) {
+            $this->setLog(__('Impossible d\'exécuter le scénario : ') . $this->getHumanName() . __(' sur : ') . $message . __(' car il est désactivé'));
+            $this->persistLog();
+            return null;
+        }
+        if ($this->getConfiguration('timeDependency', 0) == 1 && !NextDomHelper::isDateOk()) {
+            $this->setLog(__('Lancement du scénario : ') . $this->getHumanName() . __(' annulé car il utilise une condition de type temporelle et que la date système n\'est pas OK'));
+            $this->persistLog();
+            return null;
+        }
+
+        $cmd = CmdManager::byId(str_replace('#', '', $trigger));
+        if (is_object($cmd)) {
+            LogHelper::addInfo(LogTarget::EVENT, __('Exécution du scénario ') . $this->getHumanName() . __(' déclenché par : ') . $cmd->getHumanName());
+            if ($this->getConfiguration('timeline::enable')) {
+                TimeLineHelper::addTimelineEvent(['type' => NextDomObj::SCENARIO, 'id' => $this->getId(), 'name' => $this->getHumanName(true), 'datetime' => date(DateFormat::FULL), 'trigger' => $cmd->getHumanName(true)]);
+            }
+        } else {
+            LogHelper::addInfo(LogTarget::EVENT, __('Exécution du scénario ') . $this->getHumanName() . __(' déclenché par : ') . $trigger);
+            if ($this->getConfiguration('timeline::enable')) {
+                TimeLineHelper::addTimelineEvent(['type' => NextDomObj::SCENARIO, 'id' => $this->getId(), 'name' => $this->getHumanName(true), 'datetime' => date(DateFormat::FULL), 'trigger' => $trigger == 'schedule' ? 'programmation' : $trigger]);
+            }
+        }
+        if (count($this->getTags()) == 0) {
+            $this->setLog('Start : ' . trim($message, "'") . '.');
+        } else {
+            $this->setLog('Start : ' . trim($message, "'") . '. Tags : ' . json_encode($this->getTags()));
+        }
+        $this->setLastLaunch(date(DateFormat::FULL));
+        $this->setState(ScenarioState::IN_PROGRESS);
+        $this->setPID(getmypid());
+        $this->setRealTrigger($trigger);
+        foreach ($this->getElement() as $element) {
+            if (!$this->getDo()) {
+                break;
+            }
+            $element->execute($this);
+        }
+        $this->setState('stop');
+        $this->setPID();
+        $this->setLog(__('Fin correcte du scénario'));
+        $this->persistLog();
+        return $this->getReturn();
     }
 
     /**
@@ -607,73 +685,6 @@ class Scenario implements EntityInterface
     }
 
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * @param $name
-     * @return $this
-     */
-    public function setName($name)
-    {
-        if ($name != $this->getName()) {
-            $this->_changeState = true;
-            $this->_changed = true;
-        }
-        $this->name = $name;
-        return $this;
-    }
-
-    /**
-     *
-     * @param mixed $_partial
-     * @return bool|null
-     */
-    public function persistLog($_partial = false)
-    {
-        if ($this->getConfiguration('logmode', 'default') == 'none') {
-            return null;
-        }
-        $path = NEXTDOM_LOG . '/scenarioLog';
-        if (!file_exists($path)) {
-            mkdir($path);
-        }
-        $path .= '/scenario' . $this->getId() . '.log';
-        if ($_partial) {
-            file_put_contents($path, $this->getLog(), FILE_APPEND);
-        } else {
-            file_put_contents($path, "------------------------------------\n" . $this->getLog(), FILE_APPEND);
-        }
-        return true;
-    }
-
-    /**
-     *
-     * @return mixed
-     */
-    public function getLog()
-    {
-        return $this->_log;
-    }
-
-    /**
-     *
-     * @param string $log
-     */
-    public function setLog($log)
-    {
-        $this->_log .= '[' . date(DateFormat::FULL) . '][SCENARIO] ' . $log . "\n";
-        if ($this->getConfiguration('logmode', 'default') == 'realtime') {
-            $this->persistLog(true);
-            $this->_log = '';
-        }
-    }
-
-    /**
      *
      * @return array
      */
@@ -712,7 +723,7 @@ class Scenario implements EntityInterface
     {
         if ($this->getCache('state') != $state) {
             $this->emptyCacheWidget();
-            EventManager::add('scenario::update', array('scenario_id' => $this->getId(), 'state' => $state, 'lastLaunch' => $this->getLastLaunch()));
+            EventManager::add('scenario::update', ['scenario_id' => $this->getId(), 'state' => $state, 'lastLaunch' => $this->getLastLaunch()]);
         }
         $this->setCache('state', $state);
     }
@@ -762,7 +773,7 @@ class Scenario implements EntityInterface
         if (count($this->_elements) > 0) {
             return $this->_elements;
         }
-        $result = array();
+        $result = [];
         $elements = $this->getScenarioElement();
         $elementId = -1;
         if (is_array($elements)) {
@@ -783,7 +794,7 @@ class Scenario implements EntityInterface
                 return $result;
             }
         }
-        return array();
+        return [];
     }
 
     /**
@@ -862,7 +873,7 @@ class Scenario implements EntityInterface
         $scenarioCopy = clone $this;
         $scenarioCopy->setName($name);
         $scenarioCopy->setId('');
-        $scenario_element_list = array();
+        $scenario_element_list = [];
         foreach ($this->getElement() as $element) {
             $scenario_element_list[] = $element->copy();
         }
@@ -874,6 +885,13 @@ class Scenario implements EntityInterface
         }
         return $scenarioCopy;
     }
+
+    /**
+     * @return string
+     */
+    /**
+     * @return string
+     */
 
     /**
      *
@@ -888,16 +906,19 @@ class Scenario implements EntityInterface
         $this->emptyCacheWidget();
         if ($this->_changeState) {
             $this->_changeState = false;
-            EventManager::add('scenario::update', array('scenario_id' => $this->getId(), 'isActive' => $this->getIsActive(), 'state' => $this->getState(), 'lastLaunch' => $this->getLastLaunch()));
+            EventManager::add('scenario::update', ['scenario_id' => $this->getId(), 'isActive' => $this->getIsActive(), 'state' => $this->getState(), 'lastLaunch' => $this->getLastLaunch()]);
         }
     }
 
     /**
-     * @return string
+     * @param $_mode
+     * @return $this
      */
     /**
-     * @return string
+     * @param $_mode
+     * @return $this
      */
+
     /**
      * @return string
      */
@@ -910,14 +931,6 @@ class Scenario implements EntityInterface
      * @param $_mode
      * @return $this
      */
-    /**
-     * @param $_mode
-     * @return $this
-     */
-    /**
-     * @param $_mode
-     * @return $this
-     */
     public function setMode($_mode)
     {
         $this->_changed = Utils::attrChanged($this->_changed, $this->mode, $_mode);
@@ -926,14 +939,21 @@ class Scenario implements EntityInterface
     }
 
     /**
+     * @return bool|mixed|null
+     */
+    /**
+     * @return bool|mixed|null
+     */
+
+    /**
      *
      * @return mixed
      */
     public function calculateScheduleDate()
     {
-        $calculatedDate = array('prevDate' => '', 'nextDate' => '');
+        $calculatedDate = ['prevDate' => '', 'nextDate' => ''];
         if (is_array($this->getSchedule())) {
-            $calculatedDate_tmp = array('prevDate' => '', 'nextDate' => '');
+            $calculatedDate_tmp = ['prevDate' => '', 'nextDate' => ''];
             foreach ($this->getSchedule() as $schedule) {
                 try {
                     $c = new \Cron\CronExpression($schedule, new \Cron\FieldFactory);
@@ -962,11 +982,14 @@ class Scenario implements EntityInterface
     }
 
     /**
-     * @return bool|mixed|null
+     * @param $_schedule
+     * @return $this
      */
     /**
-     * @return bool|mixed|null
+     * @param $_schedule
+     * @return $this
      */
+
     /**
      * @return bool|mixed|null
      */
@@ -979,14 +1002,6 @@ class Scenario implements EntityInterface
      * @param $_schedule
      * @return $this
      */
-    /**
-     * @param $_schedule
-     * @return $this
-     */
-    /**
-     * @param $_schedule
-     * @return $this
-     */
     public function setSchedule($_schedule)
     {
         if (is_array($_schedule)) {
@@ -995,16 +1010,6 @@ class Scenario implements EntityInterface
         $this->_changed = Utils::attrChanged($this->_changed, $this->schedule, $_schedule);
         $this->schedule = $_schedule;
         return $this;
-    }
-
-    /**
-     *
-     * @return mixed
-     * @throws \Exception
-     */
-    public function getState()
-    {
-        return $this->getCache('state');
     }
 
     /**
@@ -1024,7 +1029,7 @@ class Scenario implements EntityInterface
         }
 
         $version = NextDomHelper::versionAlias($_version);
-        $replace = array(
+        $replace = [
             '#id#' => $this->getId(),
             '#state#' => $this->getState(),
             '#isActive#' => $this->getIsActive(),
@@ -1037,9 +1042,9 @@ class Scenario implements EntityInterface
             '#version#' => $_version,
             '#height#' => $this->getDisplay('height', 'auto'),
             '#width#' => $this->getDisplay('width', 'auto')
-        );
+        ];
         if (!isset(self::$_templateArray)) {
-            self::$_templateArray = array();
+            self::$_templateArray = [];
         }
         if (!isset(self::$_templateArray[$version])) {
             self::$_templateArray[$version] = FileSystemHelper::getCoreTemplateFileContent($version, NextDomObj::SCENARIO, '');
@@ -1113,7 +1118,6 @@ class Scenario implements EntityInterface
      */
     public function getIcon($onlyClass = false)
     {
-        $cssClass = '';
         if ($this->getIsActive() == 1) {
             switch ($this->getState()) {
                 case ScenarioState::STARTING:
@@ -1131,13 +1135,11 @@ class Scenario implements EntityInterface
                         // Icon stored with HTML
                         if ($onlyClass) {
                             $cssClass = trim(str_replace(['<i', 'class=', '"', '/>', '></i>'], '', $this->getDisplay('icon')));
-                        }
-                        else {
+                        } else {
                             return $this->getDisplay('icon');
                         }
-                    }
-                    else {
-                        $cssClass =  'fas fa-check';
+                    } else {
+                        $cssClass = 'fas fa-check';
                     }
                     break;
             }
@@ -1450,7 +1452,7 @@ class Scenario implements EntityInterface
         if (intval($this->getPID()) > 0 && posix_getsid(intval($this->getPID())) && (!file_exists('/proc/' . $this->getPID() . '/cmdline') || strpos(file_get_contents('/proc/' . $this->getPID() . '/cmdline'), 'scenario_id=' . $this->getId()) !== false)) {
             return true;
         }
-        if (count(SystemHelper::ps('scenario_id=' . $this->getId() . ' ', array(getmypid()))) > 0) {
+        if (count(SystemHelper::ps('scenario_id=' . $this->getId() . ' ', [getmypid()])) > 0) {
             return true;
         }
         return false;
@@ -1474,7 +1476,7 @@ class Scenario implements EntityInterface
     public function toArray()
     {
         $return = Utils::o2a($this, true);
-        $cache = $this->getCache(array('state', 'lastLaunch'));
+        $cache = $this->getCache(['state', 'lastLaunch']);
         // TODO: Pourquoi ce test a-t-il dû être rajouté ?
         if (isset($cache['state'])) {
             $return['state'] = $cache['state'];
@@ -1497,7 +1499,7 @@ class Scenario implements EntityInterface
      * @return string
      * @throws \Exception
      */
-    public function getLinkData(&$_data = array('node' => array(), 'link' => array()), $_level = 0, $_drill = null)
+    public function getLinkData(&$_data = ['node' => [], 'link' => []], $_level = 0, $_drill = null)
     {
         if ($_drill === null) {
             $_drill = ConfigManager::byKey('graphlink::scenario::drill');
@@ -1513,7 +1515,7 @@ class Scenario implements EntityInterface
             return $_data;
         }
 
-        $_data['node'][NextDomObj::SCENARIO . $this->getId()] = array(
+        $_data['node'][NextDomObj::SCENARIO . $this->getId()] = [
             'id' => NextDomObj::SCENARIO . $this->getId(),
             'name' => $this->getName(),
             'fontweight' => ($_level == 1) ? 'bold' : 'normal',
@@ -1524,10 +1526,10 @@ class Scenario implements EntityInterface
             'image' => '/public/img/NextDom_Scenario.png',
             'title' => $this->getHumanName(),
             'url' => 'index.php?v=d&p=scenario&id=' . $this->getId(),
-        );
+        ];
         $use = $this->getUse();
         $usedBy = $this->getUsedBy();
-        Utils::addGraphLink($this, NextDomObj::SCENARIO, $this->getObject(), 'object', $_data, $_level + 1, $_drill, array('dashvalue' => '1,0', 'lengthfactor' => 0.6));
+        Utils::addGraphLink($this, NextDomObj::SCENARIO, $this->getObject(), 'object', $_data, $_level + 1, $_drill, ['dashvalue' => '1,0', 'lengthfactor' => 0.6]);
         Utils::addGraphLink($this, NextDomObj::SCENARIO, $use['cmd'], 'cmd', $_data, $_level, $_drill);
         Utils::addGraphLink($this, NextDomObj::SCENARIO, $use[NextDomObj::SCENARIO], NextDomObj::SCENARIO, $_data, $_level, $_drill);
         Utils::addGraphLink($this, NextDomObj::SCENARIO, $use['eqLogic'], 'eqLogic', $_data, $_level, $_drill);
@@ -1537,9 +1539,9 @@ class Scenario implements EntityInterface
         Utils::addGraphLink($this, NextDomObj::SCENARIO, $usedBy['cmd'], 'cmd', $_data, $_level, $_drill);
         Utils::addGraphLink($this, NextDomObj::SCENARIO, $usedBy[NextDomObj::SCENARIO], NextDomObj::SCENARIO, $_data, $_level, $_drill);
         Utils::addGraphLink($this, NextDomObj::SCENARIO, $usedBy['eqLogic'], 'eqLogic', $_data, $_level, $_drill);
-        Utils::addGraphLink($this, NextDomObj::SCENARIO, $usedBy['interactDef'], 'interactDef', $_data, $_level, $_drill, array('dashvalue' => '2,6', 'lengthfactor' => 0.6));
-        Utils::addGraphLink($this, NextDomObj::SCENARIO, $usedBy['plan'], 'plan', $_data, $_level, $_drill, array('dashvalue' => '2,6', 'lengthfactor' => 0.6));
-        Utils::addGraphLink($this, NextDomObj::SCENARIO, $usedBy['view'], 'view', $_data, $_level, $_drill, array('dashvalue' => '2,6', 'lengthfactor' => 0.6));
+        Utils::addGraphLink($this, NextDomObj::SCENARIO, $usedBy['interactDef'], 'interactDef', $_data, $_level, $_drill, ['dashvalue' => '2,6', 'lengthfactor' => 0.6]);
+        Utils::addGraphLink($this, NextDomObj::SCENARIO, $usedBy['plan'], 'plan', $_data, $_level, $_drill, ['dashvalue' => '2,6', 'lengthfactor' => 0.6]);
+        Utils::addGraphLink($this, NextDomObj::SCENARIO, $usedBy['view'], 'view', $_data, $_level, $_drill, ['dashvalue' => '2,6', 'lengthfactor' => 0.6]);
         return $_data;
     }
 
@@ -1600,7 +1602,7 @@ class Scenario implements EntityInterface
         if ($_mode == 'array') {
             $return = Utils::o2a($this);
             $return['trigger'] = NextDomHelper::toHumanReadable($return['trigger']);
-            $return['elements'] = array();
+            $return['elements'] = [];
             foreach ($this->getElement() as $element) {
                 $return['elements'][] = $element->getAjaxElement('array');
             }

--- a/src/Model/Entity/ScenarioElement.php
+++ b/src/Model/Entity/ScenarioElement.php
@@ -236,7 +236,7 @@ class ScenarioElement implements EntityInterface
                 $cron = new cron();
                 $cron->setClass(NextDomObj::SCENARIO);
                 $cron->setFunction('doIn');
-                $cron->setOption(array('scenario_id' => intval($_scenario->getId()), 'scenarioElement_id' => intval($this->getId()), 'second' => date('s'), 'tags' => $_scenario->getTags()));
+                $cron->setOption(['scenario_id' => intval($_scenario->getId()), 'scenarioElement_id' => intval($this->getId()), 'second' => date('s'), 'tags' => $_scenario->getTags()]);
                 $cron->setLastRun(date(DateFormat::FULL));
                 $cron->setOnce(1);
                 $next = strtotime('+ ' . $time . ' min');
@@ -276,7 +276,7 @@ class ScenarioElement implements EntityInterface
             $cron = new Cron();
             $cron->setClass(NextDomObj::SCENARIO);
             $cron->setFunction('doIn');
-            $cron->setOption(array('scenario_id' => intval($_scenario->getId()), 'scenarioElement_id' => intval($this->getId()), 'second' => 0, 'tags' => $_scenario->getTags()));
+            $cron->setOption(['scenario_id' => intval($_scenario->getId()), 'scenarioElement_id' => intval($this->getId()), 'second' => 0, 'tags' => $_scenario->getTags()]);
             $cron->setLastRun(date(DateFormat::FULL, strtotime('now')));
             $cron->setOnce(1);
             $cron->setSchedule(CronManager::convertDateToCron($next));
@@ -396,11 +396,11 @@ class ScenarioElement implements EntityInterface
      */
     public function getAllId()
     {
-        $return = array(
-            'element' => array($this->getId()),
-            'subelement' => array(),
-            'expression' => array(),
-        );
+        $return = [
+            'element' => [$this->getId()],
+            'subelement' => [],
+            'expression' => [],
+        ];
         foreach ($this->getSubElement() as $subelement) {
             $result = $subelement->getAllId();
             $return['element'] = array_merge($return['element'], $result['element']);

--- a/src/Model/Entity/ScenarioExpression.php
+++ b/src/Model/Entity/ScenarioExpression.php
@@ -17,9 +17,9 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\CmdSubType;
 use NextDom\Enums\DateFormat;
 use NextDom\Enums\ScenarioExpressionAction;
-use NextDom\Enums\ScenarioExpressionSubType;
 use NextDom\Enums\ScenarioExpressionType;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
@@ -130,7 +130,7 @@ class ScenarioExpression implements EntityInterface
             while (CacheManager::exists($key)) {
                 $key = 'scenarioElement' . ConfigManager::genKey(10);
             }
-            CacheManager::set($key, array('scenarioExpression' => $this, 'scenario' => $scenario), 60);
+            CacheManager::set($key, ['scenarioExpression' => $this, 'scenario' => $scenario], 60);
             $cmd = NEXTDOM_ROOT . '/src/Api/start_scenario_expr.php';
             $cmd .= ' key=' . $key;
             $this->setLog($scenario, __('Execution du lancement en arriere plan : ') . $key);
@@ -217,7 +217,7 @@ class ScenarioExpression implements EntityInterface
         if ($this->getOptions('background', 0) == 0) {
             return;
         }
-        if (in_array($this->getExpression(), array(ScenarioExpressionAction::WAIT, ScenarioExpressionAction::SLEEP, ScenarioExpressionAction::STOP, ScenarioExpressionAction::SCENARIO_RETURN))) {
+        if (in_array($this->getExpression(), [ScenarioExpressionAction::WAIT, ScenarioExpressionAction::SLEEP, ScenarioExpressionAction::STOP, ScenarioExpressionAction::SCENARIO_RETURN])) {
             $this->setOptions('background', 0);
         }
         return;
@@ -420,8 +420,7 @@ class ScenarioExpression implements EntityInterface
                     sleep($options['duration']);
                 }
             }
-        }
-        else {
+        } else {
             $this->setLog($scenario, __('Aucune durée trouvée pour l\'action sleep : ') . $options['duration']);
         }
     }
@@ -508,7 +507,7 @@ class ScenarioExpression implements EntityInterface
      */
     protected function executeActionEquipment(&$scenario)
     {
-        $eqLogic = EqLogicManager::byId(str_replace(array('#eqLogic', '#'), '', $this->getOptions('eqLogic')));
+        $eqLogic = EqLogicManager::byId(str_replace(['#eqLogic', '#'], '', $this->getOptions('eqLogic')));
         if (!is_object($eqLogic)) {
             throw new CoreException(__('Action sur l\'équipement impossible. Equipement introuvable - Vérifiez l\'id : ') . $this->getOptions('eqLogic'));
         }
@@ -566,7 +565,7 @@ class ScenarioExpression implements EntityInterface
         switch ($this->getOptions('action')) {
             case 'start':
                 if ($this->getOptions('tags') != '' && !is_array($this->getOptions('tags'))) {
-                    $tags = array();
+                    $tags = [];
                     $args = Utils::arg2array($this->getOptions('tags'));
                     foreach ($args as $key => $value) {
                         $tags['#' . trim(trim($key), '#') . '#'] = ScenarioExpressionManager::setTags(trim($value), $scenario);
@@ -585,7 +584,7 @@ class ScenarioExpression implements EntityInterface
                 break;
             case 'startsync':
                 if ($this->getOptions('tags') != '' && !is_array($this->getOptions('tags'))) {
-                    $tags = array();
+                    $tags = [];
                     $args = Utils::arg2array($this->getOptions('tags'));
                     foreach ($args as $key => $value) {
                         $tags['#' . trim(trim($key), '#') . '#'] = ScenarioExpressionManager::setTags(trim($value), $scenario);
@@ -679,7 +678,7 @@ class ScenarioExpression implements EntityInterface
         $dataStore->setLink_id(-1);
         $dataStore->save();
         $limit = (isset($options['timeout'])) ? $options['timeout'] : 300;
-        $options_cmd = array('title' => $options['question'], 'message' => $options['question'], 'answer' => explode(';', $options['answer']), 'timeout' => $limit, 'variable' => $this->getOptions('variable'));
+        $options_cmd = ['title' => $options['question'], 'message' => $options['question'], 'answer' => explode(';', $options['answer']), 'timeout' => $limit, 'variable' => $this->getOptions('variable')];
         //Recuperation des tags
         $tags = $scenario->getTags();
         if (isset($tags['#profile#']) === true) {
@@ -776,7 +775,7 @@ class ScenarioExpression implements EntityInterface
      */
     protected function executeActionReport(&$scenario, $options)
     {
-        $cmd_parameters = array('files' => null);
+        $cmd_parameters = ['files' => null];
         $this->setLog($scenario, __('Génération d\'un rapport de type ') . $options['type']);
         switch ($options['type']) {
             case 'view':
@@ -785,7 +784,7 @@ class ScenarioExpression implements EntityInterface
                     throw new CoreException(__('Vue introuvable - Vérifiez l\'id : ') . $options['view_id']);
                 }
                 $this->setLog($scenario, __('Génération du rapport ') . $view->getName());
-                $cmd_parameters['files'] = array($view->report($options['export_type'], $options));
+                $cmd_parameters['files'] = [$view->report($options['export_type'], $options)];
                 $cmd_parameters['title'] = __('[' . ConfigManager::byKey('name') . '] Rapport ') . $view->getName() . __(' du ') . date(DateFormat::FULL);
                 $cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport ') . $view->getName() . __(' généré le ') . date(DateFormat::FULL);
                 break;
@@ -795,7 +794,7 @@ class ScenarioExpression implements EntityInterface
                     throw new CoreException(__('Design introuvable - Vérifiez l\'id : ') . $options['plan_id']);
                 }
                 $this->setLog($scenario, __('Génération du rapport ') . $plan->getName());
-                $cmd_parameters['files'] = array($plan->report($options['export_type'], $options));
+                $cmd_parameters['files'] = [$plan->report($options['export_type'], $options)];
                 $cmd_parameters['title'] = __('[' . ConfigManager::byKey('name') . '] Rapport ') . $plan->getName() . __(' du ') . date(DateFormat::FULL);
                 $cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport ') . $plan->getName() . __(' généré le ') . date(DateFormat::FULL);
                 break;
@@ -805,14 +804,14 @@ class ScenarioExpression implements EntityInterface
                     throw new CoreException(__('Panel introuvable - Vérifiez l\'id : ') . $options['plugin_id']);
                 }
                 $this->setLog($scenario, __('Génération du rapport ') . $plugin->getName());
-                $cmd_parameters['files'] = array($plugin->report($options['export_type'], $options));
+                $cmd_parameters['files'] = [$plugin->report($options['export_type'], $options)];
                 $cmd_parameters['title'] = __('[' . ConfigManager::byKey('name') . '] Rapport ') . $plugin->getName() . __(' du ') . date(DateFormat::FULL);
                 $cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport ') . $plugin->getName() . __(' généré le ') . date(DateFormat::FULL);
                 break;
             case 'eqAnalyse':
                 $url = NetworkHelper::getNetworkAccess('internal') . '/index.php?v=d&p=eqAnalyse&report=1';
                 $this->setLog($scenario, __('Génération du rapport ') . $url);
-                $cmd_parameters['files'] = array(ReportHelper::generate($url, 'other', 'eqAnalyse', $options['export_type'], $options));
+                $cmd_parameters['files'] = [ReportHelper::generate($url, 'other', 'eqAnalyse', $options['export_type'], $options)];
                 $cmd_parameters['title'] = __('[' . ConfigManager::byKey('name') . '] Rapport équipement du ') . date(DateFormat::FULL);
                 $cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport équipement généré le ') . date(DateFormat::FULL);
                 break;
@@ -854,7 +853,7 @@ class ScenarioExpression implements EntityInterface
     {
         $cmd = CmdManager::byId(str_replace('#', '', $this->getExpression()));
         if (is_object($cmd)) {
-            if ($cmd->getSubType() == ScenarioExpressionSubType::SLIDER && isset($options['slider'])) {
+            if ($cmd->isSubType(CmdSubType::SLIDER) && isset($options['slider'])) {
                 $options['slider'] = Utils::evaluate($options['slider']);
             }
             if (is_array($options) && (count($options) > 1 || (isset($options['background']) && $options['background'] == 1))) {
@@ -881,16 +880,16 @@ class ScenarioExpression implements EntityInterface
      */
     public function getAllId()
     {
-        $return = array(
-            'element' => array(),
-            'subelement' => array(),
-            'expression' => array($this->getId()),
-        );
-        $result = array(
-            'element' => array(),
-            'subelement' => array(),
-            'expression' => array(),
-        );
+        $return = [
+            'element' => [],
+            'subelement' => [],
+            'expression' => [$this->getId()],
+        ];
+        $result = [
+            'element' => [],
+            'subelement' => [],
+            'expression' => [],
+        ];
         if ($this->getType() == 'element') {
             $element = ScenarioElementManager::byId($this->getExpression());
             if (is_object($element)) {

--- a/src/Model/Entity/ScenarioSubElement.php
+++ b/src/Model/Entity/ScenarioSubElement.php
@@ -307,11 +307,11 @@ class ScenarioSubElement implements EntityInterface
      */
     public function getAllId()
     {
-        $return = array(
-            'element' => array(),
-            'subelement' => array($this->getId()),
-            'expression' => array(),
-        );
+        $return = [
+            'element' => [],
+            'subelement' => [$this->getId()],
+            'expression' => [],
+        ];
         foreach ($this->getExpression() as $expression) {
             $result = $expression->getAllId();
             $return['element'] = array_merge($return['element'], $result['element']);

--- a/src/Model/Entity/Update.php
+++ b/src/Model/Entity/Update.php
@@ -17,6 +17,7 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\LogTarget;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\FileSystemHelper;
@@ -171,7 +172,7 @@ class Update implements EntityInterface
     public function doUpdate()
     {
         if ($this->getConfiguration('doNotUpdate') == 1 && $this->getType() != 'core') {
-            LogHelper::add('update', 'alert', __('Vérification des mises à jour, mise à jour et réinstallation désactivées sur ') . $this->getLogicalId());
+            LogHelper::addAlert(LogTarget::UPDATE, __('Vérification des mises à jour, mise à jour et réinstallation désactivées sur ') . $this->getLogicalId());
             return;
         }
         if ($this->getType() == 'core') {
@@ -186,31 +187,31 @@ class Update implements EntityInterface
                 }
                 mkdir($cibDir);
                 if (!file_exists($cibDir) && !mkdir($cibDir, 0775, true)) {
-                    throw new \Exception(__('Impossible de créer le dossier  : ' . $cibDir . '. Problème de droits ?'));
+                    throw new CoreException(__('Impossible de créer le dossier  : ' . $cibDir . '. Problème de droits ?'));
                 }
-                LogHelper::add('update', 'alert', __('Téléchargement du plugin...'));
+                LogHelper::addAlert(LogTarget::UPDATE, __('Téléchargement du plugin...'));
                 $info = $class::downloadObject($this);
                 if ($info['path'] !== false) {
                     $tmp = $info['path'];
-                    LogHelper::add('update', 'alert', __("OK\n"));
+                    LogHelper::addAlert(LogTarget::UPDATE, __("OK\n"));
 
                     if (!file_exists($tmp)) {
-                        throw new \Exception(__('Impossible de trouver le fichier zip : ') . $this->getConfiguration('path'));
+                        throw new CoreException(__('Impossible de trouver le fichier zip : ') . $this->getConfiguration('path'));
                     }
                     if (filesize($tmp) < 100) {
-                        throw new \Exception(__('Échec lors du téléchargement du fichier. Veuillez réessayer plus tard (taille inférieure à 100 octets). Cela peut être lié à un manque de place, une version minimale requise non consistente avec votre version de NextDom, un soucis du plugin sur le market, etc.'));
+                        throw new CoreException(__('Échec lors du téléchargement du fichier. Veuillez réessayer plus tard (taille inférieure à 100 octets). Cela peut être lié à un manque de place, une version minimale requise non consistente avec votre version de NextDom, un soucis du plugin sur le market, etc.'));
                     }
                     $extension = strtolower(strrchr($tmp, '.'));
-                    if (!in_array($extension, array('.zip'))) {
-                        throw new \Exception('Extension du fichier non valide (autorisé .zip) : ' . $extension);
+                    if (!in_array($extension, ['.zip'])) {
+                        throw new CoreException('Extension du fichier non valide (autorisé .zip) : ' . $extension);
                     }
-                    LogHelper::add('update', 'alert', __('Décompression du zip...'));
+                    LogHelper::addAlert(LogTarget::UPDATE, __('Décompression du zip...'));
                     $zip = new ZipArchive;
                     $res = $zip->open($tmp);
                     if ($res === TRUE) {
                         if (!$zip->extractTo($cibDir . '/')) {
                             $content = file_get_contents($tmp);
-                            throw new \Exception(__('Impossible d\'installer le plugin. Les fichiers n\'ont pas pu être décompressés : ') . substr($content, 255));
+                            throw new CoreException(__('Impossible d\'installer le plugin. Les fichiers n\'ont pas pu être décompressés : ') . substr($content, 255));
                         }
                         $zip->close();
                         unlink($tmp);
@@ -230,15 +231,15 @@ class Update implements EntityInterface
                                 $cibDir = $cibDir . '/' . $files[0];
                             }
                         }
-                        rmove($cibDir, NEXTDOM_ROOT . '/plugins/' . $this->getLogicalId(), false, array(), true);
+                        rmove($cibDir, NEXTDOM_ROOT . '/plugins/' . $this->getLogicalId(), false, [], true);
                         rrmdir($cibDir);
                         $cibDir = NextDomHelper::getTmpFolder('market') . '/' . $this->getLogicalId();
                         if (file_exists($cibDir)) {
                             rrmdir($cibDir);
                         }
-                        LogHelper::add('update', 'alert', __("OK\n"));
+                        LogHelper::addAlert(LogTarget::UPDATE, __("OK\n"));
                     } else {
-                        throw new \Exception(__('Impossible de décompresser l\'archive zip : ') . $tmp . ' => ' . Utils::getZipErrorMessage($res));
+                        throw new CoreException(__('Impossible de décompresser l\'archive zip : ') . $tmp . ' => ' . Utils::getZipErrorMessage($res));
                     }
                 }
                 $this->postInstallUpdate($info);
@@ -303,19 +304,19 @@ class Update implements EntityInterface
             @chgrp(NEXTDOM_ROOT . '/plugins', SystemHelper::getWWWGid());
             @chmod(NEXTDOM_ROOT . '/plugins', 0775);
         }
-        LogHelper::add('update', 'alert', __('Début de la mise à jour de : ') . $this->getLogicalId() . "\n");
+        LogHelper::addAlert(LogTarget::UPDATE, __('Début de la mise à jour de : ') . $this->getLogicalId() . "\n");
         switch ($this->getType()) {
             case 'plugin':
                 $cibDir = NEXTDOM_ROOT . '/plugins/' . $this->getLogicalId();
                 if (!file_exists($cibDir) && !mkdir($cibDir, 0775, true)) {
-                    throw new \Exception(__('Impossible de créer le dossier  : ' . $cibDir . '. Problème de droits ?'));
+                    throw new CoreException(__('Impossible de créer le dossier  : ' . $cibDir . '. Problème de droits ?'));
                 }
                 try {
                     $plugin = PluginManager::byId($this->getLogicalId());
                     if (is_object($plugin)) {
-                        LogHelper::add('update', 'alert', __('Action de pré-update...'));
+                        LogHelper::addAlert(LogTarget::UPDATE, __('Action de pré-update...'));
                         $plugin->callInstallFunction('pre_update');
-                        LogHelper::add('update', 'alert', __("OK\n"));
+                        LogHelper::addAlert(LogTarget::UPDATE, __("OK\n"));
                     }
                 } catch (\Exception $e) {
 
@@ -332,7 +333,7 @@ class Update implements EntityInterface
      */
     public function postInstallUpdate($informations)
     {
-        LogHelper::add('update', 'alert', __('Post-installation de ') . $this->getLogicalId() . '...');
+        LogHelper::addAlert(LogTarget::UPDATE, __('Post-installation de ') . $this->getLogicalId() . '...');
         switch ($this->getType()) {
             case 'plugin':
                 try {
@@ -350,7 +351,7 @@ class Update implements EntityInterface
             $this->setLocalVersion($informations['localVersion']);
         }
         $this->save();
-        LogHelper::add('update', 'alert', __("OK\n"));
+        LogHelper::addAlert(LogTarget::UPDATE, __("OK\n"));
     }
 
     /**
@@ -396,7 +397,7 @@ class Update implements EntityInterface
     public function checkUpdate()
     {
         if ($this->getConfiguration('doNotUpdate') == 1 && $this->getType() != 'core') {
-            LogHelper::add('update', 'alert', __('Vérification des mises à jour, mise à jour et réinstallation désactivées sur ') . $this->getLogicalId());
+            LogHelper::addAlert(LogTarget::UPDATE, __('Vérification des mises à jour, mise à jour et réinstallation désactivées sur ') . $this->getLogicalId());
             return;
         }
         if ($this->getType() == 'core') {
@@ -498,7 +499,7 @@ class Update implements EntityInterface
     public function deleteObjet()
     {
         if ($this->getType() == 'core') {
-            throw new \Exception(__('Vous ne pouvez pas supprimer le core de NextDom'));
+            throw new CoreException(__('Vous ne pouvez pas supprimer le core de NextDom'));
         } else {
             switch ($this->getType()) {
                 case 'plugin':

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -17,6 +17,8 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\DateFormat;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\Utils;
@@ -95,7 +97,7 @@ class User implements EntityInterface
     public function preInsert()
     {
         if (is_object(UserManager::byLogin($this->getLogin()))) {
-            throw new \Exception(__('Ce nom d\'utilisateur est déja pris'));
+            throw new CoreException(__('Ce nom d\'utilisateur est déja pris'));
         }
     }
 
@@ -124,14 +126,14 @@ class User implements EntityInterface
     public function preSave()
     {
         if ($this->getLogin() == '') {
-            throw new \Exception(__('Le nom d\'utilisateur ne peut pas être vide'));
+            throw new CoreException(__('Le nom d\'utilisateur ne peut pas être vide'));
         }
         $admins = UserManager::byProfils('admin', true);
         if (count($admins) == 1 && $this->getProfils() == 'admin' && !$this->isEnabled()) {
-            throw new \Exception(__('Vous ne pouvez désactiver le dernier utilisateur'));
+            throw new CoreException(__('Vous ne pouvez désactiver le dernier utilisateur'));
         }
         if (count($admins) == 1 && $admins[0]->getId() == $this->getid() && $this->getProfils() != 'admin') {
-            throw new \Exception(__('Vous ne pouvez changer le profil du dernier administrateur'));
+            throw new CoreException(__('Vous ne pouvez changer le profil du dernier administrateur'));
         }
     }
 
@@ -155,31 +157,12 @@ class User implements EntityInterface
     }
 
     /**
-     * @return int
-     */
-    public function getEnable()
-    {
-        return $this->enable;
-    }
-
-    /**
      * @return bool
      */
-    public function isEnabled() {
+    public function isEnabled()
+    {
         return $this->enable != 0;
     }
-    /**
-     * @param $_enable
-     * @return $this
-     */
-    public function setEnable($_enable)
-    {
-        $this->_changed = Utils::attrChanged($this->_changed, $this->enable, $_enable);
-        $this->enable = $_enable;
-        return $this;
-    }
-
-    /*     * **********************Getteur Setteur*************************** */
 
     /**
      * @return int
@@ -200,10 +183,31 @@ class User implements EntityInterface
         return $this;
     }
 
+    /*     * **********************Getteur Setteur*************************** */
+
+    /**
+     * @return int
+     */
+    public function getEnable()
+    {
+        return $this->enable;
+    }
+
+    /**
+     * @param $_enable
+     * @return $this
+     */
+    public function setEnable($_enable)
+    {
+        $this->_changed = Utils::attrChanged($this->_changed, $this->enable, $_enable);
+        $this->enable = $_enable;
+        return $this;
+    }
+
     public function preRemove()
     {
         if (count(UserManager::byProfils('admin', true)) == 1 && $this->getProfils() == 'admin') {
-            throw new \Exception(__('Vous ne pouvez supprimer le dernier administrateur'));
+            throw new CoreException(__('Vous ne pouvez supprimer le dernier administrateur'));
         }
     }
 
@@ -214,7 +218,7 @@ class User implements EntityInterface
      */
     public function remove()
     {
-        NextDomHelper::addRemoveHistory(array('id' => $this->getId(), 'name' => $this->getLogin(), 'date' => date('Y-m-d H:i:s'), 'type' => 'user'));
+        NextDomHelper::addRemoveHistory(['id' => $this->getId(), 'name' => $this->getLogin(), 'date' => date(DateFormat::FULL), 'type' => 'user']);
         return DBHelper::remove($this);
     }
 

--- a/src/Model/Entity/View.php
+++ b/src/Model/Entity/View.php
@@ -17,6 +17,8 @@
 
 namespace NextDom\Model\Entity;
 
+use NextDom\Enums\DateFormat;
+use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\DBHelper;
 use NextDom\Helpers\NetworkHelper;
 use NextDom\Helpers\NextDomHelper;
@@ -86,7 +88,7 @@ class View implements EntityInterface
      * @return string
      * @throws \Exception
      */
-    public function report($_format = 'pdf', $_parameters = array())
+    public function report($_format = 'pdf', $_parameters = [])
     {
         $url = NetworkHelper::getNetworkAccess('internal') . '/index.php?v=d&p=view';
         $url .= '&view_id=' . $this->getId();
@@ -123,7 +125,7 @@ class View implements EntityInterface
     public function presave()
     {
         if (trim($this->getName()) == '') {
-            throw new \Exception(__('Le nom de la vue ne peut pas être vide'));
+            throw new CoreException(__('Le nom de la vue ne peut pas être vide'));
         }
     }
 
@@ -153,7 +155,7 @@ class View implements EntityInterface
      */
     public function remove()
     {
-        NextDomHelper::addRemoveHistory(array('id' => $this->getId(), 'name' => $this->getName(), 'date' => date('Y-m-d H:i:s'), 'type' => 'view'));
+        NextDomHelper::addRemoveHistory(['id' => $this->getId(), 'name' => $this->getName(), 'date' => date(DateFormat::FULL), 'type' => 'view']);
         return DBHelper::remove($this);
     }
 
@@ -250,10 +252,10 @@ class View implements EntityInterface
     public function toAjax($_version = 'dview', $_html = false)
     {
         $return = Utils::o2a($this);
-        $return['viewZone'] = array();
+        $return['viewZone'] = [];
         foreach ($this->getViewZone() as $viewZone) {
             $viewZone_info = Utils::o2a($viewZone);
-            $viewZone_info['viewData'] = array();
+            $viewZone_info['viewData'] = [];
             foreach ($viewZone->getViewData() as $viewData) {
                 $viewData_info = Utils::o2a($viewData);
                 $viewData_info['name'] = '';
@@ -309,7 +311,7 @@ class View implements EntityInterface
                         for ($j = 0; $j < $configurationViewZoneColumn; $j++) {
                             $viewZone_info['html'] .= '<td><center>';
                             if (isset($viewData['configuration'][$i][$j])) {
-                                $replace = array();
+                                $replace = [];
                                 preg_match_all("/#([0-9]*)#/", $viewData['configuration'][$i][$j], $matches);
                                 foreach ($matches[1] as $cmd_id) {
                                     $cmd = CmdManager::byId($cmd_id);
@@ -352,7 +354,7 @@ class View implements EntityInterface
      * @return array|null
      * @throws \Exception
      */
-    public function getLinkData(&$_data = array('node' => array(), 'link' => array()), $_level = 0, $_drill = 3)
+    public function getLinkData(&$_data = ['node' => [], 'link' => []], $_level = 0, $_drill = 3)
     {
         if (isset($_data['node']['view' . $this->getId()])) {
             return null;
@@ -362,7 +364,7 @@ class View implements EntityInterface
             return $_data;
         }
         $icon = Utils::findCodeIcon('fa-picture-o');
-        $_data['node']['view' . $this->getId()] = array(
+        $_data['node']['view' . $this->getId()] = [
             'id' => 'interactDef' . $this->getId(),
             'name' => substr($this->getName(), 0, 20),
             'icon' => $icon['icon'],
@@ -373,7 +375,7 @@ class View implements EntityInterface
             'textx' => 0,
             'title' => __('Vue :') . ' ' . $this->getName(),
             'url' => 'index.php?v=d&p=view&view_id=' . $this->getId(),
-        );
+        ];
         return null;
     }
 

--- a/src/Repo/RepoApt.php
+++ b/src/Repo/RepoApt.php
@@ -19,23 +19,24 @@
 namespace NextDom\Repo;
 
 use NextDom\Helpers\SystemHelper;
+use NextDom\Interfaces\BaseRepo;
 use NextDom\Model\Entity\Update;
 
 /**
  * Class RepoApt
  */
-class RepoApt
+class RepoApt implements BaseRepo
 {
     public static $_name = 'Apt';
     public static $_icon = 'fab fa-ubuntu';
     public static $_description = 'repo.apt.description';
 
-    public static $_scope = array(
+    public static $_scope = [
         'plugin' => false,
         'backup' => false,
         'hasConfiguration' => false,
         'core' => true,
-    );
+    ];
 
     public static $_configuration = [];
 
@@ -61,7 +62,7 @@ class RepoApt
                 }
             }
         } else if ($targetUpdate->getType() === 'core' && $targetUpdate->getLogicalId() === 'nextdom') {
-            exec(SystemHelper::getCmdSudo(). 'lsof /var/lib/dpkg/lock', $aptLocked);
+            exec(SystemHelper::getCmdSudo() . 'lsof /var/lib/dpkg/lock', $aptLocked);
             if (count($aptLocked) === 0) {
                 exec(SystemHelper::getCmdSudo() . 'apt-get update');
                 exec(SystemHelper::getCmdSudo() . "apt-cache policy nextdom | grep Installed | sed 's/Installed: \\(.*\\)/\\1/g'", $currentVersion);
@@ -82,8 +83,7 @@ class RepoApt
                         $targetUpdate->setRemoteVersion($newVersion);
                         $targetUpdate->save();
                     }
-                }
-                else {
+                } else {
                     $targetUpdate->setSource('github');
                     RepoGitHub::checkUpdate($targetUpdate);
                     $result = true;

--- a/src/Repo/RepoFile.php
+++ b/src/Repo/RepoFile.php
@@ -18,35 +18,43 @@
 
 namespace NextDom\Repo;
 
-class RepoFile
+use NextDom\Enums\DateFormat;
+use NextDom\Interfaces\BaseRepo;
+use NextDom\Model\Entity\Update;
+
+class RepoFile implements BaseRepo
 {
     public static $_name = 'File';
     public static $_icon = 'fas fa-file-invoice';
     public static $_description = 'repo.file.description';
 
-    public static $_scope = array(
+    public static $_scope = [
         'plugin' => true,
         'backup' => false,
         'hasConfiguration' => false,
-    );
+    ];
 
-    public static $_configuration = array(
-        'parameters_for_add' => array(
-            'path' => array(
+    public static $_configuration = [
+        'parameters_for_add' => [
+            'path' => [
                 'name' => 'repo.file.conf.path',
                 'type' => 'file',
-            ),
-        ),
-    );
+            ],
+        ],
+    ];
 
     public static function checkUpdate($_update)
     {
 
     }
 
+    /**
+     * @param Update $_update
+     * @return array
+     */
     public static function downloadObject($_update)
     {
-        return array('localVersion' => date('Y-m-d H:i:s'), 'path' => $_update->getConfiguration('path'));
+        return ['localVersion' => date(DateFormat::FULL), 'path' => $_update->getConfiguration('path')];
     }
 
     public static function deleteObjet($_update)
@@ -56,9 +64,9 @@ class RepoFile
 
     public static function objectInfo($_update)
     {
-        return array(
+        return [
             'doc' => '',
             'changelog' => '',
-        );
+        ];
     }
 }

--- a/src/Repo/RepoNextDom.php
+++ b/src/Repo/RepoNextDom.php
@@ -20,7 +20,9 @@
 
 namespace NextDom\Repo;
 
-class RepoNextDom
+use NextDom\Interfaces\BaseRepo;
+
+class RepoNextDom implements BaseRepo
 {
     /*     * *************************Attributs****************************** */
 
@@ -28,7 +30,7 @@ class RepoNextDom
     public static $_icon = 'fas fa-store';
     public static $_description = 'repo.nextdom.description';
 
-    public static $_scope = array(
+    public static $_scope = [
         'plugin' => true,
         'backup' => false,
         'hasConfiguration' => true,
@@ -37,24 +39,24 @@ class RepoNextDom
         'hasStore' => true,
         'hasScenarioStore' => false,
         'test' => false,
-    );
+    ];
 
-    public static $_configuration = array(
-        'configuration' => array(
-            'nextdom_stable' => array(
+    public static $_configuration = [
+        'configuration' => [
+            'nextdom_stable' => [
                 'name' => 'repo.nextdom.conf.stable',
                 'type' => 'checkbox',
-            ),
-            'nextdom_draft' => array(
+            ],
+            'nextdom_draft' => [
                 'name' => 'repo.nextdom.conf.draft',
                 'type' => 'checkbox',
-            ),
-            'show_sources_filters' => array(
+            ],
+            'show_sources_filters' => [
                 'name' => 'repo.nextdom.conf.filters',
                 'type' => 'checkbox',
-            ),
-        )
-    );
+            ],
+        ]
+    ];
 
     /*     * ***********************Méthodes statiques*************************** */
 

--- a/src/Repo/RepoSamba.php
+++ b/src/Repo/RepoSamba.php
@@ -36,6 +36,7 @@ namespace NextDom\Repo;
 
 use NextDom\Helpers\LogHelper;
 use NextDom\Helpers\Samba;
+use NextDom\Interfaces\BaseRepo;
 use NextDom\Managers\BackupManager;
 use NextDom\Managers\ConfigManager;
 
@@ -44,7 +45,7 @@ use NextDom\Managers\ConfigManager;
  *
  * @package NextDom\Repo
  */
-class RepoSamba
+class RepoSamba implements BaseRepo
 {
     /**
      * @var string General name
@@ -117,7 +118,7 @@ class RepoSamba
 
         $sambaConnection = Samba::createFromConfig('backup');
         $sambaConnection->put($backupPath, $backupDest);
-        LogHelper::addInfo("system","Backup to remote samba server done.");
+        LogHelper::addInfo("system", "Backup to remote samba server done.");
         self::cleanBackups();
     }
 

--- a/src/Repo/RepoUrl.php
+++ b/src/Repo/RepoUrl.php
@@ -21,13 +21,16 @@
 namespace NextDom\Repo;
 
 use NextDom\Com\ComShell;
+use NextDom\Enums\DateFormat;
+use NextDom\Enums\LogTarget;
 use NextDom\Exceptions\CoreException;
 use NextDom\Helpers\LogHelper;
 use NextDom\Helpers\NextDomHelper;
 use NextDom\Helpers\SystemHelper;
+use NextDom\Interfaces\BaseRepo;
 use NextDom\Managers\ConfigManager;
 
-class RepoUrl
+class RepoUrl implements BaseRepo
 {
     /*     * *************************Attributs****************************** */
 
@@ -35,31 +38,31 @@ class RepoUrl
     public static $_icon = 'fas fa-at';
     public static $_description = 'repo.url.description';
 
-    public static $_scope = array(
+    public static $_scope = [
         'plugin' => true,
         'backup' => false,
         'hasConfiguration' => true,
         'core' => true,
-    );
+    ];
 
-    public static $_configuration = array(
-        'parameters_for_add' => array(
-            'url' => array(
+    public static $_configuration = [
+        'parameters_for_add' => [
+            'url' => [
                 'name' => 'repo.url.conf.zip',
                 'type' => 'input',
-            ),
-        ),
-        'configuration' => array(
-            'core::url' => array(
+            ],
+        ],
+        'configuration' => [
+            'core::url' => [
                 'name' => 'repo.url.conf.core.url',
                 'type' => 'input',
-            ),
-            'core::version' => array(
+            ],
+            'core::version' => [
                 'name' => 'repo.url.conf.core.version',
                 'type' => 'input',
-            ),
-        ),
-    );
+            ],
+        ],
+    ];
 
     /*     * ***********************Méthodes statiques*************************** */
 
@@ -82,8 +85,8 @@ class RepoUrl
             throw new CoreException(__('Impossible d\'écrire dans le répertoire : ', __FILE__) . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R ', __FILE__) . $tmp_dir);
         }
         $result = exec('wget --no-check-certificate --progress=dot --dot=mega ' . $_update->getConfiguration('url') . ' -O ' . $tmp);
-        LogHelper::add('update', 'alert', $result);
-        return array('path' => $tmp, 'localVersion' => date('Y-m-d H:i:s'));
+        LogHelper::addAlert(LogTarget::UPDATE, $result);
+        return ['path' => $tmp, 'localVersion' => date(DateFormat::FULL)];
     }
 
     public static function deleteObjet($_update)
@@ -93,10 +96,10 @@ class RepoUrl
 
     public static function objectInfo($_update)
     {
-        return array(
+        return [
             'doc' => '',
             'changelog' => '',
-        );
+        ];
     }
 
     public static function downloadCore($_path)

--- a/src/Rest/Authenticator.php
+++ b/src/Rest/Authenticator.php
@@ -70,9 +70,9 @@ class Authenticator
 
     /**
      * Init authenticator instance
-     * 
+     *
      * @param Request $request
-     * 
+     *
      * @return Authenticator
      */
     public static function init(Request $request): Authenticator
@@ -116,12 +116,12 @@ class Authenticator
 
     /**
      * Check user credentials
-     * 
+     *
      * @param string $login User login
      * @param string $password User passowrd
      *
      * @return User|false User object or false
-     * 
+     *
      * @throws \Exception
      */
     public function checkCredentials(string $login, string $password)
@@ -136,7 +136,7 @@ class Authenticator
      * @param User $user
      *
      * @return string User token
-     * 
+     *
      * @throws \NextDom\Exceptions\CoreException
      * @throws \ReflectionException
      */
@@ -179,6 +179,25 @@ class Authenticator
     }
 
     /**
+     * Get the user from the token
+     *
+     * @return User|null User
+     * @throws \Exception
+     */
+    private function getUserFromToken()
+    {
+        $user = null;
+        $payload = Token::getPayload($this->request->headers->get('X-AUTH-TOKEN'));
+        if (!empty($payload)) {
+            $payloadData = json_decode($payload, true);
+            if (isset($payloadData['user_id'])) {
+                $user = UserManager::byId($payloadData['user_id']);
+            }
+        }
+        return $user;
+    }
+
+    /**
      * Check API Key sended in URL (?apikey=MY_KEY)\n
      * Consider connected like the first admin in database
      *
@@ -199,25 +218,6 @@ class Authenticator
             }
         }
         return $this->authenticated;
-    }
-
-    /**
-     * Get the user from the token
-     *
-     * @return User|null User
-     * @throws \Exception
-     */
-    private function getUserFromToken()
-    {
-        $user = null;
-        $payload = Token::getPayload($this->request->headers->get('X-AUTH-TOKEN'));
-        if (!empty($payload)) {
-            $payloadData = json_decode($payload, true);
-            if (isset($payloadData['user_id'])) {
-                $user = UserManager::byId($payloadData['user_id']);
-            }
-        }
-        return $user;
     }
 
     /**

--- a/src/Rest/CmdRest.php
+++ b/src/Rest/CmdRest.php
@@ -19,13 +19,15 @@
 
 namespace NextDom\Rest;
 
+use NextDom\Enums\CmdSubType;
+use NextDom\Enums\CmdType;
 use NextDom\Managers\CmdManager;
 use NextDom\Model\Entity\Cmd;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class CmdRest
- * 
+ *
  * @package NextDom\Rest
  */
 class CmdRest
@@ -46,23 +48,8 @@ class CmdRest
     }
 
     /**
-     * Get all commands visible linked to an eqLogic
-     *
-     * @param int $eqLogicId EqLogic id
-     *
-     * @return array Array of linked commands
-     *
-     * @throws \Exception
-     */
-    public static function getVisibleByEqLogic(int $eqLogicId)
-    {
-        $cmds = CmdManager::byEqLogicId($eqLogicId, null, true);
-        return self::prepareResults($cmds);
-    }
-
-    /**
      * Prepare result for response\n
-     * Associative array with following keys : 
+     * Associative array with following keys :
      *  - id
      *  - name
      *  - type
@@ -109,7 +96,7 @@ class CmdRest
 
     /**
      * Get specials data depends of type
-     * 
+     *
      * @param Cmd $cmd Command with data
      *
      * @return array Specials data
@@ -117,17 +104,16 @@ class CmdRest
     private static function getSpecialData($cmd)
     {
         $result = [];
-        if ($cmd->getType() === 'info') {
+        if ($cmd->isType(CmdType::INFO)) {
             try {
                 $result['state'] = $cmd->execCmd();
-                if ($cmd->getSubType() === 'numeric' && empty($result['state'])) {
+                if ($cmd->isSubType(CmdSubType::NUMERIC) && empty($result['state'])) {
                     $result['state'] = 0;
                 }
             } catch (\Exception $e) {
 
             }
-        }
-        elseif ($cmd->getType() === 'action') {
+        } elseif ($cmd->isType(CmdType::ACTION)) {
             $configuration = $cmd->getConfiguration();
             if (isset($configuration['minValue'])) {
                 $result['minValue'] = $configuration['minValue'];
@@ -137,6 +123,21 @@ class CmdRest
             }
         }
         return $result;
+    }
+
+    /**
+     * Get all commands visible linked to an eqLogic
+     *
+     * @param int $eqLogicId EqLogic id
+     *
+     * @return array Array of linked commands
+     *
+     * @throws \Exception
+     */
+    public static function getVisibleByEqLogic(int $eqLogicId)
+    {
+        $cmds = CmdManager::byEqLogicId($eqLogicId, null, true);
+        return self::prepareResults($cmds);
     }
 
     /**

--- a/src/Rest/EqLogicRest.php
+++ b/src/Rest/EqLogicRest.php
@@ -42,7 +42,7 @@ class EqLogicRest
 
     /**
      * Prepare result for response\n
-     * Associative array with following keys : 
+     * Associative array with following keys :
      *  - id
      *  - name
      *  - type (plugin id)
@@ -64,8 +64,8 @@ class EqLogicRest
             $eqLogicRow['name'] = $eqLogic->getName();
             $eqLogicRow['type'] = $eqLogic->getEqType_name();
             $eqLogicRow['objectId'] = $eqLogic->getObject_id();
-            $eqLogicRow['enable'] = $eqLogic->getIsEnable() == 1 ? true : false;
-            $eqLogicRow['visible'] = $eqLogic->getIsVisible() == 1 ? true : false;
+            $eqLogicRow['enable'] = $eqLogic->isEnabled();
+            $eqLogicRow['visible'] = $eqLogic->isVisible();
             $eqLogicRow['configuration'] = $eqLogic->getConfiguration();
             $result[] = $eqLogicRow;
         }

--- a/src/Rest/RoomRest.php
+++ b/src/Rest/RoomRest.php
@@ -59,7 +59,7 @@ class RoomRest
 
     /**
      * Prepare result for response\n
-     * Associative array with following keys : 
+     * Associative array with following keys :
      *  - id
      *  - name
      *  - icon
@@ -68,12 +68,13 @@ class RoomRest
      *    - name
      *    - icon
      *  - children (if exists)
-     * 
+     *
      * @param JeeObject $room
      * @param JeeObject|null $father
-     * 
+     *
+     * @param bool $addChildren
      * @return array
-     * 
+     *
      * @throws \Exception
      */
     private static function prepareResult(JeeObject $room, JeeObject $father = null, $addChildren = true)
@@ -142,26 +143,13 @@ class RoomRest
     }
 
     /**
-     * Get HTML room summary
-     * @param int $roomId Target room id
-     * @return bool|string HTML summary or false if no summary
-     * @throws \Exception
-     */
-    public static function getRoomSummary(int $roomId) {
-        $room = JeeObjectManager::byId($roomId);
-        if (is_object($room)) {
-            return $room->getHtmlSummary();
-        }
-        return false;
-    }
-
-    /**
      * Get HTML summary from list of rooms passed in argument separated by ;
      * @param string $roomsList List of rooms Id separated by ;
      * @return string[]
      * @throws \Exception
      */
-    public static function getRoomsSummary(string $roomsList) {
+    public static function getRoomsSummary(string $roomsList)
+    {
         $result = [];
         $roomsList = explode(';', $roomsList);
         if (is_array($roomsList) && count($roomsList) > 1) {
@@ -170,5 +158,20 @@ class RoomRest
             }
         }
         return $result;
+    }
+
+    /**
+     * Get HTML room summary
+     * @param int $roomId Target room id
+     * @return bool|string HTML summary or false if no summary
+     * @throws \Exception
+     */
+    public static function getRoomSummary(int $roomId)
+    {
+        $room = JeeObjectManager::byId($roomId);
+        if (is_object($room)) {
+            return $room->getHtmlSummary();
+        }
+        return false;
     }
 }

--- a/src/Rest/ScenarioRest.php
+++ b/src/Rest/ScenarioRest.php
@@ -81,7 +81,7 @@ class ScenarioRest
 
     /**
      * Prepare result for response\n
-     * Associative array by group with following keys : 
+     * Associative array by group with following keys :
      *  - id
      *  - name
      *  - displayIcon
@@ -142,18 +142,9 @@ class ScenarioRest
      * @return bool True on success
      * @throws \Exception
      */
-    public static function enable(int $scenarioId) {
+    public static function enable(int $scenarioId)
+    {
         return self::changeScenarioActiveState($scenarioId, true);
-    }
-
-    /**
-     * Disable scenario
-     * @param int $scenarioId Id of the scenario to disable
-     * @return bool True on success
-     * @throws \Exception
-     */
-    public static function disable(int $scenarioId) {
-        return self::changeScenarioActiveState($scenarioId, false);
     }
 
     /**
@@ -163,19 +154,30 @@ class ScenarioRest
      * @return bool True on success
      * @throws \Exception
      */
-    private static function changeScenarioActiveState(int $scenarioId, bool $newState) {
+    private static function changeScenarioActiveState(int $scenarioId, bool $newState)
+    {
         $scenario = ScenarioManager::byId($scenarioId);
         if (!is_object($scenario)) {
             return false;
         }
         if ($newState) {
             $scenario->setIsActive(1);
-        }
-        else {
+        } else {
             $scenario->setIsActive(0);
         }
         $scenario->save();
         return true;
+    }
+
+    /**
+     * Disable scenario
+     * @param int $scenarioId Id of the scenario to disable
+     * @return bool True on success
+     * @throws \Exception
+     */
+    public static function disable(int $scenarioId)
+    {
+        return self::changeScenarioActiveState($scenarioId, false);
     }
 
     /**

--- a/src/Rest/SummaryRest.php
+++ b/src/Rest/SummaryRest.php
@@ -41,8 +41,7 @@ class SummaryRest
         $defaultRoom = JeeObjectManager::getDefaultUserRoom($user);
         if ($defaultRoom === false) {
             return false;
-        }
-        else {
+        } else {
             return self::getRoomTree($defaultRoom->getId());
         }
     }
@@ -66,7 +65,7 @@ class SummaryRest
 
     /**
      * Prepare result for response\n
-     * Associative array with following keys : 
+     * Associative array with following keys :
      *  - id
      *  - name
      *  - icon

--- a/tests/compatibility/AjaxEqLogicTest.php
+++ b/tests/compatibility/AjaxEqLogicTest.php
@@ -79,7 +79,7 @@ class AjaxEqLogicTest extends AjaxBase
     public function testListByTypeAsUser() {
         $this->connectAsUser();
         $result = $this->getAjaxQueryWithTokenResult($this->ajaxFile, ['action' => 'listByType']);
-        $this->assertContains('"result":null', (string) $result->getBody());
+        $this->assertContains('"result":[]', (string) $result->getBody());
         $this->assertEquals(200, $result->getStatusCode());
     }
 

--- a/tests/data/tests_fixtures.sql
+++ b/tests/data/tests_fixtures.sql
@@ -60,7 +60,11 @@ INSERT INTO `scenarioSubElement` VALUES (7,0,4,'action','action',NULL,'{\"enable
 INSERT INTO `cron` VALUES (1,1,'nextdom','cron5','*/5 * * * * *',5,0,1,NULL,0);
 INSERT INTO `cron` VALUES (2,1,'nextdom','cron10','*/10 * * * * *',10,0,1,NULL,0);
 INSERT INTO `cron` VALUES (3,1,'nextdom','cron','* * * * * *',2,0,1,NULL,0);
-INSERT INTO `cron` VALUES (4,0,'nextdom','cronHourly','0 * * * * *',2,0,1,NULL,0);
+INSERT INTO `cron` VALUES (4,0,'nextdom','cronHourly','0 * * * * *',60,0,1,NULL,0);
+INSERT INTO `cron` VALUES (5,1,'plugin','cron5','*/5 * * * * *',5,0,1,NULL,0);
+INSERT INTO `cron` VALUES (6,1,'plugin','cron10','*/10 * * * * *',10,0,1,NULL,0);
+INSERT INTO `cron` VALUES (7,1,'plugin','cron','* * * * * *',2,0,1,NULL,0);
+INSERT INTO `cron` VALUES (8,0,'plugin','cronHourly','0 * * * * *',60,0,1,NULL,0);
 INSERT INTO `update` VALUES (1,'core','nextdom','nextdom','', '', 'github', 'ok', '[]');
 INSERT INTO `view` VALUES (1,'Test view','[]',NULL,'[]','[]');
 INSERT INTO `message` VALUES (1,'2019-05-03 22:00:03','newUpdate','update','De nouvelles mises à jour sont disponibles : nextdom,openzwave','');

--- a/tests/phpunit_tests/Controllers/LogDisplayModalControllerTest.php
+++ b/tests/phpunit_tests/Controllers/LogDisplayModalControllerTest.php
@@ -34,7 +34,7 @@ class LogDisplayModalControllerTest extends BaseControllerTest
         ob_start();
         $result = \NextDom\Controller\Modals\LogDisplay::get();
         $scriptResult = ob_get_clean();
-        $this->assertContains('src="/public/js/desktop/diagnostic/realtime.js"', $result);
-        $this->assertContains('var realtime_name', $scriptResult);
+        $this->assertContains('src="/public/js/modals/log.display.js"', $result);
+        $this->assertContains('var log_default_search', $scriptResult);
     }
 }

--- a/tests/phpunit_tests/UpdateManagerTest.php
+++ b/tests/phpunit_tests/UpdateManagerTest.php
@@ -36,7 +36,7 @@ class UpdateManagerTest extends PHPUnit_Framework_TestCase
     {
 
     }
-
+/*
     public function testFindNewUpdateObject()
     {
         UpdateManager::findNewUpdateObject();
@@ -110,5 +110,14 @@ class UpdateManagerTest extends PHPUnit_Framework_TestCase
         $updatesByType = UpdateManager::all('plugin');
         $this->assertCount(1, $updatesByType);
         $this->assertEquals('plugin4tests', $updatesByType[0]->getName());
+    }
+*/
+    public function testListRepo()
+    {
+        $repoList = UpdateManager::listRepo();
+        $this->assertCount(7, $repoList);
+        $this->assertEquals('Apt', $repoList['apt']['name']);
+        $this->assertEquals('\NextDom\Repo\RepoNextDom', $repoList['nextdom']['class']);
+        $this->assertEquals('input', $repoList['samba']['configuration']['configuration']['backup::ip']['type']);
     }
 }

--- a/tests/tests/libs/base_gui_test.py
+++ b/tests/tests/libs/base_gui_test.py
@@ -181,7 +181,7 @@ class BaseGuiTest(unittest.TestCase):
         :rtype:  array
         """
         js_logs = self.driver.get_log('browser')
-        if len(js_logs) > 0:
+        if js_logs:
             print(js_logs)
         return js_logs
 

--- a/translations/en_US.yml
+++ b/translations/en_US.yml
@@ -241,6 +241,8 @@ general:
      time_server: "Time Server used for time synchronization"
      ignore_system_time: "Indicates to Nexdom to ignore system time"
 health:
+  tmp-space-left: "Tmp space left"
+  tmp-problem: "On error, try to restart. If this doesn't work, disable plugin one by one."
   apache-private-tmp-disabled: "Please disable private tmp Apache (NextDom can work with). See <a href=\"https://jeedom.github.io/core/fr_FR/faq#tocAnchor-1-29\" target=\"_blank\"> </a>"
   apache-private-tmp: Apache private tmp
   authentication-error: "Warning: you always have the user admin/admin configured: this represents a serious security flaw, go <a href=\"index.php?v=d&p=user\"> </a> to change the password admin user "

--- a/translations/fr_FR.yml
+++ b/translations/fr_FR.yml
@@ -241,6 +241,8 @@ general:
      time_server: "Permet d'ajouter un serveur de temps à NextDom utilisé lorsque NextDom force la synchronisation de l'heure"
      ignore_system_time: "Ignorer la vérification de l'heure système"
 health:
+  tmp-space-left: "Espace temporaire disponible"
+  tmp-problem: "En cas d'erreur essayez de redémarrer. Si le problème persiste, testez en désactivant les plugins un à un jusqu'à trouver le coupable"
   apache-private-tmp-disabled: Veuillez désactiver le private tmp d'Apache (NextDom ne peut fonctionner avec). Voir <a href=\"https://jeedom.github.io/core/fr_FR/faq#tocAnchor-1-29\" target=\"_blank\">ici</a>
   apache-private-tmp: Apache private tmp
   authentication-error: "Attention : vous avez toujours l'utilisateur admin/admin configuré, cela représente une grave faille de sécurité, allez <a href=\"index.php?v=d&p=user\">ici</a> pour modifier le mot de passe de l'utilisateur admin"


### PR DESCRIPTION
# Création de nombreux Enums. Les mots clés sont maintenant fixé afin d'éviter les erreurs ou les fautes de frappes.
Les plus significatifs sont : 
 - CmdType : Type des commandes
 - CmdSubType : Sous-type des commandes
 - AjaxParams : Paramètres ajax usuels
 - Common : Mots clés fréquemment utilisés
 - CacheKey : Clés des données en cache
 - LogTarget : Fichier de log cible
 - ScenarioType et SubType (voir Cmd)

# Création des méthodes isVisible et isEnabled pour la plupart des classes.
Avant
```
if ($eqLogic->getIsVisible() == 1)
```
Maintenant
```
if ($eqLogic->isVIsible())
```

# Création des méthodes isType et isSubType pour les commandes et eqLogics
Avant
```
if ($cmd->getType() == 'info' && $cmd->getSubType() == 'numeric')
```
Maintenant
```
if ($cmd->isType(CmdType::INFO) && $cmd->isSubType(CmdSubType::NUMERIC))
```
# Création de nouvelles fonctions pour éviter les failles XSS
Utils::initInt : Retrouver un entier
Utils::initStr : Retrouver une chaine de caractère avec des lettres, chiffres, -, _

# Création des méthodes LogHelper::addAlert, addError, addDebug, addInfo, etc.

# Déplacement des fichiers de Repo particuliers dans le répertoire Market
# Amélioration du score sonarcloud
# Réindentation du code
# Remplacement des array('blabla') par ['blabla']