### PR TITLE
Sécurisation acces InfluxDB

### DIFF
--- a/src/Model/Entity/Cmd.php
+++ b/src/Model/Entity/Cmd.php
@@ -1217,7 +1217,7 @@ class Cmd extends BaseEntity
      */
     public function influxDb($valueToSend)
     {
-        $influxDbConf = ConfigManager::byKeys(['influxDbIp', 'influxDbPort', 'influxDbDatabase']);
+        $influxDbConf = ConfigManager::byKeys(['influxDbIp', 'influxDbPort', 'influxDbDatabase', 'influxDbLogin', 'influxDbPassword']);
         if ($influxDbConf['influxDbIp'] !== '') {
             if (empty($this->getUnite())) {
                 $unite = 'state';
@@ -1228,8 +1228,7 @@ class Cmd extends BaseEntity
             if ($this->isType(CmdType::INFO)
                 && ($this->isSubType(CmdSubType::NUMERIC) || $this->isSubType(CmdSubType::BINARY))
                 && (isset($valueToSend))) {
-                $client = new \InfluxDB\Client($influxDbConf['influxDbIp'], $influxDbConf['influxDbPort']);
-                $influxDbDatabase = $client->selectDB($influxDbConf['influxDbDatabase']);
+                $influxDbDatabase = \InfluxDB\Client::fromDSN(sprintf('influxdb://%s:%s@%s:%s/%s', urlencode($influxDbConf['influxDbLogin']), urlencode($influxDbConf['influxDbPassword']), $influxDbConf['influxDbIp'], $influxDbConf['influxDbPort'], $influxDbConf['influxDbDatabase']));
 
                 $points = [
                     new \InfluxDB\Point(

--- a/translations/en_US.yml
+++ b/translations/en_US.yml
@@ -74,6 +74,8 @@ cache:
 commandes:
   influxDbIPLabel: IP
   influxDbPortLabel: Port
+  influxDbLoginLabel: Login
+  influxDbPasswordLabel: Password
   influxDbDatabaseNameLabel: Database
 common:
   action: "Action"

--- a/translations/fr_FR.yml
+++ b/translations/fr_FR.yml
@@ -74,6 +74,8 @@ cache:
 commandes:
   influxDbIPLabel: IP
   influxDbPortLabel: Port
+  influxDbLoginLabel: Login
+  influxDbPasswordLabel: Mot de passe
   influxDbDatabaseNameLabel: Base de données
 common:
   action: "Action"

--- a/views/desktop/params/commandes.html.twig
+++ b/views/desktop/params/commandes.html.twig
@@ -163,15 +163,23 @@
                         <div class="row">
                             <div class="form-group col-sm-6 col-xs-12 col-padding">
                                 <label class="control-label" for="influxdbIp">{{ 'commandes.influxDbIPLabel'|trans }}</label>
-                                <input type="text" class="configKey form-control" id="influxdbIp" data-l1key="influxDbIp"/>
+                                <input type="text" class="configKey form-control" id="influxdbIp" data-l1key="influxDbIp" placeholder="127.0.0.1"/>
                             </div>
                             <div class="form-group col-sm-6 col-xs-12 col-padding">
                                 <label class="control-label" for="influxdbPort">{{ 'commandes.influxDbPortLabel'|trans }}</label>
-                                <input type="text" class="configKey form-control" id="influxDbPort" data-l1key="influxDbPort"/>
+                                <input type="text" class="configKey form-control" id="influxDbPort" data-l1key="influxDbPort" placeholder="8086"/>
+                            </div>
+                            <div class="form-group col-sm-6 col-xs-12 col-padding">
+                                <label class="control-label" for="influxDbLogin">{{ 'commandes.influxDbLoginLabel'|trans }}</label>
+                                <input type="text" class="configKey form-control" id="influxDbLogin" data-l1key="influxDbLogin" placeholder="nextdom"/>
+                            </div>
+                            <div class="form-group col-sm-6 col-xs-12 col-padding">
+                                <label class="control-label" for="influxDbPassword">{{ 'commandes.influxDbPasswordLabel'|trans }}</label>
+                                <input type="password" class="configKey form-control" id="influxDbPassword" data-l1key="influxDbPassword"/>
                             </div>
                             <div class="form-group col-xs-12 col-padding">
                                 <label class="control-label" for="influxDbDatabase">{{ 'commandes.influxDbDatabaseNameLabel'|trans }}</label>
-                                <input type="text" class="configKey form-control" id="influxDbDatabase" data-l1key="influxDbDatabase"/>
+                                <input type="text" class="configKey form-control" id="influxDbDatabase" data-l1key="influxDbDatabase" placeholder="nextdom"/>
                             </div>
                         </div>
                     </fieldset>


### PR DESCRIPTION
Cette feature permet d'utiliser un login/password lors de l'export des données Nextdom vers InfluxDB lorsqu'on utilise `auth-enabled = true` dans la conf influxDB

Procédure de validation :
1. Installer influxDB/Grafana en suivant le tuto de Byakee
https://www.nextdom.org/nextdom-influxdb-grafana/
Valider le fonctionnement

2. Dans Administration->Commandes->Publication, mettre un faux login/pass pour InfluxDB. A ce stade influxDB ne les vérifie pas, ça doit toujours fonctionner.

3. Mettre en place la vérification de l'authentification dans influxDB dans la section `[http]` :
```sh
$ sudo nano /etc/influxdb/influxdb.conf

[http]
  auth-enabled = true
```

redémarrer influxDB
```sh
systemctl start influxdb 
```

4. Une fois le service redémarré, avec un mauvais login/pass on doit avoir des code d'erreur 401 lorsqu'on actionne des commandes

5. Mettre le bon login/pass, tout doit fonctionner

