### PR TITLE
Update firstUse.html.twig

### DIFF
--- a/views/desktop/pages/firstUse.html.twig
+++ b/views/desktop/pages/firstUse.html.twig
@@ -202,12 +202,12 @@
                                     {% for theme in profilsWidgetThemes %}
                                         <div class="col-sm-12 col-md-6 col-lg-4 form-group">
                                             <div class="clearfix">
-                                                <label class="cursor" for={{ theme.code }}>
+                                                <label class="cursor" for="{{ theme.code }}">
                                                     <img class="themeWidgetThumbnail" src="{{ theme.icon }}">
                                                 </label>
                                             </div>
-                                            <input id={{ theme.code }} class="spacing-right" type="radio" name="themeWidget" value="{{ theme.code }}"/>
-                                            <label for={{ theme.code }}>{{ theme.code|capitalize }}</label>
+                                            <input id="{{ theme.code }}" class="spacing-right" type="radio" name="themeWidget" value="{{ theme.code }}"/>
+                                            <label for="{{ theme.code }}">{{ theme.code|capitalize }}</label>
                                         </div>
                                     {% endfor %}
                                     <input id="widget-theme" class="userAttr form-control" data-l1key="options" data-l2key="widget::theme" style="display:none" />


### PR DESCRIPTION
Fix : ajout de `"` sur des attributs HTML `id` et `for`

Pour tester :
Il faut installer un nouveau Nextdom, puis vérifier que dans l'étape 5 l'ensemble des boutons de modification de thèmes fonctionnent.