### PR TITLE
bugfix with bad symlink during update

### DIFF
--- a/log
+++ b/log
@@ -1,5 +1,1 @@
-XSym
-0016
-6f89ba840dee5372e428e9ea0f7eb973
 /var/log/nextdom
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               


### PR DESCRIPTION
après update en 0.6.0, le symlink n'est plus valide.