### PR TITLE
More debug informations in dev mod

### DIFF
--- a/src/core.php
+++ b/src/core.php
@@ -71,6 +71,8 @@ namespace {
         ('1' == ConfigManager::getDefaultConfiguration()['core']['developer::exceptionhandler'])) {
         Symfony\Component\Debug\ErrorHandler::register();
         Symfony\Component\Debug\ExceptionHandler::register();
+        Symfony\Component\Debug\Debug::enable();
+        Symfony\Component\Debug\DebugClassLoader::enable();
     }
 
     /**


### PR DESCRIPTION
Quand on active le mode dev de nextdom, les eventuels messages d'erreurs sont enrichis par plus d'information que précédemment.

Pas de procédure de test particulières.

-----
When nextdom's dev mode is activated, any error messages are enriched with more information than before.

No special test procedure.