### PR TITLE
added resizable for command editor

### DIFF
--- a/assets/js/core/plugin.template.js
+++ b/assets/js/core/plugin.template.js
@@ -352,12 +352,12 @@ $('#div_pageContainer').on('dblclick', '.cmd input,select,span,a', function (eve
 
 $('#div_pageContainer').on('dblclick', '.cmd', function () {
   $('#md_modal').dialog({title: "{{Configuration commande}}"});
-  $('#md_modal').load('index.php?v=d&modal=cmd.configure&cmd_id=' + $(this).closest('.cmd').attr('data-cmd_id')).dialog('open');
+  $('#md_modal').load('index.php?v=d&modal=cmd.configure&cmd_id=' + $(this).closest('.cmd').attr('data-cmd_id')).dialog('option', 'resizable', true).dialog('open');
 });
 
 $('#div_pageContainer').on('click', '.cmd .cmdAction[data-action=configure]', function () {
   $('#md_modal').dialog({title: "{{Configuration commande}}"});
-  $('#md_modal').load('index.php?v=d&modal=cmd.configure&cmd_id=' + $(this).closest('.cmd').attr('data-cmd_id')).dialog('open');
+  $('#md_modal').load('index.php?v=d&modal=cmd.configure&cmd_id=' + $(this).closest('.cmd').attr('data-cmd_id')).dialog('option', 'resizable', true).dialog('open');
 });
 
 $('.eqLogicThumbnailContainer').packery();


### PR DESCRIPTION
sur un virtuel (ou probablement n'importe quel plugin), quand on double clic sur une commande (ou clic sur la roue), parfois la fenêtre est toute petite, cf https://prnt.sc/q5m1qj

au moins avec ce fix on peux agrandir la fenêtre comme on veux
