### PR TITLE
avoid "code" bloc to have sub elements

### DIFF
--- a/assets/js/desktop/tools/scenario.js
+++ b/assets/js/desktop/tools/scenario.js
@@ -744,7 +744,7 @@ function initScenarioEditorEvents() {
     scenarioContainer.off('focus', ':input').on('focus', ':input', function () {
         blocFocusing($(this), false);
         if ($(this).closest(".expression").find(".expressionAttr[data-l1key='type']").filter(function () {
-            return this.value == 'condition'
+            return this.value == 'condition' || this.value == 'code'
         }).length == 0) {
             BLOC_LAST_FOCUS = false;
         } else {
@@ -2468,7 +2468,7 @@ function blocFocusing(bloc, onlyBloc) {
     BLOC_FOCUS.addClass("scenario-bloc-focused");
     if (!onlyBloc) {
         if (bloc.closest(".expression").find(".expressionAttr[data-l1key='type']").filter(function () {
-            return this.value == 'condition'
+            return this.value == 'condition' || this.value == 'code'
         }).length == 0) {
             ACTION_FOCUS = bloc.closest('.expression');
             ACTION_FOCUS.addClass("scenario-action-focused");


### PR DESCRIPTION
Lors de la création d'un scenario, on pouvait ajouter un bloc code en tant qu'enfant d'un autre bloc code, ce qui entrainait une confusion dans la gestion de la sauvegarde. 
J'ai bloqué cette possibilité, donc maintenant un bloc code ne peut pas avoir de bloc enfant.
Ne pas oublier de faire un gen_assets.sh avant de tester.